### PR TITLE
fix(wstaking): resolve RegionShare accounting overwrite and premature region unbonding (fixes #51, #52)

### DIFF
--- a/x/wstaking/keeper/region.go
+++ b/x/wstaking/keeper/region.go
@@ -84,6 +84,19 @@ func (k Keeper) BondRegion(ctx sdk.Context, validator stakingtypes.Validator, to
 		k.groupKeeper.UpdateGroupAdmin(ctx, validator.Description.RegionID, validator.OwnerAddress)
 	}
 	region.RegionShare = tokens
+	valAddr, err := sdk.ValAddressFromBech32(validator.OperatorAddress)
+	if err == nil {
+		stakes, err := k.GetStakesByValidator(ctx, valAddr)
+		if err == nil {
+			totalShares := sdk.ZeroInt()
+			for _, stake := range stakes {
+				totalShares = totalShares.Add(stake.Shares.TruncateInt())
+			}
+			if len(stakes) > 0 {
+				region.RegionShare = totalShares
+			}
+		}
+	}
 	k.SetRegion(ctx, region)
 }
 

--- a/x/wstaking/keeper/stake.go
+++ b/x/wstaking/keeper/stake.go
@@ -229,7 +229,12 @@ func (k Keeper) UnStakeBond(
 		if err != nil {
 			return amount, err
 		}
-		k.UnBondRegion(ctx, validator.Description.RegionID)
+		stakes, err := k.GetStakesByValidator(ctx, valAddr)
+		if err == nil && len(stakes) == 0 {
+			k.UnBondRegion(ctx, validator.Description.RegionID)
+		} else {
+			k.BondRegion(ctx, validator, sdk.ZeroInt(), false)
+		}
 	} else {
 		k.BondRegion(ctx, validator, stake.Shares.TruncateInt(), false)
 		k.SetStake(ctx, stake)


### PR DESCRIPTION
This PR fixes two related high-severity accounting bugs in the wstaking module: 1. RegionShare Accounting Overwrite (#51): The BondRegion function previously assigned a single staker's shares directly to region.RegionShare, overwriting any existing region share. This PR updates BondRegion to recalculate RegionShare by summing all stakes in the store for the validator. 2. Premature Region Unbonding (#52): The Unstake function previously unbound the entire region (UnBondRegion) when a single staker fully exited (stake.Shares.IsZero()), even if other stakers were still active. This PR updates the unstaking check to only unbind the region if no active stakes remain for the validator, otherwise it simply updates the RegionShare.