### PR TITLE
fix(wstaking): handle BeginBlock reward errors, reduce multi-stage truncation precision loss

### DIFF
--- a/x/wstaking/abci.go
+++ b/x/wstaking/abci.go
@@ -18,7 +18,11 @@ func BeginBlock(ctx sdk.Context, k *keeper.Keeper) {
 	regions := k.GetAllRegion(ctx)
 
 	for _, region := range regions {
-		rewards, _ := k.Calculate(ctx, sdk.NewDecFromInt(totalRewardsPerBlock), region.DelegateAmount) //rate.MulInt(totalRewardsPerBlock.Mul(region.DelegateAmount)).Mul(sdk.NewDecWithPrec(1, sdk.MEExponent))
+		rewards, err := k.Calculate(ctx, sdk.NewDecFromInt(totalRewardsPerBlock), region.DelegateAmount)
+		if err != nil {
+			k.Logger(ctx).Error("failed to calculate rewards for region", "region", region.RegionId, "error", err)
+			continue
+		}
 		region.DelegateInterest = region.DelegateInterest.Add(rewards)
 		k.SetRegion(ctx, region)
 	}

--- a/x/wstaking/keeper/alias_functions.go
+++ b/x/wstaking/keeper/alias_functions.go
@@ -20,9 +20,11 @@ func (k Keeper) CalculateInterest(ctx sdk.Context, totalStaking cmath.Int, heigh
 	return k.Calculate(ctx, blockRewards, totalStaking)
 }
 
-// getRewardsByHeight Get coins through the block height range
+// getRewardsByHeight Get coins through the block height range.
+// Accumulates rewards in sdk.Dec to avoid precision loss from intermediate TruncateInt;
+// the caller is responsible for any final truncation.
 func (k Keeper) getRewardsByHeight(fromHeight int64, toHeight int64) (coin sdk.Dec) {
-	totalCoins := sdk.ZeroInt()
+	totalCoins := sdk.ZeroDec()
 
 	lowMul := (fromHeight - 1) / mintTypes.OneYearTotalBlocks
 	highMul := (toHeight - 1) / mintTypes.OneYearTotalBlocks
@@ -32,7 +34,7 @@ func (k Keeper) getRewardsByHeight(fromHeight int64, toHeight int64) (coin sdk.D
 		amountDec := sdk.NewDec(int64(mintTypes.InitOneYearMintAmount)).
 			Quo(sdk.NewDec(int64(mintTypes.OneYearTotalBlocks))).
 			Quo(halvingDivisor)
-		mintUMECAmount := wmint.RoundUpToFourDecimalsDec(amountDec).MulInt64(100_000_000).TruncateInt()
+		mintUMECAmount := wmint.RoundUpToFourDecimalsDec(amountDec).MulInt64(100_000_000)
 
 		var blockCount int64
 		// If the range of from and to are in the same reduction period
@@ -49,10 +51,10 @@ func (k Keeper) getRewardsByHeight(fromHeight int64, toHeight int64) (coin sdk.D
 			blockCount = int64(mintTypes.OneYearTotalBlocks)
 		}
 
-		totalCoins = totalCoins.Add(mintUMECAmount.MulRaw(blockCount))
+		totalCoins = totalCoins.Add(mintUMECAmount.MulInt64(blockCount))
 	}
 
-	coin = sdk.NewDecFromInt(totalCoins)
+	coin = totalCoins
 	return
 }
 


### PR DESCRIPTION
## 🏆 Bug Bounty Claim

**Discovered & Reported by:** MeowMeow1230
**First Reported:** 2026-05-27T12:00:00Z
**Fix PR:** [this PR]

This vulnerability was identified and responsibly disclosed as part of the official Meta Earth Bug Bounty program.
I request the team to confirm eligibility and process the reward according to the program's published guidelines.

---

此漏洞由本人於 2026-05-27T12:00:00Z 首次發現並通報，已依賞金計畫進行負責任揭露。
請團隊依計畫規則確認獎勵資格並安排發放。

## Summary
- **#55**: Handle error return from `k.Calculate()` in BeginBlock reward distribution instead of silently ignoring it. On error the region is skipped and the error is logged.
- **#56**: Accumulate reward calculations in `sdk.Dec` throughout the pipeline, removing the intermediate `TruncateInt()` call. Precision is preserved until the final consumer applies truncation.

Fixes: #55, #56