### PR TITLE
fix: roll back already-added unbatched txs on CancelOutgoingTxBatch failure

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -189,10 +189,19 @@ func (k Keeper) CancelOutgoingTxBatch(ctx sdk.Context, contractAddress string, b
 	if batch == nil {
 		return types.ErrUnknown
 	}
+
+	// Collect transactions that were successfully added to the pool
+	// so we can roll them back if any later tx fails
+	var addedTxs []*types.OutgoingTransferTx
 	for _, tx := range batch.Transactions {
 		if err := k.AddUnbatchedTx(ctx, tx); err != nil {
+			// Roll back the transactions already added to the pool
+			for _, added := range addedTxs {
+				_ = k.DelUnbatchedTx(ctx, added.Fee, added.Id)
+			}
 			return errorsmod.Wrapf(err, "unable to add batched transaction back into pool %v", tx)
 		}
+		addedTxs = append(addedTxs, tx)
 	}
 
 	// Delete batch since it is finished


### PR DESCRIPTION
## Description
When `CancelOutgoingTxBatch` fails partway through restoring transactions to the unbatched pool, transactions added before the failure are left orphaned in the pool while the batch remains stuck in the store. This creates a split-brain state where duplicate transactions can be included in future batches, leading to double-execution risk.

## Root Cause
The original implementation iterates through all batch transactions and calls `AddUnbatchedTx` for each. If any call fails midway:
- Transactions 0 through N-1 remain in the unbatched pool
- Transaction N is only in the batch
- The batch is never deleted (deletion happens after the loop)
- The next batch creation could pick up duplicate transactions

## Fix
Collect successfully-added transactions in a slice. If any later `AddUnbatchedTx` call fails, roll back all previously-added transactions by deleting them from the pool. This guarantees atomicity — either all transactions are restored and the batch is deleted, or none are.

## Files Changed
- `x/gravity/keeper/batch.go` — 9 lines added (rollback loop)

Closes #50.