### PR TITLE
fix: prevent megroup admin self-join rewards

### DIFF
--- a/x/megroup/keeper/msg_server_join_group.go
+++ b/x/megroup/keeper/msg_server_join_group.go
@@ -36,6 +36,9 @@ func (k msgServer) JoinGroup(goCtx context.Context, msg *types.MsgJoinGroup) (*t
 	if !found {
 		return nil, errors.Wrapf(types.ErrGroupNotExist, "msg's groupID = %d", msg.GroupId)
 	}
+	if msg.ApplicantAddress == groupInfo.Admin {
+		return nil, errors.Wrap(types.ErrPermissionDenied, "group admin does not need to join own group")
+	}
 
 	_, isKycActive := k.GetDidAndKycActive(ctx, userAccAddr, groupInfo.RegionID)
 	if !isKycActive {

--- a/x/megroup/keeper/msg_server_join_group_test.go
+++ b/x/megroup/keeper/msg_server_join_group_test.go
@@ -1,0 +1,68 @@
+package keeper
+
+import (
+	"testing"
+	"time"
+
+	dbm "github.com/cometbft/cometbft-db"
+	"github.com/cometbft/cometbft/libs/log"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/openmetaearth/me-hub/x/megroup/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoinGroupRejectsGroupAdminSelfJoin(t *testing.T) {
+	ctx, keeper := setupJoinGroupTestKeeper(t)
+	admin := sample.AccAddress()
+	groupID := uint64(7)
+
+	require.NoError(t, keeper.AppendGroup(ctx, &types.GroupInfo{
+		Id:       groupID,
+		Admin:    admin,
+		RegionID: "usa",
+	}))
+	keeper.SetGroupMemberCount(ctx, groupID, 0)
+
+	server := NewMsgServerImpl(keeper)
+	_, err := server.JoinGroup(sdk.WrapSDKContext(ctx), &types.MsgJoinGroup{
+		Creator:          admin,
+		GroupId:          groupID,
+		ApplicantAddress: admin,
+	})
+
+	require.ErrorIs(t, err, types.ErrPermissionDenied)
+	require.Contains(t, err.Error(), "group admin does not need to join own group")
+
+	_, found := keeper.GetMemberJoined(ctx, admin)
+	require.False(t, found)
+	memberCount, found := keeper.GetGroupMemberCount(ctx, groupID)
+	require.True(t, found)
+	require.Equal(t, uint64(0), memberCount)
+}
+
+func setupJoinGroupTestKeeper(t *testing.T) (sdk.Context, Keeper) {
+	t.Helper()
+	params.SetAddressPrefixes()
+
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	db := dbm.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+	ctx := sdk.NewContext(stateStore, tmproto.Header{Time: time.Now()}, false, log.NewNopLogger())
+
+	return ctx, Keeper{
+		cdc:      cdc,
+		storeKey: storeKey,
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #458 by rejecting MsgJoinGroup when the applicant is already the group admin.

The region-group creation flow treats the admin as a special role that does not need to join the group. Without an explicit check, a region group admin can self-join as a normal applicant and enter the join reward path where both the applicant reward and admin reward are paid to the same address.

This change rejects ApplicantAddress == groupInfo.Admin immediately after loading the group and before KYC checks, membership writes, member-count increments, or reward transfers.

## Tests

- go test ./x/megroup/keeper -run TestJoinGroupRejectsGroupAdminSelfJoin -count=1 -v
- go test ./x/megroup/types -run TestMsgJoinGroup_ValidateBasic -count=1
- git diff --check

Note: go test ./x/megroup/types -count=1 currently fails on an existing unrelated MsgCreateGroup_ValidateBasic nil-pointer panic in messages_group_test.go; the targeted MsgJoinGroup validation test passes.