### PR TITLE
fix(wgov): enable stake-weighted validator voting, stop discarding delegator votes

### DIFF
--- a/x/wgov/keeper/tally.go
+++ b/x/wgov/keeper/tally.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 
 // Tally iterates over the votes and updates the tally of a proposal based on the voting power of the
@@ -43,30 +44,28 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 		}
 
 		// iterate over all delegations from voter, deduct from any delegated-to validators
-		//keeper.stakingKeeper.IterateStakes(ctx, voter, func(index int64, stake wstakingtypes.Stake) (stop bool) {
-		//	valAddrStr := stake.GetValidatorAddr().String()
-		//
-		//	if val, ok := currValidators[valAddrStr]; ok {
-		//		// There is no need to handle the special case that validator address equal to voter address.
-		//		// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
-		//		val.DelegatorDeductions = val.DelegatorDeductions.Add(stake.GetShares())
-		//		currValidators[valAddrStr] = val
-		//
-		//		// delegation shares * bonded / total shares
-		//		votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
-		//
-		//		for _, option := range vote.Options {
-		//			weight, _ := sdk.NewDecFromStr(option.Weight)
-		//			subPower := votingPower.Mul(weight)
-		//			results[option.Option] = results[option.Option].Add(subPower)
-		//		}
-		//		totalVotingPower = totalVotingPower.Add(votingPower)
-		//	}
-		//
-		//	return false
-		//})
+		keeper.stakingKeeper.IterateStakes(ctx, voter, func(index int64, stake wstakingtypes.Stake) (stop bool) {
+			valAddrStr := stake.GetValidatorAddr().String()
 
-		keeper.DeleteVote(ctx, vote.ProposalId, voter)
+			if val, ok := currValidators[valAddrStr]; ok {
+				// There is no need to handle the special case that validator address equal to voter address.
+				// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
+				val.DelegatorDeductions = val.DelegatorDeductions.Add(stake.GetShares())
+				currValidators[valAddrStr] = val
+
+				// delegation shares * bonded / total shares
+				votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+
+				for _, option := range vote.Options {
+					weight, _ := sdk.NewDecFromStr(option.Weight)
+					subPower := votingPower.Mul(weight)
+					results[option.Option] = results[option.Option].Add(subPower)
+				}
+				totalVotingPower = totalVotingPower.Add(votingPower)
+			}
+
+			return false
+		})
 		return false
 	})
 
@@ -76,9 +75,8 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 			continue
 		}
 
-		//sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
-		//votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
-		votingPower := sdk.NewDec(1)
+		sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
+		votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
 
 		for _, option := range val.Vote {
 			weight, _ := sdk.NewDecFromStr(option.Weight)

--- a/x/wgov/keeper/tally.go
+++ b/x/wgov/keeper/tally.go
@@ -54,7 +54,12 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 				currValidators[valAddrStr] = val
 
 				// delegation shares * bonded / total shares
-				votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+				var votingPower sdk.Dec
+				if val.DelegatorShares.IsZero() {
+					votingPower = sdk.ZeroDec()
+				} else {
+					votingPower = stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+				}
 
 				for _, option := range vote.Options {
 					weight, _ := sdk.NewDecFromStr(option.Weight)
@@ -76,7 +81,12 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 		}
 
 		sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
-		votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+		var votingPower sdk.Dec
+		if val.DelegatorShares.IsZero() {
+			votingPower = sdk.ZeroDec()
+		} else {
+			votingPower = sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+		}
 
 		for _, option := range val.Vote {
 			weight, _ := sdk.NewDecFromStr(option.Weight)


### PR DESCRIPTION
Fixes: #49

## Summary

Critical fix for the wgov tally module where all delegator votes were silently discarded and every validator had equal voting power regardless of stake size.

### Changes

1. **Enabled stake-weighted delegator vote counting** — Uncommented the `IterateStakes` loop that deducts voting power from validators based on delegator stakes and tallies delegator votes with proper stake weighting: `shares * bondedTokens / totalShares`

2. **Enabled stake-weighted validator voting** — Replaced hardcoded `votingPower := sdk.NewDec(1)` (equal voting power for all validators) with the proper formula: `(delegatorShares - delegatorDeductions) * bondedTokens / delegatorShares`

3. **Removed DeleteVote call** — Deleting votes during tally iteration was unnecessary and interfered with the proper processing of delegator votes.

### Impact

Before this fix, all governance votes were tallied as one-validator-one-vote regardless of stake size, and delegator votes were completely ignored. This allowed governance capture by any validator regardless of actual stake delegation.