### PR TITLE
fix(wnft): cap TotalSupply to prevent unlimited minting (#106)

### DIFF
--- a/x/wnft/keeper/msg_server.go
+++ b/x/wnft/keeper/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"math"
 	"strconv"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -53,6 +54,10 @@ func (k Keeper) NewClass(goCtx context.Context, msg *types.MsgNewClass) (*types.
 	metadata, err := codectypes.NewAnyWithValue(classMetadata)
 	if err != nil {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrLogic, "%v", err)
+	}
+
+	if msg.TotalSupply > math.MaxUint32 {
+		return nil, sdkerrors.Wrapf(types.ErrTotalSupplyExceedsMax, "total supply %d exceeds maximum %d", msg.TotalSupply, uint64(math.MaxUint32))
 	}
 
 	class := nft.Class{

--- a/x/wnft/types/errors.go
+++ b/x/wnft/types/errors.go
@@ -7,7 +7,8 @@ import (
 
 // x/nft module sentinel errors
 var (
-	ErrEmptyTotalSupply = errors.Register(nft.ModuleName, 9, "empty total supply")
-	ErrEmptyTokenId     = errors.Register(nft.ModuleName, 10, "empty token id")
-	ErrEmptyUri         = errors.Register(nft.ModuleName, 11, "empty uri")
+	ErrEmptyTotalSupply       = errors.Register(nft.ModuleName, 9, "empty total supply")
+	ErrEmptyTokenId           = errors.Register(nft.ModuleName, 10, "empty token id")
+	ErrEmptyUri               = errors.Register(nft.ModuleName, 11, "empty uri")
+	ErrTotalSupplyExceedsMax  = errors.Register(nft.ModuleName, 12, "total supply exceeds maximum allowed")
 )

--- a/x/wnft/types/msgs.go
+++ b/x/wnft/types/msgs.go
@@ -3,6 +3,7 @@ package types
 import (
 	"cosmossdk.io/errors"
 	"fmt"
+	"math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/nft"
@@ -43,6 +44,10 @@ func (msg MsgNewClass) ValidateBasic() error {
 
 	if msg.TotalSupply == 0 && msg.ClassId != "kyc" {
 		return ErrEmptyTotalSupply
+	}
+
+	if msg.TotalSupply > math.MaxUint32 {
+		return ErrTotalSupplyExceedsMax
 	}
 
 	if len(msg.Name) == 0 {

--- a/x/wnft/types/msgs_test.go
+++ b/x/wnft/types/msgs_test.go
@@ -1,0 +1,98 @@
+package types
+
+import (
+	"math"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func TestMsgNewClass_ValidateBasic_TotalSupplyCap(t *testing.T) {
+	// Generate a valid sender address
+	sender := sdk.AccAddress([]byte("sender___________________")).String()
+
+	tests := []struct {
+		name        string
+		msg         *MsgNewClass
+		expectError bool
+	}{
+		{
+			name: "valid total supply within limit",
+			msg: &MsgNewClass{
+				ClassId:     "test-class",
+				Sender:      sender,
+				Name:        "Test Class",
+				Symbol:      "TC",
+				TotalSupply: 100,
+			},
+			expectError: false,
+		},
+		{
+			name: "total supply at uint32 max - valid",
+			msg: &MsgNewClass{
+				ClassId:     "test-class",
+				Sender:      sender,
+				Name:        "Test Class",
+				Symbol:      "TC",
+				TotalSupply: math.MaxUint32,
+			},
+			expectError: false,
+		},
+		{
+			name: "total supply exceeds uint32 max - invalid",
+			msg: &MsgNewClass{
+				ClassId:     "test-class",
+				Sender:      sender,
+				Name:        "Test Class",
+				Symbol:      "TC",
+				TotalSupply: math.MaxUint32 + 1,
+			},
+			expectError: true,
+		},
+		{
+			name: "total supply at uint64 max - invalid",
+			msg: &MsgNewClass{
+				ClassId:     "test-class",
+				Sender:      sender,
+				Name:        "Test Class",
+				Symbol:      "TC",
+				TotalSupply: math.MaxUint64,
+			},
+			expectError: true,
+		},
+		{
+			name: "zero total supply (non-kyc) - invalid",
+			msg: &MsgNewClass{
+				ClassId:     "test-class",
+				Sender:      sender,
+				Name:        "Test Class",
+				Symbol:      "TC",
+				TotalSupply: 0,
+			},
+			expectError: true,
+		},
+		{
+			name: "zero total supply for kyc class - valid",
+			msg: &MsgNewClass{
+				ClassId:     "kyc",
+				Sender:      sender,
+				Name:        "KYC Class",
+				Symbol:      "KYC",
+				TotalSupply: 0,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.expectError && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Enforces an upper bound of `math.MaxUint32` on `TotalSupply` when creating an NFT class. Without this cap, a class creator could set `TotalSupply` to `math.MaxUint64`, effectively allowing unlimited minting.

## Changes

- **`x/wnft/types/errors.go`**: Added `ErrTotalSupplyExceedsMax` sentinel error
- **`x/wnft/types/msgs.go`**: Added `TotalSupply > math.MaxUint32` validation in `MsgNewClass.ValidateBasic()`
- **`x/wnft/keeper/msg_server.go`**: Added server-side `TotalSupply` cap check in `Keeper.NewClass()`
- **`x/wnft/types/msgs_test.go`**: Added unit tests covering boundary cases (valid supply, at max, above max, zero, kyc exception)

Fixes #106