### PR TITLE
fix(rollapp): use IsGlobalDao in SkipDelayRollapp to prevent MeidDao fraud bypass (#105)

### DIFF
--- a/x/rollapp/keeper/msg_server_skip_delay_rollapp.go
+++ b/x/rollapp/keeper/msg_server_skip_delay_rollapp.go
@@ -12,7 +12,7 @@ import (
 func (k msgServer) SkipDelayRollapp(goCtx context.Context, msg *types.MsgSkipDelayRollapp) (*types.MsgSkipDelayRollappResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if !k.daoKeeper.IsDao(ctx, msg.Creator) {
+	if !k.daoKeeper.IsGlobalDao(ctx, msg.Creator) {
 		return nil, types.ErrCheckGlobalDao
 	}
 

--- a/x/rollapp/keeper/msg_server_skip_delay_rollapp_test.go
+++ b/x/rollapp/keeper/msg_server_skip_delay_rollapp_test.go
@@ -1,0 +1,180 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestSkipDelayRollappTestSuite(t *testing.T) {
+	suite.Run(t, new(SkipDelayRollappTestSuite))
+}
+
+type SkipDelayRollappTestSuite struct {
+	RollappTestSuite
+}
+
+// TestSkipDelayRollapp_GlobalDaoAllowed verifies that GlobalDao can toggle skip-delay
+func (suite *SkipDelayRollappTestSuite) TestSkipDelayRollapp_GlobalDaoAllowed() {
+	suite.SetupTest()
+	suite.InitializeDao()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	// Create a rollapp first
+	rollappId := "rollapp1"
+	rollapp := types.Rollapp{
+		RollappId:     rollappId,
+		Creator:       alice,
+		MaxSequencers: 1,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	// GlobalDao should be allowed to toggle skip delay
+	msg := types.MsgSkipDelayRollapp{
+		Creator:   suite.Dao.GlobalDao,
+		RollappId: rollappId,
+		Skip:      true,
+	}
+
+	_, err := suite.msgServer.SkipDelayRollapp(goCtx, &msg)
+	suite.Require().NoError(err)
+
+	// Verify skip-delay is enabled
+	isSkip := suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollappId)
+	suite.Require().True(isSkip, "skip-delay should be enabled for rollapp after GlobalDao sets it")
+
+	// Disable skip
+	msg.Skip = false
+	_, err = suite.msgServer.SkipDelayRollapp(goCtx, &msg)
+	suite.Require().NoError(err)
+
+	isSkip = suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollappId)
+	suite.Require().False(isSkip, "skip-delay should be disabled after GlobalDao unsets it")
+}
+
+// TestSkipDelayRollapp_MeidDaoRejected verifies that MeidDao cannot toggle skip-delay
+// This is the core fix for issue #105: MeidDao should NOT be able to bypass fraud dispute delays
+func (suite *SkipDelayRollappTestSuite) TestSkipDelayRollapp_MeidDaoRejected() {
+	suite.SetupTest()
+	suite.InitializeDao()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	// Create a rollapp first
+	rollappId := "rollapp1"
+	rollapp := types.Rollapp{
+		RollappId:     rollappId,
+		Creator:       alice,
+		MaxSequencers: 1,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	// MeidDao should NOT be allowed to toggle skip delay
+	msg := types.MsgSkipDelayRollapp{
+		Creator:   suite.Dao.MeidDao,
+		RollappId: rollappId,
+		Skip:      true,
+	}
+
+	_, err := suite.msgServer.SkipDelayRollapp(goCtx, &msg)
+	suite.Require().Error(err, "MeidDao should not be allowed to toggle skip-delay")
+	suite.Require().ErrorIs(err, types.ErrCheckGlobalDao)
+
+	// Verify skip-delay is NOT enabled
+	isSkip := suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollappId)
+	suite.Require().False(isSkip, "skip-delay should not be enabled when MeidDao attempts to set it")
+}
+
+// TestSkipDelayRollapp_UnauthorizedRejected verifies that non-DAO accounts cannot toggle skip-delay
+func (suite *SkipDelayRollappTestSuite) TestSkipDelayRollapp_UnauthorizedRejected() {
+	suite.SetupTest()
+	suite.InitializeDao()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	// Create a rollapp
+	rollappId := "rollapp1"
+	rollapp := types.Rollapp{
+		RollappId:     rollappId,
+		Creator:       alice,
+		MaxSequencers: 1,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	// Random account should NOT be allowed
+	msg := types.MsgSkipDelayRollapp{
+		Creator:   alice,
+		RollappId: rollappId,
+		Skip:      true,
+	}
+
+	_, err := suite.msgServer.SkipDelayRollapp(goCtx, &msg)
+	suite.Require().Error(err, "non-DAO account should not be allowed to toggle skip-delay")
+	suite.Require().ErrorIs(err, types.ErrCheckGlobalDao)
+}
+
+// TestSkipDelayRollapp_UnknownRollapp verifies that skip-delay cannot be set for non-existent rollapps
+func (suite *SkipDelayRollappTestSuite) TestSkipDelayRollapp_UnknownRollapp() {
+	suite.SetupTest()
+	suite.InitializeDao()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	msg := types.MsgSkipDelayRollapp{
+		Creator:   suite.Dao.GlobalDao,
+		RollappId: "nonexistent-rollapp",
+		Skip:      true,
+	}
+
+	_, err := suite.msgServer.SkipDelayRollapp(goCtx, &msg)
+	suite.Require().Error(err, "should not be able to set skip-delay for non-existent rollapp")
+	suite.Require().ErrorIs(err, types.ErrUnknownRollappID)
+}
+
+// TestSkipDelayRollapp_TogglePreventsFraudBypass verifies the security fix:
+// After enabling and then disabling skip-delay, IsSkipDelayRollapp returns false
+// This prevents the selective fraud attack described in issue #105
+func (suite *SkipDelayRollappTestSuite) TestSkipDelayRollapp_TogglePreventsFraudBypass() {
+	suite.SetupTest()
+	suite.InitializeDao()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollappId := "rollapp1"
+	rollapp := types.Rollapp{
+		RollappId:     rollappId,
+		Creator:       alice,
+		MaxSequencers: 1,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	// Initially, skip should be false (default)
+	isSkip := suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollappId)
+	suite.Require().False(isSkip, "skip-delay should be false by default")
+
+	// Enable skip-delay
+	msg := types.MsgSkipDelayRollapp{
+		Creator:   suite.Dao.GlobalDao,
+		RollappId: rollappId,
+		Skip:      true,
+	}
+	_, err := suite.msgServer.SkipDelayRollapp(goCtx, &msg)
+	suite.Require().NoError(err)
+
+	isSkip = suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollappId)
+	suite.Require().True(isSkip, "skip-delay should be enabled")
+
+	// Disable skip-delay
+	msg.Skip = false
+	_, err = suite.msgServer.SkipDelayRollapp(goCtx, &msg)
+	suite.Require().NoError(err)
+
+	isSkip = suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollappId)
+	suite.Require().False(isSkip, "skip-delay should be disabled after toggle")
+}
+
+// TestIsSkipDelayRollapp_NonExistentRollapp verifies IsSkipDelayRollapp returns false for unknown rollapps
+func (suite *SkipDelayRollappTestSuite) TestIsSkipDelayRollapp_NonExistentRollapp() {
+	suite.SetupTest()
+
+	isSkip := suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, "nonexistent")
+	suite.Require().False(isSkip, "IsSkipDelayRollapp should return false for non-existent rollapp")
+}

--- a/x/rollapp/types/expected_keepers.go
+++ b/x/rollapp/types/expected_keepers.go
@@ -15,5 +15,5 @@ type ChannelKeeper interface {
 }
 
 type DaoKeeper interface {
-	IsDao(ctx sdk.Context, address string) bool
+	IsGlobalDao(ctx sdk.Context, address string) bool
 }


### PR DESCRIPTION
## Fix for #105

### Problem
The `SkipDelayRollapp` function uses `IsDao` (which includes both `GlobalDao` and `MeidDao`) instead of `IsGlobalDao`. A MeidDao account can toggle the skip-delay flag on and off, enabling selective fraud dispute bypass:

1. MeidDao enables skip for a colluding rollapp
2. Fraudulent IBC transfers are processed instantly (no dispute period)
3. MeidDao disables skip
4. Later fraud proofs only revert PENDING packets — the instantly-processed fraudulent transfers are never reverted

### Fix
Changed `IsDao` to `IsGlobalDao` in two files:

- `x/rollapp/keeper/msg_server_skip_delay_rollapp.go`: Authorization check now requires GlobalDao
- `x/rollapp/types/expected_keepers.go`: `DaoKeeper` interface updated to use `IsGlobalDao`

### Changes
```diff
- if !k.daoKeeper.IsDao(ctx, msg.Creator) {
+ if !k.daoKeeper.IsGlobalDao(ctx, msg.Creator) {
```

### Tests Added
`x/rollapp/keeper/msg_server_skip_delay_rollapp_test.go` with:
- `TestSkipDelayRollapp_GlobalDaoAllowed` — GlobalDao can toggle skip-delay
- `TestSkipDelayRollapp_MeidDaoRejected` — MeidDao is rejected (core security fix)
- `TestSkipDelayRollapp_UnauthorizedRejected` — Non-DAO accounts rejected
- `TestSkipDelayRollapp_UnknownRollapp` — Cannot set skip-delay for non-existent rollapps
- `TestSkipDelayRollapp_TogglePreventsFraudBypass` — Toggle behavior works correctly
- `TestIsSkipDelayRollapp_NonExistentRollapp` — Default false for unknown rollapps

Fixes #105