### PR TITLE
fix(ante): enforce umec base-denom fee during DeliverTx

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -371,6 +371,25 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 		}
 	}
 
+	// During DeliverTx, enforce that fees are paid in the base denomination (umec).
+	// Without this check, a proposer can include transactions that pay fees in a
+	// foreign denom (e.g. "100foo") which CheckTx would reject but DeliverTx would
+	// silently accept, creating a consensus-splitting fee policy violation.
+	if !ctx.IsCheckTx() {
+		baseDenomFee := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.ZeroInt()))
+		for _, fc := range feeCoins {
+			if fc.Denom == params.BaseDenom {
+				baseDenomFee = sdk.NewCoins(fc)
+				break
+			}
+		}
+		if !baseDenomFee.IsAllGTE(minimumFee) {
+			return sdk.Coins{}, 0, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee,
+				"fees must include at least %s in base denom %s; got %s",
+				minimumFee.String(), params.BaseDenom, feeCoins.String())
+		}
+	}
+
 	priority := getTxPriorityByFee(feeCoins)
 	return feeCoins, priority, nil
 }


### PR DESCRIPTION
## Summary

Enforces that fees include at least `minimumFee` (10000umec) in the base denomination (`umec`) during DeliverTx, not just CheckTx.

**Fixes openmetaearth/me-hub#430**

## Vulnerability

The `checkTxFeeWithValidatorMinGasPrices` function in `app/ante/fee_deduct.go` only enforced the minimum fee check when `ctx.IsCheckTx()` is true. During DeliverTx (block execution), the same checker returned success for fees paid only in a foreign denomination such as `100foo`.

This means a proposer or private block inclusion path could include a signed Cosmos transaction that ordinary nodes reject in CheckTx but accept during block execution, with fees paid in a non-`umec` denom — a consensus-splitting fee policy violation.

## Changes

**File:** `app/ante/fee_deduct.go` — `checkTxFeeWithValidatorMinGasPrices()`

Added DeliverTx validation (after the existing CheckTx block) that:
1. Scans the fee coins for a `umec`-denominated coin
2. Verifies the `umec` amount meets `minimumFee` (10000umec)
3. Returns `ErrInsufficientFee` if the base denom fee is missing or insufficient

## Testing

1. Verify CheckTx still rejects fees below 10000umec (existing behavior)
2. Verify DeliverTx now rejects transactions with only non-umec fees
3. Verify DeliverTx accepts transactions with >= 10000umec fees
4. Verify transactions with mixed denominations still work if umec meets minimum
