### PR TITLE
fix(rollapp): normalize RollappId by trimming whitespace before CreateRollapp processing

### DIFF
--- a/x/rollapp/keeper/msg_server_create_rollapp.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"strings"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,6 +15,12 @@ func (k msgServer) CreateRollapp(goCtx context.Context, msg *types.MsgCreateRoll
 	if !k.RollappsEnabled(ctx) {
 		return nil, types.ErrRollappsDisabled
 	}
+
+	// Normalize the RollappId by trimming whitespace before any processing.
+	// Without this, validation uses the trimmed canonical ID (via NewChainID)
+	// but the raw ID with whitespace is stored as the primary key, creating
+	// namespace duplicates and EIP155 index squatting opportunities.
+	msg.RollappId = strings.TrimSpace(msg.RollappId)
 
 	err := k.checkIfRollappExists(ctx, msg.RollappId)
 	if err != nil {


### PR DESCRIPTION
Fixes #451

## Summary

Normalizes  by trimming whitespace at the start of  to prevent namespace duplicates and EIP155 index squatting.

## Root Cause

 calls  for validation, but  preserves the raw . When  stores the rollapp, it uses the raw (untrimmed) ID as the primary storage key.

This creates a mismatch between validation (trimmed) and storage (raw):

1. **Namespace duplicates**: Non-EIP RollApps `" dup "` and `"dup"` pass validation as the same canonical ChainID but are stored as different keys
2. **EIP155 index squatting**: `" evil_1-1 "` stores under a whitespace key but reserves EIP155=1 in the secondary index, blocking legitimate `"good_1-1"`

## Fix

Add `msg.RollappId = strings.TrimSpace(msg.RollappId)` at the start of `CreateRollapp()`, before any processing. This ensures validation, existence checks, and storage all use the same normalized ID.

## Testing

The PoC tests from the issue should now pass:
- `" dup "` creation followed by `"dup"` creation should fail with `ErrRollappExists`
- `" evil_1-1 "` creation should not block `"good_1-1"` from being created