### PR TITLE
fix(gravity): validate duplicate BridgeTokens in genesis to prevent index split

### DIFF
--- a/x/gravity/keeper/genesis.go
+++ b/x/gravity/keeper/genesis.go
@@ -39,6 +39,9 @@ func InitGenesis(ctx sdk.Context, k Keeper, state *types.GenesisState) {
 	}
 	k.SetLastRelayerSetNonce(ctx, latestRelayerSetNonce)
 
+	if err := types.ValidateGenesisBridgeTokens(state.BridgeTokens); err != nil {
+		panic(err)
+	}
 	for _, bridgeToken := range state.BridgeTokens {
 		k.SetBridgeToken(ctx, &bridgeToken)
 	}

--- a/x/gravity/types/genesis.go
+++ b/x/gravity/types/genesis.go
@@ -1,10 +1,49 @@
 package types
 
+import (
+	fmt "fmt"
+)
+
 // ValidateBasic validates genesis state by looping through the params and
 // calling their validation functions
 func (m *GenesisState) ValidateBasic() error {
 	if err := m.Params.ValidateBasic(); err != nil {
 		return err
+	}
+	if err := ValidateGenesisBridgeTokens(m.BridgeTokens); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateGenesisBridgeTokens checks that no two BridgeTokens share the same
+// denom or the same contract address.  Duplicate entries would silently
+// overwrite one of the two KV indexes (denom→token or contract→token)
+// during InitGenesis, splitting them and corrupting bridge asset routing.
+func ValidateGenesisBridgeTokens(tokens []BridgeToken) error {
+	seenDenom := make(map[string]string, len(tokens))    // denom -> contract
+	seenContract := make(map[string]string, len(tokens)) // contract -> denom
+	for _, bt := range tokens {
+		if bt.Denom == "" {
+			return fmt.Errorf("bridge token with empty denom (contract %s)", bt.ContractAddress)
+		}
+		if bt.ContractAddress == "" {
+			return fmt.Errorf("bridge token with empty contract address (denom %s)", bt.Denom)
+		}
+		if existing, ok := seenDenom[bt.Denom]; ok {
+			return ErrDuplicate.Wrapf(
+				"bridge token denom %q already registered to contract %s, cannot also register contract %s",
+				bt.Denom, existing, bt.ContractAddress,
+			)
+		}
+		if existing, ok := seenContract[bt.ContractAddress]; ok {
+			return ErrDuplicate.Wrapf(
+				"bridge token contract %q already registered to denom %s, cannot also register denom %s",
+				bt.ContractAddress, existing, bt.Denom,
+			)
+		}
+		seenDenom[bt.Denom] = bt.ContractAddress
+		seenContract[bt.ContractAddress] = bt.Denom
 	}
 	return nil
 }

--- a/x/gravity/types/genesis_test.go
+++ b/x/gravity/types/genesis_test.go
@@ -1,0 +1,112 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisState_ValidateBasic_BridgeTokenDuplicates(t *testing.T) {
+	validToken := BridgeToken{
+		ContractAddress: "0x0000000000000000000000000000000000000001",
+		Denom:           "uusdt",
+		Name:            "Tether USD",
+		Symbol:          "USDT",
+		Decimal:         6,
+	}
+	validToken2 := BridgeToken{
+		ContractAddress: "0x0000000000000000000000000000000000000002",
+		Denom:           "uusdc",
+		Name:            "USDC Coin",
+		Symbol:          "USDC",
+		Decimal:         6,
+	}
+
+	baseGenesis := func(tokens []BridgeToken) *GenesisState {
+		return &GenesisState{
+			Params:       DefaultParams(),
+			BridgeTokens: tokens,
+		}
+	}
+
+	t.Run("valid: no duplicates", func(t *testing.T) {
+		gs := baseGenesis([]BridgeToken{validToken, validToken2})
+		require.NoError(t, gs.ValidateBasic())
+	})
+
+	t.Run("valid: single token", func(t *testing.T) {
+		gs := baseGenesis([]BridgeToken{validToken})
+		require.NoError(t, gs.ValidateBasic())
+	})
+
+	t.Run("valid: empty bridge tokens", func(t *testing.T) {
+		gs := baseGenesis(nil)
+		require.NoError(t, gs.ValidateBasic())
+	})
+
+	t.Run("invalid: duplicate denom", func(t *testing.T) {
+		dup := BridgeToken{
+			ContractAddress: "0x0000000000000000000000000000000000000003",
+			Denom:           "uusdt", // same denom as validToken
+			Name:            "Fake USD",
+			Symbol:          "fUSDT",
+			Decimal:         6,
+		}
+		gs := baseGenesis([]BridgeToken{validToken, dup})
+		err := gs.ValidateBasic()
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrDuplicate)
+		require.Contains(t, err.Error(), "uusdt")
+	})
+
+	t.Run("invalid: duplicate contract address", func(t *testing.T) {
+		dup := BridgeToken{
+			ContractAddress: "0x0000000000000000000000000000000000000001", // same contract as validToken
+			Denom:           "udai",
+			Name:            "Dai",
+			Symbol:          "DAI",
+			Decimal:         18,
+		}
+		gs := baseGenesis([]BridgeToken{validToken, dup})
+		err := gs.ValidateBasic()
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrDuplicate)
+		require.Contains(t, err.Error(), "0x0000000000000000000000000000000000000001")
+	})
+
+	t.Run("invalid: empty denom", func(t *testing.T) {
+		dup := BridgeToken{
+			ContractAddress: "0x0000000000000000000000000000000000000003",
+			Denom:           "",
+		}
+		gs := baseGenesis([]BridgeToken{dup})
+		err := gs.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "empty denom")
+	})
+
+	t.Run("invalid: empty contract address", func(t *testing.T) {
+		dup := BridgeToken{
+			ContractAddress: "",
+			Denom:           "uusdt",
+		}
+		gs := baseGenesis([]BridgeToken{dup})
+		err := gs.ValidateBasic()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "empty contract address")
+	})
+
+	t.Run("invalid: 3-way split - two denoms same, three unique contracts", func(t *testing.T) {
+		// This is the exact attack: same denom, different contracts.
+		// InitGenesis would overwrite the denom index for the second entry
+		// but leave the first contract's index pointing to a now-orphaned denom.
+		dup := BridgeToken{
+			ContractAddress: "0x0000000000000000000000000000000000000003",
+			Denom:           "uusdt", // same denom as validToken
+		}
+		gs := baseGenesis([]BridgeToken{validToken, validToken2, dup})
+		err := gs.ValidateBasic()
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrDuplicate)
+	})
+}


