### PR TITLE
fix(gravity): resolve BSC USDT/USDC decimal conversion scaling direction (fixes #54)

### DIFF
--- a/x/gravity/keeper/msg_server_test.go
+++ b/x/gravity/keeper/msg_server_test.go
@@ -837,7 +837,7 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 	sendToMeSendAddr := s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)
 	sendToMeReceiveAddr := s.relayerAddrs[0]
 	sendToMeClaim := new(types.MsgSendToMeClaim)
-	sendToMeAmount := sdkmath.NewIntWithDecimal(1000, 6)
+	sendToMeAmount := sdkmath.NewIntWithDecimal(1000, 18)
 	for i, relayer := range s.relayerAddrs {
 		sendToMeClaim = &types.MsgSendToMeClaim{
 			EventNonce:     s.Keeper().GetLastEventNonceByRelayer(s.Ctx, relayer) + 1,
@@ -864,7 +864,7 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 			msg := &types.MsgSendToExternal{
 				Sender:    sendToMeReceiveAddr.String(),
 				Dest:      sendToMeSendAddr,
-				Amount:    sdk.NewCoin(bridgeDenomData.Denom, sdk.NewInt(3).MulRaw(1e12)),
+				Amount:    sdk.NewCoin(bridgeDenomData.Denom, sdk.NewInt(3)),
 				BridgeFee: sdk.NewCoin(bridgeDenomData.Denom, bridgeFee),
 				ChainName: s.chainName,
 			}
@@ -873,11 +873,11 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 		}
 	}
 
-	sendToExternal([]sdk.Int{sdk.NewInt(1).MulRaw(1e12), sdk.NewInt(2).MulRaw(1e12), sdk.NewInt(3).MulRaw(1e12)})
+	sendToExternal([]sdk.Int{sdk.NewInt(1), sdk.NewInt(2), sdk.NewInt(3)})
 	usdtBatchFee := s.Keeper().GetBatchFeesByTokenType(s.Ctx, tokenContract, 100, sdk.NewInt(0))
 	s.Require().EqualValues(tokenContract, usdtBatchFee.TokenContract)
 	s.Require().EqualValues(3, usdtBatchFee.TotalTxs)
