### PR TITLE
fix(ante): reject oversized gas_limit to prevent fee checker panic

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -359,6 +359,9 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 
 			// Determine the required fees by multiplying each required minimum gas
 			// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
+			if gas > math.MaxInt64 {
+				return nil, 0, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "gas limit %d exceeds max int64", gas)
+			}
 			glDec := sdk.NewDec(int64(gas))
 			for i, gp := range minGasPrices {
 				fee := gp.Amount.Mul(glDec)

--- a/app/ante/fee_deduct_test.go
+++ b/app/ante/fee_deduct_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/openmetaearth/me-hub/app/ante"
 	"github.com/openmetaearth/me-hub/app/params"
+	"math"
 	"regexp"
 	"strconv"
 	"testing"
@@ -391,3 +392,60 @@ func TestCheckFunds(t *testing.T) {
 		})
 	}
 }
+
+type MockFeeTx struct {
+	msgs       []sdk.Msg
+	gas        uint64
+	fee        sdk.Coins
+	feePayer   sdk.AccAddress
+	feeGranter sdk.AccAddress
+}
+
+func (m MockFeeTx) GetMsgs() []sdk.Msg { return m.msgs }
+func (m MockFeeTx) ValidateBasic() error { return nil }
+func (m MockFeeTx) GetGas() uint64 { return m.gas }
+func (m MockFeeTx) GetFee() sdk.Coins { return m.fee }
+func (m MockFeeTx) FeePayer() sdk.AccAddress { return m.feePayer }
+func (m MockFeeTx) FeeGranter() sdk.AccAddress { return m.feeGranter }
+
+func TestCheckTxFeeWithValidatorMinGasPrices_GasLimitOverflow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := sdk.Context{}.WithIsCheckTx(true).WithMinGasPrices(sdk.DecCoins{sdk.NewDecCoin("umec", sdk.NewInt(1))})
+	mockBankKeeper := mock.NewMockBankKeeper(ctrl)
+	mockAccountKeeper := authantetestutil.NewMockAccountKeeper(ctrl)
+	mockFeegrantKeeper := authantetestutil.NewMockFeegrantKeeper(ctrl)
+	mockStakingKeeper := mock.NewMockStakingKeeper(ctrl)
+	mockKycKeeper := mock.NewMockKycKeeper(ctrl)
+	mockDaoKeeper := mock.NewMockDaoKeeper(ctrl)
+	mockWasmKeeper := mock.NewMockWasmKeeper(ctrl)
+
+	decorator := ante.NewDeductFeeDecorator(
+		mockAccountKeeper,
+		mockBankKeeper,
+		mockFeegrantKeeper,
+		mockDaoKeeper,
+		mockStakingKeeper,
+		mockKycKeeper,
+		nil,
+		mockWasmKeeper,
+	)
+
+	feePayer := NewAccount()
+	mockTx := &MockFeeTx{
+		gas:      math.MaxInt64 + 1,
+		fee:      sdk.NewCoins(sdk.NewCoin("umec", sdk.NewInt(1000000))),
+		feePayer: feePayer.GetAddress(),
+	}
+
+	require.NotPanics(t, func() {
+		_, err := decorator.AnteHandle(ctx, mockTx, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+			return ctx, nil
+		})
+		require.Error(t, err)
+		require.True(t, sdkerrors.ErrInvalidRequest.Is(err))
+		require.Contains(t, err.Error(), "gas limit 9223372036854775808 exceeds max int64")
+	})
+}
+


### PR DESCRIPTION
This PR fixes a medium-severity bug bounty finding where an oversized transaction \gas_limit\ (exceeding \math.MaxInt64\) overflows during fee checker calculations, leading to a panic in \sdk.NewCoin\ and triggering BaseApp panic recovery.

### Cause:
In \pp/ante/fee_deduct.go\, \checkTxFeeWithValidatorMinGasPrices\ converts \gas\ (which is \uint64\) to \int64\ via \int64(gas)\. If \gas > math.MaxInt64\, this results in a negative \int64\ value. When multiplying the minimum gas price with this negative limit, the required fee becomes negative, causing \sdk.NewCoin\ to panic: \
egative coin amount: ...\.

### Solution:
1. Validate that \gas <= math.MaxInt64\ in \checkTxFeeWithValidatorMinGasPrices\ before performing the narrowing conversion.
2. Return a clean \sdkerrors.ErrInvalidRequest\ error when this limit is exceeded, preventing CheckTx panics.
3. Added a unit test in \ee_deduct_test.go\ (\TestCheckTxFeeWithValidatorMinGasPrices_GasLimitOverflow\) to verify the correct error is returned and no panic occurs.

Closes #417