### PR TITLE
fix(wstaking): fix unbonding bypass, RegionShare overwrite, premature region unbond, MEID instant unbond

### DIFF
--- a/x/wstaking/keeper/delegation.go
+++ b/x/wstaking/keeper/delegation.go
@@ -22,29 +22,18 @@ const unbondingTime = time.Hour * 24 * 7
 // an unbonding object and inserting it into the unbonding queue which will be
 // processed during the staking EndBlocker.
 func (k Keeper) Undelegate(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, isMeid bool, amount math.Int, delegation stakingtypes.Delegation) (time.Time, math.Int, error) {
-	if !isMeid {
-		if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
-			return time.Time{}, amount, stakingtypes.ErrMaxUnbondingDelegationEntries
-		}
+	if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
+		return time.Time{}, amount, stakingtypes.ErrMaxUnbondingDelegationEntries
 	}
 	returnAmount, err := k.Unbond(ctx, amount, isMeid, delegation)
 	if err != nil {
 		return time.Time{}, amount, err
 	}
-	completionTime := ctx.BlockHeader().Time
 	// transfer the validator tokens to the not bonded pool
-	if !isMeid {
-		k.bondedTokensToNotBonded(ctx, returnAmount)
-		completionTime = ctx.BlockHeader().Time.Add(unbondingTime)
-		ubd := k.SetUnbondingDelegationEntry(ctx, delAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
-		k.InsertUBDQueue(ctx, ubd, completionTime)
-	} else {
-		amt := sdk.NewCoin(params.BaseDenom, returnAmount)
-		err = k.bankKeeper.UndelegateCoinsFromModuleToAccount(ctx, stakingtypes.BondedPoolName, delAddr, sdk.NewCoins(amt))
-		if err != nil {
-			return completionTime, returnAmount, err
-		}
-	}
+	k.bondedTokensToNotBonded(ctx, returnAmount)
+	completionTime := ctx.BlockHeader().Time.Add(unbondingTime)
+	ubd := k.SetUnbondingDelegationEntry(ctx, delAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
+	k.InsertUBDQueue(ctx, ubd, completionTime)
 	return completionTime, returnAmount, nil
 }
 

--- a/x/wstaking/keeper/region.go
+++ b/x/wstaking/keeper/region.go
@@ -83,7 +83,7 @@ func (k Keeper) BondRegion(ctx sdk.Context, validator stakingtypes.Validator, to
 		region.OperatorAddress = validator.OperatorAddress
 		k.groupKeeper.UpdateGroupAdmin(ctx, validator.Description.RegionID, validator.OwnerAddress)
 	}
-	region.RegionShare = tokens
+	region.RegionShare = region.RegionShare.Add(tokens)
 	k.SetRegion(ctx, region)
 }
 

--- a/x/wstaking/keeper/stake.go
+++ b/x/wstaking/keeper/stake.go
@@ -179,7 +179,7 @@ func (k Keeper) Unstake(
 		k.BondedStakeTokensToNotBonded(ctx, returnAmount, validator.Description.RegionID)
 	}
 
-	completionTime := ctx.BlockHeader().Time.Add(time.Second)
+	completionTime := ctx.BlockHeader().Time.Add(unbondingTime)
 	ubs := k.SetUnbondingStakeEntry(ctx, stakerAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
 	k.InsertUBSQueue(ctx, ubs, completionTime)
 	return completionTime, nil
@@ -229,7 +229,9 @@ func (k Keeper) UnStakeBond(
 		if err != nil {
 			return amount, err
 		}
-		k.UnBondRegion(ctx, validator.Description.RegionID)
+		if validator.DelegatorShares.IsZero() {
+			k.UnBondRegion(ctx, validator.Description.RegionID)
+		}
 	} else {
 		k.BondRegion(ctx, validator, stake.Shares.TruncateInt(), false)
 		k.SetStake(ctx, stake)


### PR DESCRIPTION
## 🏆 Bug Bounty Claim

**Discovered & Reported by:** MeowMeow1230
**First Reported:** 2026-05-27T12:00:00Z
**Fix PR:** [this PR]

This vulnerability was identified and responsibly disclosed as part of the official Meta Earth Bug Bounty program.
I request the team to confirm eligibility and process the reward according to the program's published guidelines.

---

此漏洞由本人於 2026-05-27T12:00:00Z 首次發現並通報，已依賞金計畫進行負責任揭露。
請團隊依計畫規則確認獎勵資格並安排發放。

## Summary

Four fixes for the wstaking module.

### #52 (High) ✅ Confirmed Bug: Premature Region Unbond
`stake.go` `UnStakeBond()` called `UnBondRegion()` when a single staker's shares reached zero, without checking if other stakers still held shares on the validator. Added `validator.DelegatorShares.IsZero()` guard.

### #53 (High) ✅ Confirmed Bug: MEID Instant Unbond Bypass
`delegation.go` `Undelegate()` had a separate branch for MEID tokens that performed an instant bank transfer without any unbonding period. Removed the bypass, applying the same unbonding period to all token types.

### #48 (Critical) ⚠️ Under Appeal: Unbonding Time Bypass
`stake.go` used `time.Second` instead of the proper unbonding time constant (`time.Hour * 24 * 7`). Changed to use the `unbondingTime` constant already defined in the package. Closed as "working as intended" — appeal pending, see issue #48.

### #51 (High) ⚠️ Under Appeal: RegionShare Overwrite
`region.go` `BondRegion()` used assignment (`=`) for `RegionShare` instead of accumulation (`+=`). Changed to use `Add()`. Closed as "working as intended" — appeal pending, see issue #51.

Fixes: #52, #53
Under appeal: #48, #51