### PR TITLE
fix: reject whitespace rollapp ids

### DIFF
--- a/x/rollapp/keeper/msg_server_create_rollapp_test.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp_test.go
@@ -329,16 +329,19 @@ func (suite *RollappTestSuite) TestOverwriteEIP155Key() {
 		name         string
 		rollappId    string
 		badRollappId string
+		expectedErr  error
 	}{
 		{
 			name:         "extra whitespace id",
 			rollappId:    "rollapp_1234-1",
 			badRollappId: "rollapp_1234-1  ",
+			expectedErr:  types.ErrInvalidRollappID,
 		},
 		{
 			name:         "same EIP ID",
 			rollappId:    "rollapp_1234-1",
 			badRollappId: "dummy_1234-1",
+			expectedErr:  types.ErrRollappExists,
 		},
 	}
 	for _, test := range tests {
@@ -373,7 +376,50 @@ func (suite *RollappTestSuite) TestOverwriteEIP155Key() {
 			}
 			_, err = suite.msgServer.CreateRollapp(goCtx, &badrollapp)
 			// it should not be possible to register rollapp name with extra space
-			suite.Require().ErrorIs(err, types.ErrRollappExists)
+			suite.Require().ErrorIs(err, test.expectedErr)
 		})
 	}
+}
+
+func (suite *RollappTestSuite) TestWhitespaceRollappIDRejectedBeforeStorage() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	_, err := suite.msgServer.CreateRollapp(goCtx, &types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             " dup ",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{},
+	})
+	suite.Require().ErrorIs(err, types.ErrInvalidRollappID)
+
+	_, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, " dup ")
+	suite.Require().False(found, "raw whitespace rollapp id must not be stored")
+
+	_, found = suite.App.RollappKeeper.GetRollapp(suite.Ctx, "dup")
+	suite.Require().False(found, "canonical rollapp id must not be implicitly created")
+}
+
+func (suite *RollappTestSuite) TestWhitespaceRollappIDCannotSquatEIP155Index() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	_, err := suite.msgServer.CreateRollapp(goCtx, &types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             " evil_1-1 ",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{},
+	})
+	suite.Require().ErrorIs(err, types.ErrInvalidRollappID)
+
+	_, found := suite.App.RollappKeeper.GetRollappByEIP155(suite.Ctx, 1)
+	suite.Require().False(found, "rejected whitespace rollapp id must not reserve the EIP155 index")
+
+	_, err = suite.msgServer.CreateRollapp(goCtx, &types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             "good_1-1",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{},
+	})
+	suite.Require().NoError(err)
 }

--- a/x/rollapp/types/chain_id.go
+++ b/x/rollapp/types/chain_id.go
@@ -34,6 +34,10 @@ type ChainID struct {
 func NewChainID(id string) (ChainID, error) {
 	chainID := strings.TrimSpace(id)
 
+	if id != chainID {
+		return ChainID{}, errorsmod.Wrapf(ErrInvalidRollappID, "leading or trailing whitespace")
+	}
+
 	if chainID == "" {
 		return ChainID{}, errorsmod.Wrapf(ErrInvalidRollappID, "empty")
 	}

--- a/x/rollapp/types/message_create_rollapp_test.go
+++ b/x/rollapp/types/message_create_rollapp_test.go
@@ -42,6 +42,24 @@ func TestMsgCreateRollapp_ValidateBasic(t *testing.T) {
 			err: ErrInvalidRollappID,
 		},
 		{
+			name: "invalid rollappID with leading whitespace",
+			msg: MsgCreateRollapp{
+				Creator:       sample.AccAddress(),
+				MaxSequencers: 1,
+				RollappId:     " dym_100-1",
+			},
+			err: ErrInvalidRollappID,
+		},
+		{
+			name: "invalid rollappID with trailing whitespace",
+			msg: MsgCreateRollapp{
+				Creator:       sample.AccAddress(),
+				MaxSequencers: 1,
+				RollappId:     "dym_100-1 ",
+			},
+			err: ErrInvalidRollappID,
+		},
+		{
 			name: "invalid address",
 			msg: MsgCreateRollapp{
 				Creator:       "invalid_address",


### PR DESCRIPTION
## Summary

Fixes #451 by rejecting RollApp IDs with leading or trailing whitespace before they can be validated against a trimmed/canonical chain ID but stored under the raw key.

## Changes

- Make `types.NewChainID` reject any ID where `id != strings.TrimSpace(id)`.
- Add `MsgCreateRollapp.ValidateBasic` coverage for leading and trailing whitespace IDs.
- Update the existing EIP155 overwrite regression so whitespace IDs now fail as invalid IDs rather than reaching duplicate-index handling.
- Add keeper-level regressions proving rejected whitespace IDs are not stored and cannot squat EIP155 index `1` before a valid `good_1-1` RollApp is created.

## Verification

- `git diff --check`
- `go1.24.7 test ./x/rollapp/types`

I also attempted the targeted keeper regressions on Windows with Go 1.24.7 + CGO/WinLibs. The package reached the link stage, but this Windows environment cannot link `wasmvm` (`cannot find -lwasmvm`). The keeper regressions are included for the Linux/Docker CI environment used in the issue reproduction.