### PR TITLE
fix(gravity): reject duplicate BridgeTokens and validate BridgeToken in genesis

### DIFF
--- a/x/gravity/keeper/bridge_token_test.go
+++ b/x/gravity/keeper/bridge_token_test.go
@@ -1,7 +1,9 @@
 package keeper_test
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/testutil/helpers"
+	"github.com/openmetaearth/me-hub/x/gravity/keeper"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 )
 
@@ -33,3 +35,97 @@ func (suite *KeeperTestSuite) TestKeeper_BridgeToken() {
 		return false
 	})
 }
+
+func (suite *KeeperTestSuite) TestGenesisValidationAndImport() {
+	// 1. Test same denom with two contracts in ValidateBasic
+	genesis1 := &types.GenesisState{
+		Params: types.DefaultParams(),
+		BridgeTokens: []types.BridgeToken{
+			{
+				ContractAddress: helpers.GenerateAddress().Hex(),
+				Denom:           "testdenom",
+				Name:            "Test 1",
+				Symbol:          "T1",
+				Decimal:         18,
+				Supply:          sdk.NewInt(100),
+			},
+			{
+				ContractAddress: helpers.GenerateAddress().Hex(),
+				Denom:           "testdenom",
+				Name:            "Test 2",
+				Symbol:          "T2",
+				Decimal:         18,
+				Supply:          sdk.NewInt(200),
+			},
+		},
+	}
+	suite.Error(genesis1.ValidateBasic())
+
+	// 2. Test same contract with two denoms in ValidateBasic
+	contractAddr := helpers.GenerateAddress().Hex()
+	genesis2 := &types.GenesisState{
+		Params: types.DefaultParams(),
+		BridgeTokens: []types.BridgeToken{
+			{
+				ContractAddress: contractAddr,
+				Denom:           "denom1",
+				Name:            "Test 1",
+				Symbol:          "T1",
+				Decimal:         18,
+				Supply:          sdk.NewInt(100),
+			},
+			{
+				ContractAddress: contractAddr,
+				Denom:           "denom2",
+				Name:            "Test 2",
+				Symbol:          "T2",
+				Decimal:         18,
+				Supply:          sdk.NewInt(200),
+			},
+		},
+	}
+	suite.Error(genesis2.ValidateBasic())
+
+	// 3. Test defensive check in InitGenesis
+	suite.Panics(func() {
+		keeper.InitGenesis(suite.Ctx, suite.Keeper(), genesis1)
+	})
+}
+
+func (suite *KeeperTestSuite) TestGenesisExportImport() {
+	genesis := &types.GenesisState{
+		Params: types.DefaultParams(),
+		BridgeTokens: []types.BridgeToken{
+			{
+				ContractAddress: helpers.GenerateAddress().Hex(),
+				Denom:           "canonicaldenom",
+				Name:            "Canonical",
+				Symbol:          "CAN",
+				Decimal:         18,
+				Supply:          sdk.NewInt(500),
+			},
+		},
+	}
+
+	// 1. Import
+	keeper.InitGenesis(suite.Ctx, suite.Keeper(), genesis)
+
+	// 2. Verify keeper state
+	token, err := suite.Keeper().GetBridgeTokenByDenom(suite.Ctx, "canonicaldenom")
+	suite.NoError(err)
+	suite.Equal("canonicaldenom", token.Denom)
+
+	// 3. Export
+	exported := keeper.ExportGenesis(suite.Ctx, suite.Keeper())
+	suite.Len(exported.BridgeTokens, 1)
+	suite.Equal("canonicaldenom", exported.BridgeTokens[0].Denom)
+
+	// 4. Re-import after resetting context
+	suite.SetupTest()
+	keeper.InitGenesis(suite.Ctx, suite.Keeper(), exported)
+	tokenReimported, err := suite.Keeper().GetBridgeTokenByDenom(suite.Ctx, "canonicaldenom")
+	suite.NoError(err)
+	suite.Equal("canonicaldenom", tokenReimported.Denom)
+}
+
+

