### PR TITLE
fix(wstaking): resolve staker unbonding timelock bypass (fixes #48)

### DIFF
--- a/x/wstaking/keeper/stake.go
+++ b/x/wstaking/keeper/stake.go
@@ -179,7 +179,7 @@ func (k Keeper) Unstake(
 		k.BondedStakeTokensToNotBonded(ctx, returnAmount, validator.Description.RegionID)
 	}
 
-	completionTime := ctx.BlockHeader().Time.Add(time.Second)
+	completionTime := ctx.BlockHeader().Time.Add(k.UnbondingTime(ctx))
 	ubs := k.SetUnbondingStakeEntry(ctx, stakerAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
 	k.InsertUBSQueue(ctx, ubs, completionTime)
 	return completionTime, nil


### PR DESCRIPTION
This PR fixes a critical security vulnerability where the unbonding period for unstaking validators was hardcoded to 1 second instead of using the governance staking parameter. It replaces the hardcoded time.Second with k.UnbondingTime(ctx).