### PR TITLE
fix(wstaking): return error on validator address mismatch instead of silent overwrite

### DIFF
--- a/x/wstaking/keeper/msg_server_delegate.go
+++ b/x/wstaking/keeper/msg_server_delegate.go
@@ -22,6 +22,10 @@ func (k MsgServer) Delegate(goCtx context.Context, msg *stakingtypes.MsgDelegate
 	if !isFound {
 		return nil, types.ErrRegionNotExist
 	}
+	if msg.ValidatorAddress != "" && msg.ValidatorAddress != region.OperatorAddress {
+		return nil, sdkerrors.Wrapf(types.ErrInvalidValidator,
+			"validator address %s does not match region operator %s", msg.ValidatorAddress, region.OperatorAddress)
+	}
 	msg.ValidatorAddress = region.OperatorAddress
 	valAddr, valErr := sdk.ValAddressFromBech32(msg.ValidatorAddress)
 	if valErr != nil {

--- a/x/wstaking/keeper/msg_server_undelegate.go
+++ b/x/wstaking/keeper/msg_server_undelegate.go
@@ -25,6 +25,10 @@ func (k MsgServer) Undelegate(goCtx context.Context, msg *stakingtypes.MsgUndele
 	if !isFound {
 		return nil, types.ErrRegionNotExist
 	}
+	if msg.ValidatorAddress != "" && msg.ValidatorAddress != region.OperatorAddress {
+		return nil, sdkerrors.Wrapf(types.ErrInvalidValidator,
+			"validator address %s does not match region operator %s", msg.ValidatorAddress, region.OperatorAddress)
+	}
 	msg.ValidatorAddress = region.OperatorAddress
 	valAddr, err := sdk.ValAddressFromBech32(msg.ValidatorAddress)
 	if err != nil {

--- a/x/wstaking/types/errors.go
+++ b/x/wstaking/types/errors.go
@@ -97,6 +97,7 @@ var (
 	ErrHooks                    = sdkerrors.Register(ModuleName, 1301, "hooks error")
 	ErrExistingReplaceValidator = sdkerrors.Register(ModuleName, 1302, "another validator replacement is already in progress")
 	ErrValidatorNotBonded       = sdkerrors.Register(ModuleName, 1303, "only bonded validator can be replaced")
+	ErrInvalidValidator         = sdkerrors.Register(ModuleName, 1230, "validator address does not match region operator address")
 
 	ErrStakeOnValidatorIsEmpty = sdkerrors.Register(ModuleName, 1304, "stake on validator is empty")
 	ErrProtoProc               = sdkerrors.Register(ModuleName, 1305, "proc proto error.")


### PR DESCRIPTION
## 🏆 Bug Bounty Claim

**Discovered & Reported by:** MeowMeow1230
**First Reported:** 2026-05-27T12:00:00Z
**Fix PR:** [this PR]

This vulnerability was identified and responsibly disclosed as part of the official Meta Earth Bug Bounty program.
I request the team to confirm eligibility and process the reward according to the program's published guidelines.

---

此漏洞由本人於 2026-05-27T12:00:00Z 首次發現並通報，已依賞金計畫進行負責任揭露。
請團隊依計畫規則確認獎勵資格並安排發放。

## Summary
Validator address was silently overwritten with region operator address in delegate/undelegate handlers, producing a result different from what the user signed. Now returns a clear error when the addresses don't match.

Fixes: #62