--- a/x/gravity/keeper/genesis.go
+++ b/x/gravity/keeper/genesis.go
@@ -39,7 +39,22 @@ func InitGenesis(ctx sdk.Context, k Keeper, state *types.GenesisState) {
 	}
 	k.SetLastRelayerSetNonce(ctx, latestRelayerSetNonce)
 
+	denoms := make(map[string]bool)
+	contracts := make(map[string]bool)
 	for _, bridgeToken := range state.BridgeTokens {
+		if err := bridgeToken.ValidateBasic(); err != nil {
+			panic(err)
+		}
+		if denoms[bridgeToken.Denom] {
+			panic("duplicate bridge token denom: " + bridgeToken.Denom)
+		}
+		denoms[bridgeToken.Denom] = true
+
+		if contracts[bridgeToken.ContractAddress] {
+			panic("duplicate bridge token contract: " + bridgeToken.ContractAddress)
+		}
+		contracts[bridgeToken.ContractAddress] = true
+
 		k.SetBridgeToken(ctx, &bridgeToken)
 	}
 

--- a/x/gravity/types/genesis.go
+++ b/x/gravity/types/genesis.go
@@ -1,10 +1,33 @@
 package types
 
+import (
+	errorsmod "cosmossdk.io/errors"
+)
+
 // ValidateBasic validates genesis state by looping through the params and
 // calling their validation functions
 func (m *GenesisState) ValidateBasic() error {
 	if err := m.Params.ValidateBasic(); err != nil {
 		return err
 	}
+
+	denoms := make(map[string]bool)
+	contracts := make(map[string]bool)
+
+	for _, token := range m.BridgeTokens {
+		if err := token.ValidateBasic(); err != nil {
+			return err
+		}
+		if denoms[token.Denom] {
+			return errorsmod.Wrapf(ErrDuplicate, "duplicate bridge token denom: %s", token.Denom)
+		}
+		denoms[token.Denom] = true
+
+		if contracts[token.ContractAddress] {
+			return errorsmod.Wrapf(ErrDuplicate, "duplicate bridge token contract: %s", token.ContractAddress)
+		}
+		contracts[token.ContractAddress] = true
+	}
+
 	return nil
 }

--- a/x/gravity/types/types.go
+++ b/x/gravity/types/types.go
@@ -33,6 +33,26 @@ func (m *ERC20Token) ValidateBasic() error {
 	return nil
 }
 
+// ValidateBasic performs stateless validation
+func (m *BridgeToken) ValidateBasic() error {
+	if len(m.Name) == 0 {
+		return errorsmod.Wrap(ErrEmpty, "name")
+	}
+	if len(m.Symbol) == 0 {
+		return errorsmod.Wrap(ErrEmpty, "symbol")
+	}
+	if len(m.Denom) == 0 {
+		return errorsmod.Wrap(ErrEmpty, "denom")
+	}
+	if err := utils.ValidateEthereumAddress(m.ContractAddress); err != nil {
+		return errorsmod.Wrap(err, "invalid contract address")
+	}
+	if m.Supply.IsNil() || m.Supply.IsNegative() {
+		return errorsmod.Wrap(ErrInvalid, "supply")
+	}
+	return nil
+}
+
 // --- BRIDGE VALIDATOR(S) --- //
 
 // ValidateBasic performs stateless checks on validity


### PR DESCRIPTION
This PR fixes a high-severity bug bounty finding where duplicate \BridgeToken\ imports in genesis could split the denom/contract indexes, leading to bridge routing corruption and AppHash inconsistency.

### Changes
1. Added \ValidateBasic()\ for \BridgeToken\ to ensure correct denom, contract address (Ethereum format), name, symbol, and non-negative supply.
2. Updated \GenesisState.ValidateBasic()\ to validate all bridge tokens and reject duplicate denoms or contract addresses.
3. Added defensive duplicate and validity checks in \InitGenesis\ to abort/panic on malformed genesis states.
4. Added comprehensive unit tests in \ridge_token_test.go\ to cover:
   - Same denom with two contracts rejection.
   - Same contract with two denoms rejection.
   - Defensive checks panic behavior in \InitGenesis\.
   - Export/import flow verification.

Closes #421