### PR TITLE
fix: re-enable DeployerWhitelist check in CreateRollapp

### DIFF
--- a/x/rollapp/keeper/msg_server_create_rollapp.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp.go
@@ -21,11 +21,11 @@ func (k msgServer) CreateRollapp(goCtx context.Context, msg *types.MsgCreateRoll
 	}
 
 	// check to see if there is an active whitelist
-	//if whitelist := k.DeployerWhitelist(ctx); len(whitelist) > 0 {
-	//	if !k.IsAddressInDeployerWhiteList(ctx, msg.Creator) {
-	//		return nil, types.ErrUnauthorizedRollappCreator
-	//	}
-	//}
+	if whitelist := k.DeployerWhitelist(ctx); len(whitelist) > 0 {
+		if !k.IsAddressInDeployerWhiteList(ctx, msg.Creator) {
+			return nil, types.ErrUnauthorizedRollappCreator
+		}
+	}
 
 	rollapp := msg.GetRollapp()
 	err = rollapp.ValidateBasic()


### PR DESCRIPTION
Re-enables the commented-out DeployerWhitelist authorization check in MsgCreateRollapp, preventing non-whitelisted accounts from creating RollApps and squatting namespaces. Matches the enforcement already present in UpdateRollapp.

Fixes the failing test TestCreateRollappUnauthorizedRollappCreator.

**Changes:**
- Uncomments 5 lines in msg_server_create_rollapp.go that enforce the DeployerWhitelist gate
- Build passes
- Test TestCreateRollappUnauthorizedRollappCreator now passes

Closes #16.