### PR TITLE
fix: normalize fixed deposit region pagination

### DIFF
--- a/x/wstaking/keeper/query_fixed_deposit.go
+++ b/x/wstaking/keeper/query_fixed_deposit.go
@@ -79,6 +79,7 @@ func (k Keeper) FixedDepositByRegion(goCtx context.Context, req *types.QueryFixe
 	if req.QueryType != types.FixedDepositState_AllState && req.QueryType != types.FixedDepositState_NotExpired && req.QueryType != types.FixedDepositState_Expired {
 		return nil, status.Error(codes.InvalidArgument, "invalid query type")
 	}
+	normalizeFixedDepositByRegionPagination(req)
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	fixedDeposits, pageRes, err := k.queryFixedDepositByRegionRecursively(ctx, req, nil)

--- a/x/wstaking/keeper/query_fixed_deposit_pagination.go
+++ b/x/wstaking/keeper/query_fixed_deposit_pagination.go
@@ -1,0 +1,16 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func normalizeFixedDepositByRegionPagination(req *types.QueryFixedDepositByRegionRequest) {
+	if req.Pagination == nil {
+		req.Pagination = &query.PageRequest{}
+	}
+	if req.Pagination.Limit == 0 {
+		req.Pagination.Limit = query.DefaultLimit
+		req.Pagination.CountTotal = true
+	}
+}

--- a/x/wstaking/keeper/query_fixed_deposit_pagination_test.go
+++ b/x/wstaking/keeper/query_fixed_deposit_pagination_test.go
@@ -1,0 +1,49 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeFixedDepositByRegionPagination(t *testing.T) {
+	tests := []struct {
+		name       string
+		pagination *query.PageRequest
+		wantLimit  uint64
+		wantTotal  bool
+	}{
+		{
+			name:      "missing pagination uses sdk default",
+			wantLimit: query.DefaultLimit,
+			wantTotal: true,
+		},
+		{
+			name:       "zero limit uses sdk default",
+			pagination: &query.PageRequest{},
+			wantLimit:  query.DefaultLimit,
+			wantTotal:  true,
+		},
+		{
+			name:       "explicit limit remains unchanged",
+			pagination: &query.PageRequest{Limit: 5},
+			wantLimit:  5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &types.QueryFixedDepositByRegionRequest{
+				Pagination: tt.pagination,
+			}
+
+			normalizeFixedDepositByRegionPagination(req)
+
+			require.NotNil(t, req.Pagination)
+			require.Equal(t, tt.wantLimit, req.Pagination.Limit)
+			require.Equal(t, tt.wantTotal, req.Pagination.CountTotal)
+		})
+	}
+}

--- a/x/wstaking/keeper/query_fixed_deposit_test.go
+++ b/x/wstaking/keeper/query_fixed_deposit_test.go
@@ -158,3 +158,16 @@ func (s *KeeperTestSuite) TestFixedDepositByRegionPagination() {
 	// Check the total number of FixedDeposits
 	require.Equal(s.T(), 30, len(allFixedDeposits))
 }
+
+func (s *KeeperTestSuite) TestFixedDepositByRegionNilPaginationDoesNotPanic() {
+	s.SetupTest()
+
+	req := &types.QueryFixedDepositByRegionRequest{
+		RegionId:  types.MeEarthRegionId,
+		QueryType: types.FixedDepositState_AllState,
+	}
+
+	s.Require().NotPanics(func() {
+		_, _ = s.queryClient.FixedDepositByRegion(s.Ctx, req)
+	})
+}


### PR DESCRIPTION
## Summary
- normalize omitted `FixedDepositByRegion` pagination before entering the recursive query path
- apply `query.DefaultLimit` and `CountTotal = true` for a zero limit, matching Cosmos SDK default pagination semantics
- preserve explicit pagination limits and add focused plus keeper-suite regression coverage

## Root cause
The recursive query helper calls `query.Paginate`, which accepts an omitted pagination request, and then dereferences `req.Pagination.Limit` and `req.Pagination.Key`. When the optional gRPC `pagination` field is omitted, that later dereference can panic.

## Verification
- `go1.24.7 test x/wstaking/keeper/query_fixed_deposit_pagination.go x/wstaking/keeper/query_fixed_deposit_pagination_test.go -run TestNormalizeFixedDepositByRegionPagination -count=1 -v`
- `git diff --check`

The existing keeper integration suite now includes a nil-pagination regression. Running the full package locally on Windows reaches the project-specific linker boundary because `-lwasmvm` is unavailable; Linux CI can execute it.

Fixes #170