### PR TITLE
fix: validate relayer addresses in gravity queries

### DIFF
--- a/x/gravity/keeper/grpc_query.go
+++ b/x/gravity/keeper/grpc_query.go
@@ -81,8 +81,12 @@ func (k QueryServer) RelayerSetConfirm(c context.Context, req *types.QueryRelaye
 	if req.GetNonce() <= 0 {
 		return nil, status.Error(codes.InvalidArgument, "nonce")
 	}
+	relayerAddress, err := parseQueryRelayerAddress(req.GetRelayerAddress())
+	if err != nil {
+		return nil, err
+	}
 	ctx := sdk.UnwrapSDKContext(c)
-	return &types.QueryRelayerSetConfirmResponse{Confirm: k.GetRelayerSetConfirm(ctx, req.Nonce, sdk.MustAccAddressFromBech32(req.RelayerAddress))}, nil
+	return &types.QueryRelayerSetConfirmResponse{Confirm: k.GetRelayerSetConfirm(ctx, req.Nonce, relayerAddress)}, nil
 }
 
 func (k QueryServer) RelayerSetConfirmsByNonce(c context.Context, req *types.QueryRelayerSetConfirmsByNonceRequest) (*types.QueryRelayerSetConfirmsByNonceResponse, error) {
@@ -116,8 +120,12 @@ func (k QueryServer) LastRelayerSetRequests(c context.Context, req *types.QueryL
 }
 
 func (k QueryServer) LastPendingRelayerSetRequestByAddr(c context.Context, req *types.QueryLastPendingRelayerSetRequestByAddrRequest) (*types.QueryLastPendingRelayerSetRequestByAddrResponse, error) {
+	relayerAddress, err := parseQueryRelayerAddress(req.GetRelayerAddress())
+	if err != nil {
+		return nil, err
+	}
 	ctx := sdk.UnwrapSDKContext(c)
-	relayer, ok := k.GetRelayer(ctx, sdk.MustAccAddressFromBech32(req.RelayerAddress))
+	relayer, ok := k.GetRelayer(ctx, relayerAddress)
 	if !ok {
 		return nil, types.ErrNotFoundRelayer
 	}
@@ -139,9 +147,12 @@ func (k QueryServer) LastPendingRelayerSetRequestByAddr(c context.Context, req *
 }
 
 func (k QueryServer) LastPendingBatchRequestByAddr(c context.Context, req *types.QueryLastPendingBatchRequestByAddrRequest) (*types.QueryLastPendingBatchRequestByAddrResponse, error) {
+	relayerAddress, err := parseQueryRelayerAddress(req.GetRelayerAddress())
+	if err != nil {
+		return nil, err
+	}
 	ctx := sdk.UnwrapSDKContext(c)
-	RelayerAddress := sdk.MustAccAddressFromBech32(req.RelayerAddress)
-	relayer, ok := k.GetRelayer(ctx, RelayerAddress)
+	relayer, ok := k.GetRelayer(ctx, relayerAddress)
 	if !ok {
 		return nil, types.ErrNotFoundRelayer
 	}
@@ -151,7 +162,7 @@ func (k QueryServer) LastPendingBatchRequestByAddr(c context.Context, req *types
 		if relayer.StartHeight > int64(batch.Block) {
 			return false
 		}
-		foundConfirm := k.GetBatchConfirm(ctx, batch.TokenContract, batch.BatchNonce, RelayerAddress) != nil
+		foundConfirm := k.GetBatchConfirm(ctx, batch.TokenContract, batch.BatchNonce, relayerAddress) != nil
 		if !foundConfirm {
 			pendingBatchReq = batch
 			return true
@@ -162,14 +173,22 @@ func (k QueryServer) LastPendingBatchRequestByAddr(c context.Context, req *types
 }
 
 func (k QueryServer) LastEventNonceByAddr(c context.Context, req *types.QueryLastEventNonceByAddrRequest) (*types.QueryLastEventNonceByAddrResponse, error) {
+	relayerAddress, err := parseQueryRelayerAddress(req.GetRelayerAddress())
+	if err != nil {
+		return nil, err
+	}
 	ctx := sdk.UnwrapSDKContext(c)
-	lastEventNonce := k.GetLastEventNonceByRelayer(ctx, sdk.MustAccAddressFromBech32(req.RelayerAddress))
+	lastEventNonce := k.GetLastEventNonceByRelayer(ctx, relayerAddress)
 	return &types.QueryLastEventNonceByAddrResponse{EventNonce: lastEventNonce}, nil
 }
 
 func (k QueryServer) LastEventBlockHeightByAddr(c context.Context, req *types.QueryLastEventBlockHeightByAddrRequest) (*types.QueryLastEventBlockHeightByAddrResponse, error) {
+	relayerAddress, err := parseQueryRelayerAddress(req.GetRelayerAddress())
+	if err != nil {
+		return nil, err
+	}
 	ctx := sdk.UnwrapSDKContext(c)
-	lastEventBlockHeight := k.GetLastEventBlockHeightByRelayer(ctx, sdk.MustAccAddressFromBech32(req.RelayerAddress))
+	lastEventBlockHeight := k.GetLastEventBlockHeightByRelayer(ctx, relayerAddress)
 	return &types.QueryLastEventBlockHeightByAddrResponse{BlockHeight: lastEventBlockHeight}, nil
 }
 
@@ -222,13 +241,16 @@ func (k QueryServer) BatchConfirm(c context.Context, req *types.QueryBatchConfir
 	if req.GetNonce() <= 0 {
 		return nil, status.Error(codes.InvalidArgument, "nonce")
 	}
+	relayerAddress, err := parseQueryRelayerAddress(req.GetRelayerAddress())
+	if err != nil {
+		return nil, err
+	}
 	ctx := sdk.UnwrapSDKContext(c)
-	RelayerAddress := sdk.MustAccAddressFromBech32(req.RelayerAddress)
-	_, ok := k.GetRelayer(ctx, RelayerAddress)
+	_, ok := k.GetRelayer(ctx, relayerAddress)
 	if !ok {
 		return nil, types.ErrNotFoundRelayer
 	}
-	confirm := k.GetBatchConfirm(ctx, req.TokenContract, req.Nonce, RelayerAddress)
+	confirm := k.GetBatchConfirm(ctx, req.TokenContract, req.Nonce, relayerAddress)
 	return &types.QueryBatchConfirmResponse{Confirm: confirm}, nil
 }
 

--- a/x/gravity/keeper/grpc_query_relayer_address.go
+++ b/x/gravity/keeper/grpc_query_relayer_address.go
@@ -1,0 +1,15 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func parseQueryRelayerAddress(relayerAddress string) (sdk.AccAddress, error) {
+	address, err := sdk.AccAddressFromBech32(relayerAddress)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "relayer address")
+	}
+	return address, nil
+}

--- a/x/gravity/keeper/grpc_query_relayer_address_test.go
+++ b/x/gravity/keeper/grpc_query_relayer_address_test.go
@@ -1,0 +1,30 @@
+package keeper
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestParseQueryRelayerAddress(t *testing.T) {
+	t.Run("rejects malformed input", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			address, err := parseQueryRelayerAddress("not-a-bech32-address")
+
+			require.Nil(t, address)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	})
+
+	t.Run("accepts valid input", func(t *testing.T) {
+		want := sdk.AccAddress([]byte("01234567890123456789"))
+
+		address, err := parseQueryRelayerAddress(want.String())
+
+		require.NoError(t, err)
+		require.Equal(t, want, address)
+	})
+}

--- a/x/gravity/keeper/grpc_query_test.go
+++ b/x/gravity/keeper/grpc_query_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/openmetaearth/me-hub/testutil/helpers"
 	"github.com/openmetaearth/me-hub/x/gravity/keeper"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *KeeperTestSuite) TestQueryUnbatchedTxs() {
@@ -73,4 +75,15 @@ func (s *KeeperTestSuite) TestQueryUnbatchedTxs() {
 	s.Require().Len(res.Txs, numTxs-pageLimit)
 	s.Require().NotNil(res.Pagination)
 	s.Require().Nil(res.Pagination.NextKey)
+}
+
+func (s *KeeperTestSuite) TestQueriesRejectInvalidRelayerAddressWithoutPanic() {
+	queryServer := keeper.NewQueryServerImpl(s.Keeper())
+
+	s.Require().NotPanics(func() {
+		_, err := queryServer.LastEventNonceByAddr(s.Ctx, &types.QueryLastEventNonceByAddrRequest{
+			RelayerAddress: "not-a-bech32-address",
+		})
+		s.Require().Equal(codes.InvalidArgument, status.Code(err))
+	})
 }


### PR DESCRIPTION
## Summary
- replace panic-prone `sdk.MustAccAddressFromBech32` calls in six public Gravity query handlers
- parse caller-controlled relayer addresses through a shared helper that returns gRPC `InvalidArgument`
- add a focused parser regression and a keeper-suite regression for the public query path

## Affected queries
- `RelayerSetConfirm`
- `LastPendingRelayerSetRequestByAddr`
- `LastPendingBatchRequestByAddr`
- `LastEventNonceByAddr`
- `LastEventBlockHeightByAddr`
- `BatchConfirm`

## Verification
- `go1.24.7 test x/gravity/keeper/grpc_query_relayer_address.go x/gravity/keeper/grpc_query_relayer_address_test.go -run TestParseQueryRelayerAddress -count=1 -v`
- `go1.24.7 test ./x/gravity/types -count=1`
- `git diff --check`

The existing keeper integration suite now includes a malformed-address regression. Running the full package locally on Windows reaches the project-specific linker boundary because `-lwasmvm` is unavailable; Linux CI can execute it.

Fixes #177