### PR TITLE
fix: call SetInviterReward after successful payout to prevent replay

### DIFF
--- a/x/wstaking/keeper/invite_reward.go
+++ b/x/wstaking/keeper/invite_reward.go
@@ -30,6 +30,7 @@ func (k Keeper) SendInviteReward(ctx sdk.Context, inviter, invitee, regionId str
 	); err != nil {
 		return fmt.Errorf("send kyc reward to inviter, %v", err)
 	}
+	k.SetInviterReward(ctx, invitee)
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(types.EventInviteReward,
 			sdk.NewAttribute(types.AttributeKeyKycInviterRewardSender, region.RegionTreasureAddr),


### PR DESCRIPTION
Closes #11. After SendInviteReward successfully transfers the invite reward, now calls SetInviterReward to persist the invitee as rewarded, preventing replay attacks where the same invitee could trigger multiple payouts.