### PR TITLE
fix(wgov): enable stake-weighted validator voting, stop discarding delegator votes

### DIFF
--- a/x/wgov/keeper/tally.go
+++ b/x/wgov/keeper/tally.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 
 // Tally iterates over the votes and updates the tally of a proposal based on the voting power of the
@@ -43,30 +44,30 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 		}
 
 		// iterate over all delegations from voter, deduct from any delegated-to validators
-		//keeper.stakingKeeper.IterateStakes(ctx, voter, func(index int64, stake wstakingtypes.Stake) (stop bool) {
-		//	valAddrStr := stake.GetValidatorAddr().String()
-		//
-		//	if val, ok := currValidators[valAddrStr]; ok {
-		//		// There is no need to handle the special case that validator address equal to voter address.
-		//		// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
-		//		val.DelegatorDeductions = val.DelegatorDeductions.Add(stake.GetShares())
-		//		currValidators[valAddrStr] = val
-		//
-		//		// delegation shares * bonded / total shares
-		//		votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
-		//
-		//		for _, option := range vote.Options {
-		//			weight, _ := sdk.NewDecFromStr(option.Weight)
-		//			subPower := votingPower.Mul(weight)
-		//			results[option.Option] = results[option.Option].Add(subPower)
-		//		}
-		//		totalVotingPower = totalVotingPower.Add(votingPower)
-		//	}
-		//
-		//	return false
-		//})
+		keeper.stakingKeeper.IterateStakes(ctx, voter, func(index int64, stake wstakingtypes.Stake) (stop bool) {
+			valAddrStr := stake.GetValidatorAddr().String()
 
-		keeper.DeleteVote(ctx, vote.ProposalId, voter)
+			if val, ok := currValidators[valAddrStr]; ok {
+				// There is no need to handle the special case that validator address equal to voter address.
+				// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
+				val.DelegatorDeductions = val.DelegatorDeductions.Add(stake.GetShares())
+				currValidators[valAddrStr] = val
+
+				// delegation shares * bonded / total shares
+				votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+
+				for _, option := range vote.Options {
+					weight, _ := sdk.NewDecFromStr(option.Weight)
+					subPower := votingPower.Mul(weight)
+					results[option.Option] = results[option.Option].Add(subPower)
+				}
+				totalVotingPower = totalVotingPower.Add(votingPower)
+			}
+
+			return false
+		})
+
+		// Preserve delegator votes — do NOT delete after processing
 		return false
 	})
 
@@ -76,9 +77,8 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 			continue
 		}
 
-		//sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
-		//votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
-		votingPower := sdk.NewDec(1)
+		sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
+		votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
 
 		for _, option := range val.Vote {
 			weight, _ := sdk.NewDecFromStr(option.Weight)


### PR DESCRIPTION
## 🏆 Bug Bounty Claim

**Discovered & Reported by:** MeowMeow1230
**First Reported:** 2026-05-27T12:00:00Z
**Fix PR:** [this PR]

This vulnerability was identified and responsibly disclosed as part of the official Meta Earth Bug Bounty program.
I request the team to confirm eligibility and process the reward according to the program's published guidelines.

---

此漏洞由本人於 2026-05-27T12:00:00Z 首次發現並通報，已依賞金計畫進行負責任揭露。
請團隊依計畫規則確認獎勵資格並安排發放。

## Summary

The governance Tally() function had stake-weighted voting code that was fully implemented but commented out. In its place, every validator was given a flat voting power of `sdk.NewDec(1)`, and delegator votes were discarded via `DeleteVote()` immediately after processing.

## Changes

- Uncomment delegator deduction loop (`IterateStakes`) to properly deduct delegated voting power from validators when the delegator votes directly
- Remove `DeleteVote()` call that was discarding delegator votes after processing
- Replace hard-coded voting power of `sdk.NewDec(1)` with proper stake-proportional formula: `sharesAfterDeductions * bondedTokens / delegatorShares`
- Add `wstakingtypes` import for Stake type reference

Fixes: #49