### PR TITLE
fix: reject zero gravity external addresses

### DIFF
--- a/utils/eth_validation.go
+++ b/utils/eth_validation.go
@@ -45,6 +45,9 @@ func ValidateEthereumAddress(address string) error {
 	if !common.IsHexAddress(address) {
 		return errors.New("doesn't pass format validation")
 	}
+	if IsZeroEthereumAddress(address) {
+		return errors.New("zero address")
+	}
 	expectAddress := common.HexToAddress(address).Hex()
 	if expectAddress != address {
 		return fmt.Errorf("mismatch expected: %s, got: %s", expectAddress, address)

--- a/utils/eth_validation_test.go
+++ b/utils/eth_validation_test.go
@@ -70,7 +70,7 @@ func TestValidateEthereumAddress(t *testing.T) {
 			"invalid address", "0x", true,
 		},
 		{
-			"zero address", common.Address{}.String(), false,
+			"zero address", common.Address{}.String(), true,
 		},
 		{
 			"valid address", helpers.GenerateAddress().Hex(), false,

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -10,6 +10,7 @@ package keeper_test
 // Coverage:
 //   GRAV-001  Attest must reject historical-nonce claims (no backward rewind)
 //   GRAV-004  Failed AttestationHandler must not advance lastObservedEventNonce
+//   GRAV-005  BondedRelayer must reject zero external signer addresses
 
 import (
 	"encoding/hex"
@@ -17,6 +18,7 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 	trontypes "github.com/openmetaearth/me-hub/x/tron/types"
@@ -193,6 +195,36 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 				"handler failed; retries are now impossible",
 			probeClaim.GetEventNonce())
 	}
+}
+
+// ---------------------------------------------------------------------------
+// GRAV-005: Zero external signer address in bonded relayer set
+// ---------------------------------------------------------------------------
+//
+// MsgBondedRelayer previously accepted the Ethereum zero address as an
+// ExternalAddress. That address can pass syntax and checksum checks, but it is
+// not a usable signer for relayer-set confirmations.
+
+func (s *KeeperTestSuite) TestGrav005_BondedRelayerRejectsZeroExternalAddress() {
+	zeroExternalAddress := common.Address{}.Hex()
+	relayerAddress := s.relayerAddrs[0]
+
+	msg := &types.MsgBondedRelayer{
+		RelayerAddress:  relayerAddress.String(),
+		ExternalAddress: zeroExternalAddress,
+		DelegateAmount:  sdk.NewCoin(params.BaseDenom, s.Keeper().GetGravityMinDelegate(s.Ctx)),
+		ChainName:       s.chainName,
+	}
+
+	_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msg)
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "zero address")
+
+	_, found := s.Keeper().GetRelayer(s.Ctx, relayerAddress)
+	s.Require().False(found, "zero-address relayer must not be persisted")
+
+	_, found = s.Keeper().GetRelayerByExternalAddress(s.Ctx, zeroExternalAddress)
+	s.Require().False(found, "zero address must not be indexed as an external relayer address")
 }
 
 // ---------------------------------------------------------------------------

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -25,6 +25,9 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 
 func (s MsgServer) BondedRelayer(c context.Context, msg *types.MsgBondedRelayer) (*types.MsgBondedRelayerResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
+	if err := types.ValidateExternalAddr(msg.ChainName, msg.ExternalAddress); err != nil {
+		return nil, errorsmod.Wrapf(types.ErrInvalid, "invalid external address: %s", err)
+	}
 	relayerAddress := sdk.MustAccAddressFromBech32(msg.RelayerAddress)
 	if !s.IsProposalRelayer(ctx, msg.RelayerAddress) {
 		return nil, types.ErrNotProposedRelayer
@@ -195,6 +198,9 @@ func (s MsgServer) UnbondedRelayer(c context.Context, msg *types.MsgUnbondedRela
 
 func (s MsgServer) RelayerSetConfirm(c context.Context, msg *types.MsgRelayerSetConfirm) (*types.MsgRelayerSetConfirmResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
+	if err := types.ValidateExternalAddr(msg.ChainName, msg.ExternalAddress); err != nil {
+		return nil, errorsmod.Wrapf(types.ErrInvalid, "invalid external address: %s", err)
+	}
 
 	relayerSet := s.GetRelayerSet(ctx, msg.Nonce)
 	if relayerSet == nil {

--- a/x/gravity/types/zero_external_address_test.go
+++ b/x/gravity/types/zero_external_address_test.go
@@ -1,0 +1,44 @@
+package types_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/testutil/helpers"
+	bsctypes "github.com/openmetaearth/me-hub/x/bsc/types"
+	gravitytypes "github.com/openmetaearth/me-hub/x/gravity/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEthereumExternalZeroAddressRejected(t *testing.T) {
+	zeroAddress := common.Address{}.Hex()
+	relayerAddress := helpers.GenAccAddress().String()
+
+	require.Error(t, gravitytypes.ValidateExternalAddr(bsctypes.ModuleName, zeroAddress))
+
+	bondedRelayer := &gravitytypes.MsgBondedRelayer{
+		RelayerAddress:  relayerAddress,
+		ExternalAddress: zeroAddress,
+		DelegateAmount:  sdk.NewCoin(params.BaseDenom, sdk.NewInt(1)),
+		ChainName:       bsctypes.ModuleName,
+	}
+	require.Error(t, bondedRelayer.ValidateBasic())
+
+	relayerSetConfirm := &gravitytypes.MsgRelayerSetConfirm{
+		Nonce:           1,
+		RelayerAddress:  relayerAddress,
+		ExternalAddress: zeroAddress,
+		Signature:       hex.EncodeToString([]byte{1}),
+		ChainName:       bsctypes.ModuleName,
+	}
+	require.Error(t, relayerSetConfirm.ValidateBasic())
+
+	bridgeValidator := &gravitytypes.BridgeValidator{
+		Power:           gravitytypes.PowerBase,
+		ExternalAddress: zeroAddress,
+	}
+	require.Error(t, bridgeValidator.ValidateBasic())
+}


### PR DESCRIPTION
## Summary

Fixes #454 by rejecting the Ethereum zero address anywhere it can become a Gravity external signer address.

## Changes

- Reject `0x0000000000000000000000000000000000000000` in `utils.ValidateEthereumAddress` after format/checksum validation.
- Add the same external-address validation in the `MsgServer` paths for `BondedRelayer` and `RelayerSetConfirm`, so direct keeper-level calls cannot persist or confirm a zero signer even when bypassing tx `ValidateBasic`.
- Add regressions for:
  - Ethereum address validation rejecting zero address
  - `MsgBondedRelayer`, `MsgRelayerSetConfirm`, and `BridgeValidator` rejecting zero external addresses
  - keeper-level `BondedRelayer` rejection without persisting/indexing the zero address

## Verification

- `git diff --check`
- `go1.24.7 test ./utils ./x/gravity/types`

I also attempted the targeted keeper regression on Windows with Go 1.24.7 + CGO/WinLibs. The package reached the link stage, but the Windows environment cannot link `wasmvm` (`cannot find -lwasmvm`). The keeper regression is included for the Linux/Docker CI environment used in the issue reproduction.