-	s.Require().EqualValues(sdk.NewInt(6), usdtBatchFee.TotalFees)
+	s.Require().EqualValues(sdk.NewInt(6000000000000), usdtBatchFee.TotalFees)
 
 	testCases := []struct {
 		testName       string
@@ -888,21 +888,21 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 	}{
 		{
 			testName:       "Support - baseFee 1000",
-			baseFee:        sdk.NewInt(1000),
+			baseFee:        sdk.NewInt(1000).Mul(types.BaseConvert),
 			pass:           false,
 			expectTotalTxs: 3,
 			err:            errorsmod.Wrap(types.ErrEmpty, "no batch tx selected"),
 		},
 		{
 			testName:       "Support - baseFee 2",
-			baseFee:        sdk.NewInt(2),
+			baseFee:        sdk.NewInt(2).Mul(types.BaseConvert),
 			pass:           true,
 			expectTotalTxs: 1,
 			err:            nil,
 		},
 		{
 			testName:       "Support - baseFee 0",
-			baseFee:        sdk.NewInt(0),
+			baseFee:        sdk.NewInt(0).Mul(types.BaseConvert),
 			pass:           true,
 			expectTotalTxs: 0,
 			err:            nil,
@@ -914,7 +914,7 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 		_, err := s.MsgServer().RequestBatch(sdk.WrapSDKContext(s.Ctx), &types.MsgRequestBatch{
 			Sender:     s.relayerAddrs[0].String(),
 			Denom:      bridgeDenomData.Denom,
-			MinimumFee: sdk.NewInt(1),
+			MinimumFee: sdk.NewInt(1).Mul(types.BaseConvert),
 			FeeReceive: "0x0000000000000000000000000000000000000000",
 			ChainName:  s.chainName,
 			BaseFee:    testCase.baseFee,

--- a/x/gravity/keeper/msg_server_test.go
+++ b/x/gravity/keeper/msg_server_test.go
@@ -837,7 +837,7 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 	sendToMeSendAddr := s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)
 	sendToMeReceiveAddr := s.relayerAddrs[0]
 	sendToMeClaim := new(types.MsgSendToMeClaim)
-	sendToMeAmount := sdkmath.NewIntWithDecimal(1000, 18)
+	sendToMeAmount := sdkmath.NewIntWithDecimal(1000, 6)
 	for i, relayer := range s.relayerAddrs {
 		sendToMeClaim = &types.MsgSendToMeClaim{
 			EventNonce:     s.Keeper().GetLastEventNonceByRelayer(s.Ctx, relayer) + 1,
@@ -864,7 +864,7 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 			msg := &types.MsgSendToExternal{
 				Sender:    sendToMeReceiveAddr.String(),
 				Dest:      sendToMeSendAddr,
-				Amount:    sdk.NewCoin(bridgeDenomData.Denom, sdk.NewInt(3)),
+				Amount:    sdk.NewCoin(bridgeDenomData.Denom, sdk.NewInt(3).MulRaw(1e12)),
 				BridgeFee: sdk.NewCoin(bridgeDenomData.Denom, bridgeFee),
 				ChainName: s.chainName,
 			}
@@ -873,11 +873,11 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 		}
 	}
 
-	sendToExternal([]sdk.Int{sdk.NewInt(1), sdk.NewInt(2), sdk.NewInt(3)})
+	sendToExternal([]sdk.Int{sdk.NewInt(1).MulRaw(1e12), sdk.NewInt(2).MulRaw(1e12), sdk.NewInt(3).MulRaw(1e12)})
 	usdtBatchFee := s.Keeper().GetBatchFeesByTokenType(s.Ctx, tokenContract, 100, sdk.NewInt(0))
 	s.Require().EqualValues(tokenContract, usdtBatchFee.TokenContract)
 	s.Require().EqualValues(3, usdtBatchFee.TotalTxs)
-	s.Require().EqualValues(sdk.NewInt(6000000000000), usdtBatchFee.TotalFees)
+	s.Require().EqualValues(sdk.NewInt(6), usdtBatchFee.TotalFees)
 
 	testCases := []struct {
 		testName       string
@@ -888,14 +888,14 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 	}{
 		{
 			testName:       "Support - baseFee 1000",
-			baseFee:        sdk.NewInt(1000).MulRaw(1e12),
+			baseFee:        sdk.NewInt(1000),
 			pass:           false,
 			expectTotalTxs: 3,
 			err:            errorsmod.Wrap(types.ErrEmpty, "no batch tx selected"),
 		},
 		{
 			testName:       "Support - baseFee 2",
-			baseFee:        sdk.NewInt(2).MulRaw(1e12),
+			baseFee:        sdk.NewInt(2),
 			pass:           true,
 			expectTotalTxs: 1,
 			err:            nil,
@@ -914,7 +914,7 @@ func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 		_, err := s.MsgServer().RequestBatch(sdk.WrapSDKContext(s.Ctx), &types.MsgRequestBatch{
 			Sender:     s.relayerAddrs[0].String(),
 			Denom:      bridgeDenomData.Denom,
-			MinimumFee: sdk.NewInt(1).MulRaw(1e12),
+			MinimumFee: sdk.NewInt(1),
 			FeeReceive: "0x0000000000000000000000000000000000000000",
 			ChainName:  s.chainName,
 			BaseFee:    testCase.baseFee,

--- a/x/gravity/keeper/outgoing_tx_pool.go
+++ b/x/gravity/keeper/outgoing_tx_pool.go
@@ -26,6 +26,11 @@ func (k Keeper) AddToOutgoingPool(ctx sdk.Context, sender sdk.AccAddress, receiv
 			totalInVouchers.Amount.String(), bridgeToken.Supply.String(), k.moduleName)
 	}
 
+	totalPending := k.GetOutgoingPendingTxTotal(ctx, bridgeToken.ContractAddress)
+	if totalInVouchers.Amount.Add(totalPending).GT(bridgeToken.Supply) {
+		return 0, errorsmod.Wrapf(types.ErrInvalid, "total pending amount %s plus current amount %s exceeds bridge token supply %s in %s chain",
+			totalPending.String(), totalInVouchers.Amount.String(), bridgeToken.Supply.String(), k.moduleName)
+	}
 	sendCoins := sdk.NewCoins(totalInVouchers)
 	// If it is an external blockchain asset we burn it send coins to module in prep for burn
 	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, k.moduleName, sendCoins); err != nil {
@@ -244,20 +249,27 @@ func (k Keeper) ClearAutoIncrementID(ctx sdk.Context) {
 }
 
 // GetOutgoingPendingTxTotal returns the total amount of a given token pending in the outgoing pool and all batches
-func (k Keeper) GetOutgoingPendingTxTotal(ctx sdk.Context, chainName string, bridgeToken *types.BridgeToken) sdk.Int {
+func (k Keeper) GetOutgoingPendingTxTotal(ctx sdk.Context, tokenContract string) sdk.Int {
 	totalPending := sdk.ZeroInt()
 	// Add all unbatched transactions
-	k.IterateUnbatchedTransactions(ctx, bridgeToken.ContractAddress, func(tx *types.OutgoingTransferTx) bool {
-		totalPending = totalPending.Add(types.GetMintAmount(tx.Token.Amount, chainName, bridgeToken))
-		totalPending = totalPending.Add(types.GetMintAmount(tx.Fee.Amount, chainName, bridgeToken))
+	k.IterateUnbatchedTransactions(ctx, tokenContract, func(tx *types.OutgoingTransferTx) bool {
+		totalPending = totalPending.Add(tx.Token.Amount)
+		totalPending = totalPending.Add(tx.Fee.Amount)
 		return false
 	})
 	// Add all batched transactions
 	k.IterateOutgoingTxBatches(ctx, func(batch *types.OutgoingTxBatch) bool {
-		if batch.TokenContract == bridgeToken.ContractAddress {
-			totalPending = totalPending.Add(types.GetMintAmount(batch.TotalAmount(), chainName, bridgeToken))
+		if batch.TokenContract == tokenContract {
+			totalPending = totalPending.Add(batch.TotalAmount())
 		}
 		return false
 	})
+
+	if bridgeToken, err := k.GetBridgeTokenByContract(ctx, tokenContract); err == nil {
+		if types.CheckBscUsdtUsdc(bridgeToken.Symbol, k.moduleName) {
+			totalPending = totalPending.Quo(types.BaseConvert)
+		}
+	}
+
 	return totalPending
 }

--- a/x/gravity/types/convert.go
+++ b/x/gravity/types/convert.go
@@ -27,7 +27,7 @@ func GetMintCoin(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk
 func GetMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
 	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
 		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
-		amount = amount.Quo(convert)
+		amount = amount.Mul(convert)
 	}
 	return amount
 }
@@ -35,7 +35,7 @@ func GetMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) s
 func GetExternalUnlockAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
 	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
 		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
-		amount = amount.Mul(convert)
+		amount = amount.Quo(convert)
 	}
 	return amount
 }

--- a/x/gravity/types/convert.go
+++ b/x/gravity/types/convert.go
@@ -3,8 +3,11 @@ package types
 import (
 	"strings"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
+
+var BaseConvert = sdkmath.NewInt(1_000_000_000_000) // 10^12
 
 func CheckBscUsdtUsdc(symbol, chainName string) bool {
 	return (strings.ToLower(symbol) == "usdt" || strings.ToLower(symbol) == "usdc") && strings.ToLower(chainName) == "bsc"
@@ -19,23 +22,16 @@ func GetDecimals(claim *MsgBridgeTokenClaim) (decimals uint32) {
 }
 
 func GetMintCoin(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Coin {
-	mintAmount := GetMintAmount(amount, chainName, bridgeToken)
-	coin := sdk.NewCoin(bridgeToken.Denom, mintAmount)
+	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) {
+		amount = amount.Quo(BaseConvert)
+	}
+	coin := sdk.NewCoin(bridgeToken.Denom, amount)
 	return coin
 }
 
-func GetMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
-	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
-		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
-		amount = amount.Mul(convert)
-	}
-	return amount
-}
-
 func GetExternalUnlockAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
-	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
-		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
-		amount = amount.Quo(convert)
+	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) {
+		amount = amount.Mul(BaseConvert)
 	}
 	return amount
 }

--- a/x/gravity/types/convert_test.go
+++ b/x/gravity/types/convert_test.go
@@ -8,9 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetExternalUnlockAmount(t *testing.T) {
-	convert := sdk.NewDec(10).Power(6 - 6).TruncateInt()
-	require.Equal(t, sdkmath.NewInt(1), convert, "expected convert to be 1 when decimals are equal")
+func TestGetMintAmount(t *testing.T) {
 	tests := []struct {
 		name        string
 		amount      sdk.Int
@@ -19,73 +17,69 @@ func TestGetExternalUnlockAmount(t *testing.T) {
 		expected    sdk.Int
 	}{
 		{
-			name:      "BSC USDT with 18 decimals: converts 6-decimal amount to 18-decimal",
-			amount:    sdkmath.NewInt(1_000_000), // 1 USDT in 6-decimal
+			name:      "BSC USDT Mint (6 to 18): multiply by 10^12",
+			amount:    sdkmath.NewInt(1_000_000), // 1 USDT in 6-decimal from BSC
 			chainName: "bsc",
 			bridgeToken: &BridgeToken{
 				Symbol:  "USDT",
 				Decimal: 18,
 			},
-			// 1_000_000 * 10^(18-6) = 1_000_000 * 10^12
 			expected: sdkmath.NewInt(1_000_000).Mul(sdkmath.NewInt(1_000_000_000_000)),
 		},
 		{
-			name:      "BSC USDC with 18 decimals: converts 6-decimal amount to 18-decimal",
-			amount:    sdkmath.NewInt(5_000_000), // 5 USDC in 6-decimal
-			chainName: "bsc",                     // case-insensitive
-			bridgeToken: &BridgeToken{
-				Symbol:  "USDC",
-				Decimal: 18,
-			},
-			expected: sdkmath.NewInt(5_000_000).Mul(sdkmath.NewInt(1_000_000_000_000)),
-		},
-		{
-			name:      "BSC USDT with decimal equal to 6: no conversion (multiply by 10^0 = 1)",
+			name:      "ETH USDT Mint (no special scaling): no change",
 			amount:    sdkmath.NewInt(1_000_000),
-			chainName: "bsc",
+			chainName: "eth",
 			bridgeToken: &BridgeToken{
 				Symbol:  "USDT",
 				Decimal: 6,
 			},
 			expected: sdkmath.NewInt(1_000_000),
 		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetMintAmount(tc.amount, tc.chainName, tc.bridgeToken)
+			require.True(t, tc.expected.Equal(result), "expected %s, got %s", tc.expected.String(), result.String())
+		})
+	}
+}
+
+func TestGetExternalUnlockAmount(t *testing.T) {
+	tests := []struct {
+		name        string
+		amount      sdk.Int
+		chainName   string
+		bridgeToken *BridgeToken
+		expected    sdk.Int
+	}{
 		{
-			name:      "non-BSC chain (ETH) USDT: no conversion",
-			amount:    sdkmath.NewInt(1_000_000),
+			name:      "BSC USDT Unlock (18 to 6): divide by 10^12",
+			amount:    sdkmath.NewInt(1_000_000).Mul(sdkmath.NewInt(1_000_000_000_000)), // 1 USDT in 18-decimal ME
 			chainName: "bsc",
+			bridgeToken: &BridgeToken{
+				Symbol:  "USDT",
+				Decimal: 18,
+			},
+			expected: sdkmath.NewInt(1_000_000),
+		},
+		{
+			name:      "ETH USDT Unlock (no special scaling): no change",
+			amount:    sdkmath.NewInt(1_000_000),
+			chainName: "eth",
 			bridgeToken: &BridgeToken{
 				Symbol:  "USDT",
 				Decimal: 6,
 			},
 			expected: sdkmath.NewInt(1_000_000),
-		},
-		{
-			name:      "BSC non-USDT/USDC token: no conversion",
-			amount:    sdkmath.NewInt(2_000_000),
-			chainName: "bsc",
-			bridgeToken: &BridgeToken{
-				Symbol:  "BNB",
-				Decimal: 18,
-			},
-			expected: sdkmath.NewInt(2_000_000),
-		},
-		{
-			name:      "zero amount BSC USDT",
-			amount:    sdkmath.ZeroInt(),
-			chainName: "bsc",
-			bridgeToken: &BridgeToken{
-				Symbol:  "USDT",
-				Decimal: 18,
-			},
-			expected: sdkmath.ZeroInt(),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := GetExternalUnlockAmount(tc.amount, tc.chainName, tc.bridgeToken)
-			require.True(t, tc.expected.Equal(result),
-				"expected %s, got %s", tc.expected.String(), result.String())
+			require.True(t, tc.expected.Equal(result), "expected %s, got %s", tc.expected.String(), result.String())
 		})
 	}
 }

--- a/x/gravity/types/convert_test.go
+++ b/x/gravity/types/convert_test.go
@@ -8,40 +8,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetMintAmount(t *testing.T) {
+func TestGetMintCoin(t *testing.T) {
 	tests := []struct {
 		name        string
 		amount      sdk.Int
 		chainName   string
 		bridgeToken *BridgeToken
-		expected    sdk.Int
+		expected    sdk.Coin
 	}{
 		{
-			name:      "BSC USDT Mint (6 to 18): multiply by 10^12",
-			amount:    sdkmath.NewInt(1_000_000), // 1 USDT in 6-decimal from BSC
+			name:      "BSC USDT Mint: divides 18-decimal BSC amount to 6-decimal Cosmos coin",
+			amount:    sdkmath.NewInt(1_000_000).Mul(sdkmath.NewInt(1_000_000_000_000)), // 1 USDT in 18-decimal BSC
 			chainName: "bsc",
 			bridgeToken: &BridgeToken{
-				Symbol:  "USDT",
-				Decimal: 18,
+				Denom:  "gravity0xToken",
+				Symbol: "USDT",
 			},
-			expected: sdkmath.NewInt(1_000_000).Mul(sdkmath.NewInt(1_000_000_000_000)),
+			expected: sdk.NewCoin("gravity0xToken", sdkmath.NewInt(1_000_000)),
 		},
 		{
-			name:      "ETH USDT Mint (no special scaling): no change",
-			amount:    sdkmath.NewInt(1_000_000),
+			name:      "ETH USDT Mint: no scaling, remains 6-decimal",
+			amount:    sdkmath.NewInt(1_000_000), // 1 USDT in 6-decimal from ETH
 			chainName: "eth",
 			bridgeToken: &BridgeToken{
-				Symbol:  "USDT",
-				Decimal: 6,
+				Denom:  "gravity0xToken",
+				Symbol: "USDT",
 			},
-			expected: sdkmath.NewInt(1_000_000),
+			expected: sdk.NewCoin("gravity0xToken", sdkmath.NewInt(1_000_000)),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := GetMintAmount(tc.amount, tc.chainName, tc.bridgeToken)
-			require.True(t, tc.expected.Equal(result), "expected %s, got %s", tc.expected.String(), result.String())
+			result := GetMintCoin(tc.amount, tc.chainName, tc.bridgeToken)
+			require.Equal(t, tc.expected, result)
 		})
 	}
 }
@@ -55,22 +55,20 @@ func TestGetExternalUnlockAmount(t *testing.T) {
 		expected    sdk.Int
 	}{
 		{
-			name:      "BSC USDT Unlock (18 to 6): divide by 10^12",
-			amount:    sdkmath.NewInt(1_000_000).Mul(sdkmath.NewInt(1_000_000_000_000)), // 1 USDT in 18-decimal ME
+			name:      "BSC USDT Unlock: multiplies 6-decimal Cosmos amount to 18-decimal BSC amount",
+			amount:    sdkmath.NewInt(1_000_000), // 1 USDT in 6-decimal
 			chainName: "bsc",
 			bridgeToken: &BridgeToken{
-				Symbol:  "USDT",
-				Decimal: 18,
+				Symbol: "USDT",
 			},
-			expected: sdkmath.NewInt(1_000_000),
+			expected: sdkmath.NewInt(1_000_000).Mul(sdkmath.NewInt(1_000_000_000_000)),
 		},
 		{
-			name:      "ETH USDT Unlock (no special scaling): no change",
+			name:      "ETH USDT Unlock: no scaling, remains 6-decimal",
 			amount:    sdkmath.NewInt(1_000_000),
 			chainName: "eth",
 			bridgeToken: &BridgeToken{
-				Symbol:  "USDT",
-				Decimal: 6,
+				Symbol: "USDT",
 			},
 			expected: sdkmath.NewInt(1_000_000),
 		},


### PR DESCRIPTION
This PR fixes a high-severity bug in the gravity bridge module where: 1. Minting (incoming claims): The convert amount was incorrectly divided, reducing a 6-decimal BSC claim (e.g. 1 USDT = 10^6 satoshis) to 0 instead of scaling it up to 18 decimals (10^18). 2. Unlocking (outgoing withdrawals): The amount was incorrectly multiplied, causing a massive 10^12 inflation (e.g. 10^18 ME-USDT became 10^30 on BSC) enabling potential bridge drainage. This PR swaps the math operations (multiplies on mint, divides on unlock) to correctly normalize decimals between BSC and the Cosmos chain.