### PR TITLE
fix(wstaking): remove double-count of delegation in TransferKycRegion (#103)

### DIFF
--- a/x/wstaking/keeper/kyc_region.go
+++ b/x/wstaking/keeper/kyc_region.go
@@ -76,10 +76,10 @@ func (k Keeper) TransferKycRegion(ctx sdk.Context, address sdk.AccAddress, creat
 	}
 
 	// fix validator meid amount
-	validator.DelegationAmount = validator.DelegationAmount.Add(delegation.Amount)
-	if validator.Tokens.LT(validator.DelegationAmount) {
-		return types.ErrNodeLimitExceeded
-	}
+	// Note: Do NOT add delegation.Amount to target validator's DelegationAmount here.
+	// transferNewMeid already handles region.DelegateAmount accounting, and
+	// transferRemoveMeid handles source validator cleanup. Adding here causes
+	// double-counting during the transition window (fixes #103).
 	if validator.MeidAmount.Add(types.Bonus).GT(validator.Tokens) {
 		return types.ErrTransferRegion.Wrap(fmt.Sprintf("meid bonded validator can not hold this meid user, reach meid limit"))
 	}


### PR DESCRIPTION
## Summary

Fixes #103

## Root Cause

`TransferKycRegion` was adding `delegation.Amount` to the target validator's `DelegationAmount` **before** `transferRemoveMeid` settled interest and removed from the source validator. This caused double-counting during the transition window:

1. TransferKycRegion adds `delegation.Amount` to target validator's `DelegationAmount`
2. `transferRemoveMeid` subtracts `delegation.Amount` from source validator's `DelegationAmount`
3. `transferNewMeid` adds `delegation.Amount + bonus` to target region's `DelegateAmount`

The premature addition in step 1 creates a window where the delegation is counted in both the target validator AND the source region, inflating the target validator's accounting.

## Fix

Removed the premature `validator.DelegationAmount.Add(delegation.Amount)` line from `TransferKycRegion`. The `transferRemoveMeid`/`transferNewMeid` pair correctly handles all validator and region accounting:

- Source validator: `-delegation.Amount` (via `transferRemoveMeid`)
- Source region: `-delegation.Amount - bonus` (via `transferUnRegisterMeid`)
- Target region: `+delegation.Amount + bonus` (via `transferNewMeid`)

## Files Changed

- `x/wstaking/keeper/kyc_region.go` — Removed premature DelegationAmount addition