### PR TITLE
Preserve upgrade version maps for migrations

### DIFF
--- a/app/upgrades/v2_0_13/upgrade.go
+++ b/app/upgrades/v2_0_13/upgrade.go
@@ -30,13 +30,6 @@ func CreateUpgradeHandler(
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 		logger.Info("upgrade starting...")
 
-		// Initialize consensus versions for all modules
-		for n, m := range mm.Modules {
-			if mod, ok := m.(module.HasConsensusVersion); ok {
-				fromVM[n] = mod.ConsensusVersion()
-			}
-		}
-
 		params := keepers.GovKeeper.GetParams(ctx)
 		maxDepositPeriod := 30 * time.Minute
 		params.MaxDepositPeriod = &maxDepositPeriod
@@ -71,9 +64,11 @@ func CreateUpgradeHandler(
 
 		bscGenState := GenGravityGenesis(ctx.BlockHeight(), proposalRelayers, bsctypes.DefaultGenesisState(), delegateAmount, bsctypes.ModuleName)
 		gravitykeeper.InitGenesis(ctx, keepers.BscKeeper, bscGenState)
+		markInitializedModuleVersion(fromVM, mm, bsctypes.ModuleName)
 
 		tronGenstate := GenGravityGenesis(ctx.BlockHeight(), proposalRelayers, trontypes.DefaultGenesisState(), delegateAmount, trontypes.ModuleName)
 		gravitykeeper.InitGenesis(ctx, keepers.TronKeeper, tronGenstate)
+		markInitializedModuleVersion(fromVM, mm, trontypes.ModuleName)
 
 		logger.Info("2. upgrade for setting umec metadata.")
 		keepers.BankKeeper.SetDenomMetaData(ctx, banktypes.Metadata{
@@ -97,6 +92,18 @@ func CreateUpgradeHandler(
 		})
 		logger.Info("upgrade finished successfully.")
 		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}
+
+func markInitializedModuleVersion(fromVM module.VersionMap, mm *module.Manager, moduleName string) {
+	// BSC and Tron are initialized above with custom genesis state; only absent
+	// entries should be marked so existing module versions still migrate.
+	if _, exists := fromVM[moduleName]; exists {
+		return
+	}
+
+	if mod, ok := mm.Modules[moduleName].(module.HasConsensusVersion); ok {
+		fromVM[moduleName] = mod.ConsensusVersion()
 	}
 }
 

--- a/app/upgrades/v2_0_13/upgrade_test.go
+++ b/app/upgrades/v2_0_13/upgrade_test.go
@@ -1,0 +1,40 @@
+package v2_0_13
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+	bsctypes "github.com/openmetaearth/me-hub/x/bsc/types"
+	trontypes "github.com/openmetaearth/me-hub/x/tron/types"
+	"github.com/stretchr/testify/require"
+)
+
+type consensusVersionModule struct {
+	version uint64
+}
+
+func (m consensusVersionModule) ConsensusVersion() uint64 {
+	return m.version
+}
+
+func TestMarkInitializedModuleVersionOnlySetsAbsentModule(t *testing.T) {
+	mm := &module.Manager{
+		Modules: map[string]interface{}{
+			bsctypes.ModuleName:  consensusVersionModule{version: 1},
+			trontypes.ModuleName: consensusVersionModule{version: 1},
+			"existing":           consensusVersionModule{version: 3},
+		},
+	}
+	fromVM := module.VersionMap{
+		bsctypes.ModuleName: 0,
+		"existing":          2,
+	}
+
+	markInitializedModuleVersion(fromVM, mm, bsctypes.ModuleName)
+	markInitializedModuleVersion(fromVM, mm, trontypes.ModuleName)
+
+	require.Equal(t, uint64(0), fromVM[bsctypes.ModuleName])
+	require.Equal(t, uint64(1), fromVM[trontypes.ModuleName])
+	require.Equal(t, uint64(2), fromVM["existing"])
+	require.Len(t, fromVM, 3)
+}

--- a/app/upgrades/v2_0_14/upgrade.go
+++ b/app/upgrades/v2_0_14/upgrade.go
@@ -8,8 +8,7 @@ import (
 	"github.com/openmetaearth/me-hub/app/upgrades"
 )
 
-// CreateUpgradeHandler creates an SDK upgrade handler for v2.0.13
-// This upgrade initializes the Gravity bridge module for BSC and Tron
+// CreateUpgradeHandler creates an SDK upgrade handler for v2.0.14.
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
@@ -19,13 +18,6 @@ func CreateUpgradeHandler(
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 		logger.Info("upgrade starting...")
-
-		// Initialize consensus versions for all modules
-		for n, m := range mm.Modules {
-			if mod, ok := m.(module.HasConsensusVersion); ok {
-				fromVM[n] = mod.ConsensusVersion()
-			}
-		}
 
 		evmParams := keepers.EvmKeeper.GetParams(ctx)
 		evmParams.EvmDenom = "umec"

--- a/app/upgrades/v2_0_14/upgrade_test.go
+++ b/app/upgrades/v2_0_14/upgrade_test.go
@@ -1,0 +1,51 @@
+package v2_0_14_test
+
+import (
+	"testing"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	v2_0_14 "github.com/openmetaearth/me-hub/app/upgrades/v2_0_14"
+	"github.com/stretchr/testify/require"
+)
+
+type consensusVersionModule struct {
+	version uint64
+}
+
+func (m consensusVersionModule) ConsensusVersion() uint64 {
+	return m.version
+}
+
+func TestCreateUpgradeHandlerPreservesFromVersionForMigrations(t *testing.T) {
+	const moduleName = "tracked"
+
+	mm := &module.Manager{
+		Modules: map[string]interface{}{
+			moduleName: consensusVersionModule{version: 2},
+		},
+		OrderMigrations: []string{moduleName},
+	}
+
+	configurator := module.NewConfigurator(nil, nil, nil)
+	migrated := false
+	require.NoError(t, configurator.RegisterMigration(moduleName, 1, func(sdk.Context) error {
+		migrated = true
+		return nil
+	}))
+
+	fromVM := module.VersionMap{moduleName: 1}
+	testApp := apptesting.Setup(t, false)
+	handler := v2_0_14.CreateUpgradeHandler(mm, configurator, nil, &testApp.AppKeepers)
+	ctx := testApp.BaseApp.NewContext(false, tmproto.Header{})
+
+	updatedVM, err := handler(ctx, upgradetypes.Plan{}, fromVM)
+
+	require.NoError(t, err)
+	require.True(t, migrated)
+	require.Equal(t, uint64(1), fromVM[moduleName])
+	require.Equal(t, uint64(2), updatedVM[moduleName])
+}


### PR DESCRIPTION
Fixes #245.

## Summary
- removes the blanket consensus-version rewrite before `RunMigrations`, so existing module source versions are preserved
- keeps the v2.0.13 custom BSC/Tron genesis path from running twice by marking only those manually initialized modules when they are absent from `fromVM`
- updates the v2.0.14 handler to pass the upgrade version map directly through to the SDK migration runner
- adds focused regression coverage for the migration path and the v2.0.13 manual-init guard

## Validation
- `go test ./app/upgrades/...`
- `git diff --check`
- Also checked `go test ./app/...`; it currently fails in `app/ante` because the existing `MockDaoKeeper` test mock is missing `IsDao`, which is outside this upgrade-handler change.

## Bug bounty payout
Meta Earth / OpenMetaEarth bug bounty payout: `$MEC` via ME Pass.

Wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`
