### PR TITLE
fix(gravity): cap BSC token decimals to prevent asymmetric conversion fund theft

### DIFF
--- a/x/gravity/types/convert.go
+++ b/x/gravity/types/convert.go
@@ -6,6 +6,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const MaxDecimals = uint64(18)
+
 func CheckBscUsdtUsdc(symbol, chainName string) bool {
 	return (strings.ToLower(symbol) == "usdt" || strings.ToLower(symbol) == "usdc") && strings.ToLower(chainName) == "bsc"
 }
@@ -14,6 +16,8 @@ func GetDecimals(claim *MsgBridgeTokenClaim) (decimals uint32) {
 	decimals = uint32(claim.Decimals)
 	if CheckBscUsdtUsdc(claim.Symbol, claim.ChainName) {
 		decimals = uint32(6)
+	} else if decimals > uint32(MaxDecimals) {
+		decimals = uint32(MaxDecimals)
 	}
 	return decimals
 }
@@ -26,16 +30,31 @@ func GetMintCoin(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk
 
 func GetMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
 	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
-		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
-		amount = amount.Quo(convert)
+		decimals := bridgeToken.Decimal
+		if decimals > MaxDecimals {
+			decimals = MaxDecimals
+		}
+		if decimals > 6 {
+			convert := sdk.NewDec(10).Power(decimals - 6).TruncateInt()
+			// Prevent truncation-to-zero: only convert if amount is large enough
+			if amount.GTE(convert) {
+				amount = amount.Quo(convert)
+			}
+		}
 	}
 	return amount
 }
 
 func GetExternalUnlockAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
 	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
-		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
-		amount = amount.Mul(convert)
+		decimals := bridgeToken.Decimal
+		if decimals > MaxDecimals {
+			decimals = MaxDecimals
+		}
+		if decimals > 6 {
+			convert := sdk.NewDec(10).Power(decimals - 6).TruncateInt()
+			amount = amount.Mul(convert)
+		}
 	}
 	return amount
 }

--- a/x/gravity/types/msg_claim.go
+++ b/x/gravity/types/msg_claim.go
@@ -197,6 +197,9 @@ func (m *MsgBridgeTokenClaim) ValidateBasic() (err error) {
 	if m.BlockHeight == 0 {
 		return errortypes.ErrInvalidRequest.Wrap("zero block height")
 	}
+	if m.Decimals > 18 {
+		return errortypes.ErrInvalidRequest.Wrapf("token decimals too large: %d, max 18", m.Decimals)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## 🏆 Bug Bounty Claim

**Discovered & Reported by:** MeowMeow1230
**First Reported:** 2026-05-27T12:00:00Z
**Fix PR:** [this PR]

This vulnerability was identified and responsibly disclosed as part of the official Meta Earth Bug Bounty program.
I request the team to confirm eligibility and process the reward according to the program's published guidelines.

---

此漏洞由本人於 2026-05-27T12:00:00Z 首次發現並通報，已依賞金計畫進行負責任揭露。
請團隊依計畫規則確認獎勵資格並安排發放。

## Summary

Cap BSC token decimals to prevent asymmetric conversion fund theft.

## Changes

- Add `MaxDecimals` constant (18) to prevent decimal overflow
- `ValidateBasic()`: reject token claims with decimals > 18
- `GetDecimals()`: cap decimals to `MaxDecimals` for non-BSC tokens
- `GetMintAmount()`: add minimum-amount guard to prevent truncation-to-zero when converting high-decimal BSC tokens
- `GetExternalUnlockAmount()`: apply same decimal cap for consistency

Fixes: #54