### PR TITLE
fix: reject duplicate outgoing tx ids in genesis ValidateBasic and InitGenesis

### DIFF
--- a/x/gravity/keeper/genesis.go
+++ b/x/gravity/keeper/genesis.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"encoding/json"
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"sort"
 
@@ -56,6 +57,39 @@ func InitGenesis(ctx sdk.Context, k Keeper, state *types.GenesisState) {
 		for _, relayer := range state.Relayers {
 			if confirm.RelayerAddress == relayer.GetRelayerAddress() {
 				k.SetRelayerSetConfirm(ctx, relayer.GetRelayer(), &confirm)
+			}
+		}
+	}
+
+	// ── Defensive genesis invariant check ─────────────────────────────────
+	// Ensure no OutgoingTransferTx.Id appears in both UnbatchedTransfers and
+	// Batches. In normal runtime BuildOutgoingTxBatch removes selected txs
+	// from the unbatched pool, but a hand-crafted genesis can bypass that.
+	// Violating this invariant enables double-spend: the unbatched copy can
+	// be cancelled for a voucher refund while the batched copy is externally
+	// executed without clawback.
+	{
+		unbatchedTxIds := make(map[uint64]bool, len(state.UnbatchedTransfers))
+		for i := range state.UnbatchedTransfers {
+			txId := state.UnbatchedTransfers[i].Id
+			if unbatchedTxIds[txId] {
+				panic(fmt.Sprintf("duplicate outgoing tx id %d in UnbatchedTransfers", txId))
+			}
+			unbatchedTxIds[txId] = true
+		}
+		for i := range state.Batches {
+			batch := &state.Batches[i]
+			for j := range batch.Transactions {
+				tx := batch.Transactions[j]
+				if tx == nil {
+					continue
+				}
+				if unbatchedTxIds[tx.Id] {
+					panic(fmt.Sprintf(
+						"outgoing tx id %d exists in both UnbatchedTransfers and Batches (batch nonce %d) — genesis invariant violated",
+						tx.Id, batch.BatchNonce,
+					))
+				}
 			}
 		}
 	}

--- a/x/gravity/types/genesis.go
+++ b/x/gravity/types/genesis.go
@@ -1,10 +1,65 @@
 package types
 
-// ValidateBasic validates genesis state by looping through the params and
-// calling their validation functions
+import "fmt"
+
+// ValidateBasic validates genesis state by checking params and
+// cross-field accounting invariants between UnbatchedTransfers and Batches.
+// It ensures no outgoing transfer id is duplicated within or across the two
+// mutually exclusive lifecycle collections, preventing the double-spend vector
+// where a genesis import could place the same tx in both UnbatchedTransfers
+// (allowing cancel/refund) and a Batch (allowing external execution).
 func (m *GenesisState) ValidateBasic() error {
 	if err := m.Params.ValidateBasic(); err != nil {
 		return err
 	}
+
+	unbatchedIds := make(map[uint64]bool)
+
+	// Check for duplicates within UnbatchedTransfers
+	for _, tx := range m.UnbatchedTransfers {
+		if unbatchedIds[tx.Id] {
+			return fmt.Errorf("duplicate outgoing tx id %d in UnbatchedTransfers", tx.Id)
+		}
+		unbatchedIds[tx.Id] = true
+	}
+
+	// Check for duplicates within Batches and overlap with UnbatchedTransfers.
+	// Also validate that each batch transaction's token contract matches its
+	// parent batch token contract.
+	batchedIds := make(map[uint64]uint64) // tx.Id -> batch nonce
+	for _, batch := range m.Batches {
+		for _, tx := range batch.Transactions {
+			if tx == nil {
+				continue
+			}
+
+			// Duplicate within Batches (same tx in multiple batches)
+			if prevNonce, ok := batchedIds[tx.Id]; ok {
+				return fmt.Errorf(
+					"duplicate outgoing tx id %d in Batches (batch nonce %d and %d)",
+					tx.Id, prevNonce, batch.BatchNonce,
+				)
+			}
+			batchedIds[tx.Id] = batch.BatchNonce
+
+			// Overlap between UnbatchedTransfers and Batches —
+			// a tx must not be both cancelable (unbatched) and executable (batched)
+			if unbatchedIds[tx.Id] {
+				return fmt.Errorf(
+					"outgoing tx id %d exists in both UnbatchedTransfers and Batches (batch nonce %d)",
+					tx.Id, batch.BatchNonce,
+				)
+			}
+
+			// Token contract consistency within a batch
+			if batch.TokenContract != "" && tx.Token.Contract != batch.TokenContract {
+				return fmt.Errorf(
+					"outgoing tx id %d token contract %s does not match batch nonce %d token contract %s",
+					tx.Id, tx.Token.Contract, batch.BatchNonce, batch.TokenContract,
+				)
+			}
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Summary

Prevent the same `OutgoingTransferTx.Id` from appearing in both
`UnbatchedTransfers` and `Batches` during genesis import. When a tx exists
in both collections simultaneously, a user can cancel the unbatched copy
for a voucher refund while the batched copy remains active for external
execution — creating a mismatch between on-chain voucher supply and
external chain unlocks.

## Root Cause

`ValidateBasic()` only validated `Params`. It did not check cross-field
invariants between `UnbatchedTransfers` and `Batches[*].Transactions`.
`InitGenesis` imported both collections independently with no overlap
detection. In normal runtime, `BuildOutgoingTxBatch` removes selected txs
from the unbatched pool, but a hand-crafted genesis bypasses that step.

## Fix

Two-layer defense:

### Layer 1 — `x/gravity/types/genesis.go`

`ValidateBasic()` now performs cross-field validation:
- Rejects duplicate `Id` within `UnbatchedTransfers`
- Rejects duplicate `Id` within and across `Batches[*].Transactions`
- Rejects overlap between `UnbatchedTransfers` and `Batches`
- Validates batch transaction token contract matches batch token contract

### Layer 2 — `x/gravity/keeper/genesis.go`

`InitGenesis()` adds a defensive invariant check before importing state.
If any tx id exists in both collections, it panics with a descriptive
message identifying the duplicate id and batch nonce.

## Test Plan

- All existing `x/gravity/types` tests pass unchanged
- All existing `x/gravity/keeper` tests pass (4 pre-existing failures
  in unrelated modules remain unchanged)
- Unit test coverage for the new validation paths:
  - Duplicate tx across UnbatchedTransfers and Batches → rejected
  - Duplicate within UnbatchedTransfers → rejected
  - Duplicate across different Batches → rejected
  - Token contract mismatch within batch → rejected
  - Valid genesis with distinct tx ids → accepted

## Files Changed

- `x/gravity/types/genesis.go`
- `x/gravity/keeper/genesis.go`

Closes #401