### PR TITLE
fix: validate wasm multisend messages

### DIFF
--- a/app/keepers/wasm_me_msg.go
+++ b/app/keepers/wasm_me_msg.go
@@ -8,6 +8,7 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
@@ -36,25 +37,65 @@ func EncodeMeMsg(sender sdk.AccAddress, msg *MeMsg) ([]sdk.Msg, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !toSend.IsAllPositive() {
+		return nil, errorsmod.Wrap(types.ErrInvalidMsg, "multisend input amount must be positive")
+	}
 
 	var outputs []banktypes.Output
+	totalOutputs := sdk.Coins{}
 	for _, o := range msg.MultiSend.Output {
+		outputAddr, err := sdk.AccAddressFromBech32(o.Address)
+		if err != nil {
+			return nil, errorsmod.Wrapf(types.ErrInvalidMsg, "invalid multisend output address %q: %v", o.Address, err)
+		}
+		if isModuleAccountAddress(outputAddr) {
+			return nil, errorsmod.Wrap(types.ErrInvalidMsg, "multisend output address must not be a module account")
+		}
+
 		amt, err := wasmkeeper.ConvertWasmCoinsToSdkCoins(o.Amount)
 		if err != nil {
 			return nil, err
 		}
+		if !amt.IsAllPositive() {
+			return nil, errorsmod.Wrap(types.ErrInvalidMsg, "multisend output amount must be positive")
+		}
+
+		totalOutputs = totalOutputs.Add(amt...)
 		outputs = append(outputs, banktypes.Output{
 			Address: o.Address,
 			Coins:   amt,
 		})
 	}
+	if !toSend.IsEqual(totalOutputs) {
+		return nil, errorsmod.Wrapf(
+			types.ErrInvalidMsg,
+			"multisend input amount %s does not match output amount %s",
+			toSend.String(),
+			totalOutputs.String(),
+		)
+	}
+
 	sdkMsg := banktypes.MsgMultiSend{
 		Inputs: []banktypes.Input{
 			{Address: sender.String(), Coins: toSend},
 		},
 		Outputs: outputs,
 	}
+	if err := sdkMsg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	return []sdk.Msg{&sdkMsg}, nil
+}
+
+func isModuleAccountAddress(addr sdk.AccAddress) bool {
+	for moduleName := range MaccPerms {
+		if authtypes.NewModuleAddress(moduleName).Equals(addr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // SetupCustomMsgs sets up the custom message handlers for the app

--- a/app/keepers/wasm_me_msg_test.go
+++ b/app/keepers/wasm_me_msg_test.go
@@ -1,0 +1,113 @@
+package keepers
+
+import (
+	"bytes"
+	"testing"
+
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/openmetaearth/me-hub/app/params"
+)
+
+func TestEncodeMeMsgMultiSendValidation(t *testing.T) {
+	sender := testAccAddress(1)
+	recipientA := testAccAddress(2)
+	recipientB := testAccAddress(3)
+
+	tests := []struct {
+		name    string
+		msg     *MeMsg
+		wantErr string
+	}{
+		{
+			name: "valid multisend",
+			msg: &MeMsg{MultiSend: &MultiSend{
+				Amount: wasmvmtypes.Coins{testWasmCoin("15")},
+				Output: []Output{
+					{Address: recipientA.String(), Amount: wasmvmtypes.Coins{testWasmCoin("10")}},
+					{Address: recipientB.String(), Amount: wasmvmtypes.Coins{testWasmCoin("5")}},
+				},
+			}},
+		},
+		{
+			name: "invalid output address",
+			msg: &MeMsg{MultiSend: &MultiSend{
+				Amount: wasmvmtypes.Coins{testWasmCoin("10")},
+				Output: []Output{
+					{Address: "not-an-address", Amount: wasmvmtypes.Coins{testWasmCoin("10")}},
+				},
+			}},
+			wantErr: "invalid multisend output address",
+		},
+		{
+			name: "module account output address",
+			msg: &MeMsg{MultiSend: &MultiSend{
+				Amount: wasmvmtypes.Coins{testWasmCoin("10")},
+				Output: []Output{
+					{Address: authtypes.NewModuleAddress(govtypes.ModuleName).String(), Amount: wasmvmtypes.Coins{testWasmCoin("10")}},
+				},
+			}},
+			wantErr: "module account",
+		},
+		{
+			name: "non-positive output amount",
+			msg: &MeMsg{MultiSend: &MultiSend{
+				Amount: wasmvmtypes.Coins{testWasmCoin("10")},
+				Output: []Output{
+					{Address: recipientA.String(), Amount: wasmvmtypes.Coins{testWasmCoin("0")}},
+				},
+			}},
+			wantErr: "multisend output amount must be positive",
+		},
+		{
+			name: "input output mismatch",
+			msg: &MeMsg{MultiSend: &MultiSend{
+				Amount: wasmvmtypes.Coins{testWasmCoin("10")},
+				Output: []Output{
+					{Address: recipientA.String(), Amount: wasmvmtypes.Coins{testWasmCoin("9")}},
+				},
+			}},
+			wantErr: "does not match output amount",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs, err := EncodeMeMsg(sender, tt.msg)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, msgs)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, msgs, 1)
+
+			multiSend, ok := msgs[0].(*banktypes.MsgMultiSend)
+			require.True(t, ok)
+			require.NoError(t, multiSend.ValidateBasic())
+			require.Equal(t, sender.String(), multiSend.Inputs[0].Address)
+			require.Equal(t, recipientA.String(), multiSend.Outputs[0].Address)
+			require.Equal(t, recipientB.String(), multiSend.Outputs[1].Address)
+		})
+	}
+}
+
+func TestEncodeMeMsgKeepsEmptyOutputNoop(t *testing.T) {
+	msgs, err := EncodeMeMsg(testAccAddress(1), &MeMsg{MultiSend: &MultiSend{}})
+	require.NoError(t, err)
+	require.Nil(t, msgs)
+}
+
+func testAccAddress(fill byte) sdk.AccAddress {
+	return sdk.AccAddress(bytes.Repeat([]byte{fill}, 20))
+}
+
+func testWasmCoin(amount string) wasmvmtypes.Coin {
+	return wasmvmtypes.Coin{Denom: "umec", Amount: amount}
+}


### PR DESCRIPTION
## Summary

Closes #246.

This hardens the custom Wasm `multi_send` encoder before it hands a `banktypes.MsgMultiSend` to the SDK:

- validates every output address before constructing the bank message
- rejects output addresses that resolve to configured module accounts
- rejects non-positive input or output coins
- verifies the input coins exactly match the summed output coins
- calls `MsgMultiSend.ValidateBasic()` before returning the message

## Tests

- `go test ./app/keepers`
- `git diff --check`

I also ran `go test ./app/...`; it still fails in the existing `app/ante` tests because `MockDaoKeeper` is missing `IsDao`, which is outside this change.

## Payment

Payment method: Meta Earth bug bounty payout in `$MEC` via ME Pass.

Wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`