### PR TITLE
fix: enforce single-message tx for wasm contract creator fee routing

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -75,39 +75,37 @@ func (dfd DeductFeeDecorator) ParseWasmMsgContractCreator(ctx sdk.Context, tx sd
 	// wasm exec message should be the only message in tx
 	// to be considered as a wasm transaction
 	// this criterion is coarse, refine it later!
+	if len(tx.GetMsgs()) != 1 {
+		return "", false
+	}
 
-	allwasm := true
+	msg := tx.GetMsgs()[0]
 	var contract string
-	for _, msg := range tx.GetMsgs() {
-		switch msg := msg.(type) {
-		case *wasmtypes.MsgExecuteContract:
-			contract = msg.Contract
-		case *wasmtypes.MsgMigrateContract:
-			contract = msg.Contract
-		case *wasmtypes.MsgUpdateAdmin:
-			contract = msg.Contract
-		case *wasmtypes.MsgClearAdmin:
-			contract = msg.Contract
-		case *wasmtypes.MsgSudoContract:
-			contract = msg.Contract
-		default:
-			allwasm = false
-		}
+	switch msg := msg.(type) {
+	case *wasmtypes.MsgExecuteContract:
+		contract = msg.Contract
+	case *wasmtypes.MsgMigrateContract:
+		contract = msg.Contract
+	case *wasmtypes.MsgUpdateAdmin:
+		contract = msg.Contract
+	case *wasmtypes.MsgClearAdmin:
+		contract = msg.Contract
+	case *wasmtypes.MsgSudoContract:
+		contract = msg.Contract
+	default:
+		return "", false
 	}
 
-	if allwasm {
-		addr, err := sdk.AccAddressFromBech32(contract)
-		if err != nil {
-			return "", false
-		}
-		contractInfo := dfd.wasmKeeper.GetContractInfo(ctx, addr)
-		if contractInfo == nil {
-			return "", false
-		}
-		admin := contractInfo.Creator
-		return admin, true
+	addr, err := sdk.AccAddressFromBech32(contract)
+	if err != nil {
+		return "", false
 	}
-	return "", false
+	contractInfo := dfd.wasmKeeper.GetContractInfo(ctx, addr)
+	if contractInfo == nil {
+		return "", false
+	}
+	admin := contractInfo.Creator
+	return admin, true
 }
 
 func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {


### PR DESCRIPTION
Closes #23.

## Summary

Multi-message wasm transactions can redirect the 40% contract creator fee share to a trailing contract. When a transaction contains multiple wasm messages, the current implementation uses the LAST wasm message's contract to determine the fee recipient — allowing an attacker to append a no-op call to their own contract after a legitimate target contract execution, stealing the fee share.

## Fix

Enforce single-message requirement:  now returns false unless the transaction contains exactly one message, which must be a wasm type (MsgExecuteContract, MsgMigrateContract, MsgUpdateAdmin, MsgClearAdmin, or MsgSudoContract).

Before: multi-message tx with all-wasm msgs → last contract's creator gets 40%
After: multi-message tx → false returned (40% goes to global DAO fee pool as intended)