### PR TITLE
feat: add vulnerability report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a Critical/High Security Vulnerability (Private)
+    url: ../../security/advisories/new
+    about: For Critical or High severity vulnerabilities, please use GitHub's Private Vulnerability Reporting to avoid public disclosure.

--- a/.github/ISSUE_TEMPLATE/vulnerability-report.yml
+++ b/.github/ISSUE_TEMPLATE/vulnerability-report.yml
@@ -1,0 +1,112 @@
+name: Vulnerability Report
+description: Report a non-critical vulnerability or bug (for critical/security issues, use Private Vulnerability Reporting instead).
+title: "[Vulnerability]: "
+labels: ["vulnerability", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **⚠️ For critical/high severity vulnerabilities**, please use [Private Vulnerability Reporting](../../security/advisories/new) instead of this public form to avoid exposing exploitable bugs.
+
+  - type: input
+    id: title
+    attributes:
+      label: Vulnerability Title
+      description: A one-sentence summary of the vulnerability.
+      placeholder: "e.g. Memory leak during ME-HUB node synchronization"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Self-Assessed Severity
+      options:
+        - "Critical (Chain halt / consensus compromise)"
+        - "High (Severe functionality issues / data inconsistency)"
+        - "Medium (Functional issue but recoverable)"
+        - "Low (Minor issue / UI bug)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: Affected Module
+      multiple: true
+      options:
+        - ME-Hub
+        - Sequencer
+        - SDK/API
+        - Documentation
+        - Explorer/UI
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Vulnerability Description
+      description: Describe the issue in detail, including how it can be triggered and what the potential impact is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: poc
+    attributes:
+      label: PoC (Required for Medium severity and above)
+      description: Code / scripts / screenshots / screen recordings
+    validations:
+      required: false
+
+  - type: input
+    id: block-height
+    attributes:
+      label: Testnet Block Height
+      placeholder: "e.g. 1234567"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: reproducible
+    attributes:
+      label: Is it consistently reproducible?
+      options:
+        - "Yes"
+        - "No"
+        - "Sometimes"
+    validations:
+      required: false
+
+  - type: input
+    id: wallet
+    attributes:
+      label: MEC Wallet Address (For reward distribution)
+      placeholder: "me1..."
+    validations:
+      required: false
+
+  - type: input
+    id: telegram
+    attributes:
+      label: Telegram
+    validations:
+      required: false
+
+  - type: input
+    id: email
+    attributes:
+      label: Email
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Add a structured issue template for vulnerability reports and configure the issue template chooser.

## Changes

- `.github/ISSUE_TEMPLATE/vulnerability-report.yml`: Vulnerability report issue form with structured fields (severity, affected module, reproduction steps, PoC, environment info, contact info).
- `.github/ISSUE_TEMPLATE/config.yml`: Disable blank issues and add a contact link directing Critical/High severity vulnerabilities to GitHub's Private Vulnerability Reporting.

## Behavior After Merge

- Contributors clicking "New Issue" will see the vulnerability report template as a structured form.
- Blank issues are disabled to ensure all submissions follow the template.
- Critical/High severity vulnerabilities are guided to use Private Vulnerability Reporting (private channel, not publicly visible).

## Notes

- Requires enabling "Private vulnerability reporting" in repository Settings → Advanced Security for the private reporting link to work.