### PR TITLE
fix: allow higher KYC levels to join MEGroup

### DIFF
--- a/x/megroup/keeper/keeper.go
+++ b/x/megroup/keeper/keeper.go
@@ -257,7 +257,7 @@ func (k Keeper) GetDidAndKycActive(sdkCtx sdk.Context, address sdk.AccAddress, r
 	if didInfo.RegionId != regionID {
 		return "", false
 	}
-	if didInfo.KycLevel != didTypes.KYC_LEVEL_TWO {
+	if didInfo.KycLevel < didTypes.KYC_LEVEL_TWO {
 		return "", false
 	}
 	if didInfo.Status == didTypes.DID_STATUS_ACTIVE {

--- a/x/megroup/keeper/kyc_active_test.go
+++ b/x/megroup/keeper/kyc_active_test.go
@@ -1,0 +1,146 @@
+package keeper
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	"github.com/openmetaearth/me-hub/x/kyc/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDidAndKycActiveAcceptsMinimumLevelTwo(t *testing.T) {
+	params.SetAddressPrefixes()
+	address := sample.Acc()
+	const did = "did:me:test"
+	const requiredRegion = "usa"
+
+	tests := []struct {
+		name      string
+		foundDID  bool
+		foundInfo bool
+		region    string
+		level     didtypes.KycLevel
+		status    didtypes.DidStatus
+		want      bool
+	}{
+		{
+			name:      "level none rejected",
+			foundDID:  true,
+			foundInfo: true,
+			region:    requiredRegion,
+			level:     didtypes.KYC_LEVEL_NONE,
+			status:    didtypes.DID_STATUS_ACTIVE,
+		},
+		{
+			name:      "level one rejected",
+			foundDID:  true,
+			foundInfo: true,
+			region:    requiredRegion,
+			level:     didtypes.KYC_LEVEL_ONE,
+			status:    didtypes.DID_STATUS_ACTIVE,
+		},
+		{
+			name:      "level two accepted",
+			foundDID:  true,
+			foundInfo: true,
+			region:    requiredRegion,
+			level:     didtypes.KYC_LEVEL_TWO,
+			status:    didtypes.DID_STATUS_ACTIVE,
+			want:      true,
+		},
+		{
+			name:      "level three accepted",
+			foundDID:  true,
+			foundInfo: true,
+			region:    requiredRegion,
+			level:     didtypes.KYC_LEVEL_THREE,
+			status:    didtypes.DID_STATUS_ACTIVE,
+			want:      true,
+		},
+		{
+			name:      "level five accepted",
+			foundDID:  true,
+			foundInfo: true,
+			region:    requiredRegion,
+			level:     didtypes.KYC_LEVEL_FIVE,
+			status:    didtypes.DID_STATUS_ACTIVE,
+			want:      true,
+		},
+		{
+			name:      "wrong region rejected",
+			foundDID:  true,
+			foundInfo: true,
+			region:    "eu",
+			level:     didtypes.KYC_LEVEL_FIVE,
+			status:    didtypes.DID_STATUS_ACTIVE,
+		},
+		{
+			name:      "inactive did rejected",
+			foundDID:  true,
+			foundInfo: true,
+			region:    requiredRegion,
+			level:     didtypes.KYC_LEVEL_FIVE,
+			status:    didtypes.DID_STATUS_INACTIVE,
+		},
+		{
+			name:      "missing did rejected",
+			foundInfo: true,
+			region:    requiredRegion,
+			level:     didtypes.KYC_LEVEL_FIVE,
+			status:    didtypes.DID_STATUS_ACTIVE,
+		},
+		{
+			name:     "missing did info rejected",
+			foundDID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kycKeeper := mockKycKeeper{
+				didByAddress: map[string]string{},
+				infoByDID:    map[string]didtypes.DidInfo{},
+			}
+			if tt.foundDID {
+				kycKeeper.didByAddress[address.String()] = did
+			}
+			if tt.foundInfo {
+				kycKeeper.infoByDID[did] = didtypes.DidInfo{
+					Did:      did,
+					Address:  address.String(),
+					RegionId: tt.region,
+					KycLevel: tt.level,
+					Status:   tt.status,
+				}
+			}
+
+			keeper := Keeper{kycKeeper: kycKeeper}
+			gotDID, ok := keeper.GetDidAndKycActive(sdk.Context{}, address, requiredRegion)
+
+			require.Equal(t, tt.want, ok)
+			if tt.want {
+				require.Equal(t, did, gotDID)
+			}
+		})
+	}
+}
+
+type mockKycKeeper struct {
+	didByAddress map[string]string
+	infoByDID    map[string]didtypes.DidInfo
+}
+
+func (m mockKycKeeper) RegisterEventHandler(string, int, string, handler.HandlerFunc) {}
+
+func (m mockKycKeeper) GetDID(_ sdk.Context, addr sdk.AccAddress) (string, bool) {
+	did, found := m.didByAddress[addr.String()]
+	return did, found
+}
+
+func (m mockKycKeeper) GetDidInfo(_ sdk.Context, did string) (didtypes.DidInfo, bool) {
+	info, found := m.infoByDID[did]
+	return info, found
+}


### PR DESCRIPTION
## Summary

Fixes #284 by treating MEGroup KYC membership as a minimum level-2 requirement instead of requiring exactly KYC level 2.

KYC levels 3, 4, and 5 represent stronger verification than level 2, and the KYC reward flow already uses level >= 2 semantics. The MEGroup helper now matches that module-level meaning while still rejecting level none/one, wrong-region credentials, missing DID state, and inactive DID state.

## Tests

- go test ./x/megroup/keeper -run TestGetDidAndKycActiveAcceptsMinimumLevelTwo -count=1 -v
- git diff --check