### PR TITLE
fix: add owner check to UpdateRollapp to prevent configuration hijack

### DIFF
--- a/x/rollapp/keeper/msg_server_update_rollapp.go
+++ b/x/rollapp/keeper/msg_server_update_rollapp.go
@@ -10,16 +10,21 @@ import (
 func (k msgServer) UpdateRollapp(goCtx context.Context, msg *types.MsgUpdateRollapp) (*types.MsgUpdateRollappResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	rollapp, found := k.GetRollapp(ctx, msg.RollappId)
+	if !found {
+		return nil, types.ErrUnknownRollappID
+	}
+
+	// check that the creator is the owner of the rollapp
+	if msg.Creator != rollapp.Creator {
+		return nil, types.ErrUnauthorizedRollappCreator
+	}
+
 	// check to see if there is an active whitelist
 	if whitelist := k.DeployerWhitelist(ctx); len(whitelist) > 0 {
 		if !k.IsAddressInDeployerWhiteList(ctx, msg.Creator) {
 			return nil, types.ErrUnauthorizedRollappCreator
 		}
-	}
-
-	rollapp, found := k.GetRollapp(ctx, msg.RollappId)
-	if !found {
-		return nil, types.ErrUnknownRollappID
 	}
 
 	if msg.MaxSequencers != 0 {


### PR DESCRIPTION
Closes #8.

Adds an owner check to MsgUpdateRollapp: the msg.Creator must match the rollapp.Creator before allowing any configuration update. This prevents a non-owner from hijacking another creator's rollapp configuration.

Fix: check rollapp.Creator == msg.Creator before applying MaxSequencers, ChannelId, or PermissionedAddresses changes.