### PR TITLE
fix: prevent uint64->int64 overflow panic on oversized gas_limit (#417)

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -359,6 +359,9 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 
 			// Determine the required fees by multiplying each required minimum gas
 			// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
+			if gas > math.MaxInt64 {
+				return nil, 0, sdkerrors.Wrapf(sdkerrors.ErrInvalidGasLimit, "gas limit %d exceeds maximum allowed value", gas)
+			}
 			glDec := sdk.NewDec(int64(gas))
 			for i, gp := range minGasPrices {
 				fee := gp.Amount.Mul(glDec)


### PR DESCRIPTION
## What

Adds an overflow guard in `checkTxFeeWithValidatorMinGasPrices` to prevent a panic when `gas_limit` exceeds `math.MaxInt64`.

## The Bug

In `app/ante/fee_deduct.go`, line 362 (original), the code does:

```go
glDec := sdk.NewDec(int64(gas))
```

When `gas` (a `uint64`) is greater than `math.MaxInt64` (9,223,372,036,854,775,807), the cast `int64(gas)` overflows to a **negative** value. This negative decimal is then used to compute fees, which eventually causes `sdk.NewCoin` to panic on a negative amount — a **denial-of-service vector** where any user can submit a transaction with an oversized `gas_limit` to crash validators.

## The Fix

Added an explicit bounds check before the conversion:

```go
if gas > math.MaxInt64 {
    return nil, 0, sdkerrors.Wrapf(sdkerrors.ErrInvalidGasLimit, "gas limit %d exceeds maximum allowed value", gas)
}
```

This returns a normal error (`ErrInvalidGasLimit`) instead of panicking, consistent with the Cosmos SDK error handling pattern.

Fixes #417