### PR TITLE
fix: MsgMintNFT singer option in tx.proto

### DIFF
--- a/proto/metaearth/wnft/tx.proto
+++ b/proto/metaearth/wnft/tx.proto
@@ -51,7 +51,7 @@ message MsgNewClass {
 message MsgNewClassResponse {}
 
 message MsgMintNFT {
-  option (cosmos.msg.v1.signer) = "sender";
+  option (cosmos.msg.v1.signer) = "creator";
 
   // class_id defines the unique identifier of the nft classification, similar
   // to the contract address of ERC721


### PR DESCRIPTION
this pull request updates the signer option in tx.proto by changing it from "sender" to "creator" in MsgMintNFT. this ensures the singer field matches the intended massage creator and improves consistency in transaction handling.