### PR DESCRIPTION
## Fix #421 — BridgeToken genesis duplicate validation

### Vulnerability

Genesis import (`InitGenesis`) iterates `BridgeTokens` and calls `SetBridgeToken`, which writes to **two KV indexes** (by denom and by contract). `GenesisState.ValidateBasic()` did not check for duplicate denom or contract entries. A malicious genesis could contain two entries with the same denom but different contracts (or vice versa), causing the second `SetBridgeToken` to overwrite the denom index while leaving the first entry's contract index still pointing to the old (now orphaned) value. This splits the indexes and corrupts bridge asset routing.

### Fix

Three changes:

1. **`x/gravity/types/genesis.go`** — Added `ValidateGenesisBridgeTokens()` that checks for duplicate denom and duplicate contract address using O(n) maps. Returns `ErrDuplicate` on conflict. Also rejects empty denom/contract. Called from `GenesisState.ValidateBasic()`.

2. **`x/gravity/keeper/genesis.go`** — Added defense-in-depth call to `ValidateGenesisBridgeTokens()` in `InitGenesis()` that panics before any `SetBridgeToken` writes if duplicates are found.

3. **`x/gravity/types/genesis_test.go`** — Comprehensive unit tests covering:
   - Valid: no duplicates, single token, empty bridge tokens
   - Invalid: duplicate denom, duplicate contract address
   - Invalid: empty denom, empty contract address
   - Invalid: 3-entry index split attack scenario (same denom, different contracts)

### Testing

```bash
go test ./x/gravity/types/ -run TestGenesisState_ValidateBasic_BridgeTokenDuplicates -v
```