### PR TITLE
fix: reject nil Gravity relayer set queries

### DIFF
--- a/x/gravity/keeper/grpc_query.go
+++ b/x/gravity/keeper/grpc_query.go
@@ -74,6 +74,9 @@ func (k QueryServer) CurrentRelayerSet(c context.Context, _ *types.QueryCurrentR
 }
 
 func (k QueryServer) RelayerSetRequest(c context.Context, req *types.QueryRelayerSetRequestRequest) (*types.QueryRelayerSetRequestResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
 	return &types.QueryRelayerSetRequestResponse{RelayerSet: k.GetRelayerSet(sdk.UnwrapSDKContext(c), req.Nonce)}, nil
 }
 

--- a/x/gravity/keeper/grpc_query_nil_request_test.go
+++ b/x/gravity/keeper/grpc_query_nil_request_test.go
@@ -1,0 +1,18 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openmetaearth/me-hub/x/gravity/keeper"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestRelayerSetRequestRejectsNilRequest(t *testing.T) {
+	_, err := (keeper.QueryServer{}).RelayerSetRequest(context.Background(), nil)
+
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}


### PR DESCRIPTION
## Summary

Fixes #238 by rejecting nil RelayerSetRequest query pointers before accessing req.Nonce.

Without this guard, the public Gravity gRPC query handler dereferences a missing request body and panics instead of returning a structured client error. The new regression invokes the handler with nil and verifies gRPC InvalidArgument.

## Verification

- git diff --check
- go test x/gravity/keeper/grpc_query_nil_request_test.go -run TestRelayerSetRequestRejectsNilRequest -count=1 -v
- go test ./x/gravity/types -count=1