### PR TITLE
fix: reject bridge token symbols colliding with native base denom

### DIFF
--- a/x/gravity/keeper/attestation_handler.go
+++ b/x/gravity/keeper/attestation_handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/utils"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 )
@@ -49,6 +50,10 @@ func (k Keeper) AttestationHandler(ctx sdk.Context, externalClaim types.External
 		denom := utils.GetDenom(claim.Symbol)
 		if err := sdk.ValidateDenom(denom); err != nil {
 			return errorsmod.Wrapf(types.ErrInvalid, "invalid denom derived from symbol: %v", err)
+		}
+		// Reject bridge tokens whose derived denom collides with the native base denom.
+		if denom == params.BaseDenom {
+			return errorsmod.Wrapf(types.ErrInvalid, "bridge token symbol %q derives denom %q which collides with native denom", claim.Symbol, denom)
 		}
 		// This requires determining whether the same denom exists on the same chain, because different chains share the same denom.
 		if existing, err := k.GetBridgeTokenByDenom(ctx, denom); err == nil {


### PR DESCRIPTION
Closes #12. Reject MsgBridgeTokenClaim when the derived denom equals params.BaseDenom ("umec"), preventing bridge tokens from inflating native supply.