### PR TITLE
fix(wstaking): resolve 4 bug bounty findings — unbonding bypass, RegionShare, region unbond, MEID unbond

### DIFF
--- a/x/wstaking/keeper/delegation.go
+++ b/x/wstaking/keeper/delegation.go
@@ -22,29 +22,18 @@ const unbondingTime = time.Hour * 24 * 7
 // an unbonding object and inserting it into the unbonding queue which will be
 // processed during the staking EndBlocker.
 func (k Keeper) Undelegate(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, isMeid bool, amount math.Int, delegation stakingtypes.Delegation) (time.Time, math.Int, error) {
-	if !isMeid {
-		if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
-			return time.Time{}, amount, stakingtypes.ErrMaxUnbondingDelegationEntries
-		}
+	if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
+		return time.Time{}, amount, stakingtypes.ErrMaxUnbondingDelegationEntries
 	}
 	returnAmount, err := k.Unbond(ctx, amount, isMeid, delegation)
 	if err != nil {
 		return time.Time{}, amount, err
 	}
-	completionTime := ctx.BlockHeader().Time
 	// transfer the validator tokens to the not bonded pool
-	if !isMeid {
-		k.bondedTokensToNotBonded(ctx, returnAmount)
-		completionTime = ctx.BlockHeader().Time.Add(unbondingTime)
-		ubd := k.SetUnbondingDelegationEntry(ctx, delAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
-		k.InsertUBDQueue(ctx, ubd, completionTime)
-	} else {
-		amt := sdk.NewCoin(params.BaseDenom, returnAmount)
-		err = k.bankKeeper.UndelegateCoinsFromModuleToAccount(ctx, stakingtypes.BondedPoolName, delAddr, sdk.NewCoins(amt))
-		if err != nil {
-			return completionTime, returnAmount, err
-		}
-	}
+	k.bondedTokensToNotBonded(ctx, returnAmount)
+	completionTime := ctx.BlockHeader().Time.Add(unbondingTime)
+	ubd := k.SetUnbondingDelegationEntry(ctx, delAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
+	k.InsertUBDQueue(ctx, ubd, completionTime)
 	return completionTime, returnAmount, nil
 }
 

--- a/x/wstaking/keeper/region.go
+++ b/x/wstaking/keeper/region.go
@@ -83,7 +83,7 @@ func (k Keeper) BondRegion(ctx sdk.Context, validator stakingtypes.Validator, to
 		region.OperatorAddress = validator.OperatorAddress
 		k.groupKeeper.UpdateGroupAdmin(ctx, validator.Description.RegionID, validator.OwnerAddress)
 	}
-	region.RegionShare = tokens
+	region.RegionShare = region.RegionShare.Add(tokens)
 	k.SetRegion(ctx, region)
 }
 

--- a/x/wstaking/keeper/stake.go
+++ b/x/wstaking/keeper/stake.go
@@ -179,7 +179,7 @@ func (k Keeper) Unstake(
 		k.BondedStakeTokensToNotBonded(ctx, returnAmount, validator.Description.RegionID)
 	}
 
-	completionTime := ctx.BlockHeader().Time.Add(time.Second)
+	completionTime := ctx.BlockHeader().Time.Add(unbondingTime)
 	ubs := k.SetUnbondingStakeEntry(ctx, stakerAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
 	k.InsertUBSQueue(ctx, ubs, completionTime)
 	return completionTime, nil
@@ -229,7 +229,9 @@ func (k Keeper) UnStakeBond(
 		if err != nil {
 			return amount, err
 		}
-		k.UnBondRegion(ctx, validator.Description.RegionID)
+		if validator.DelegatorShares.Sub(shares).IsZero() {
+				k.UnBondRegion(ctx, validator.Description.RegionID)
+			}
 	} else {
 		k.BondRegion(ctx, validator, stake.Shares.TruncateInt(), false)
 		k.SetStake(ctx, stake)


### PR DESCRIPTION
Fixes: #48, #51, #52, #53

## Summary

Four critical/high-severity fixes for the wstaking module:

1. **#48 Critical: 1-second unbonding bypass** — `stake.go:182` used `time.Second` for unbonding completion time. Changed to use the 7-day `unbondingTime` constant (same as `delegation.go`).

2. **#51 High: RegionShare accounting overwrite** — `region.go:86` overwrote `RegionShare` with `tokens` instead of adding. This means each new stake resets the region's share count, breaking accounting for regions with multiple stakers.

3. **#52 High: UnBondRegion premature unbond** — `stake.go:232` called `UnBondRegion` whenever a single staker's shares reached zero, even if other stakers remained in the region. Added a check that `validator.DelegatorShares` will reach zero after the unbond before triggering region cleanup.

4. **#53 High: MEID instant unbonding** — `delegation.go:41-46` had an `else` branch that instantly transferred MEID tokens to the user account, bypassing the unbonding period entirely. Removed the instant transfer path so MEID tokens follow the same 7-day unbonding queue as non-MEID tokens.