### PR TITLE
fix: reject missing megroup create info

### DIFF
--- a/x/megroup/types/messages_group.go
+++ b/x/megroup/types/messages_group.go
@@ -46,6 +46,9 @@ func (msg *MsgCreateGroup) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	if msg.GroupInfo == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "group info cannot be nil")
+	}
 	_, err = sdk.AccAddressFromBech32(msg.GroupInfo.Admin)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid Group Admin address (%s)", err)

--- a/x/megroup/types/messages_group_test.go
+++ b/x/megroup/types/messages_group_test.go
@@ -21,9 +21,19 @@ func TestMsgCreateGroup_ValidateBasic(t *testing.T) {
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		}, {
+			name: "nil group info",
+			msg: MsgCreateGroup{
+				Creator: sample.AccAddress(),
+			},
+			err: sdkerrors.ErrInvalidRequest,
+		}, {
 			name: "valid address",
 			msg: MsgCreateGroup{
 				Creator: sample.AccAddress(),
+				GroupInfo: &GroupInfo{
+					Admin:    sample.AccAddress(),
+					RegionID: "USA",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- reject `MsgCreateGroup` values that omit the optional nested `GroupInfo`
- return `sdkerrors.ErrInvalidRequest` before dereferencing protobuf input
- add a regression for nil group info and make the positive validation fixture complete

## Root cause
`MsgCreateGroup.ValidateBasic` validated the creator and then dereferenced `msg.GroupInfo.Admin` and `msg.GroupInfo.RegionID`. Because protobuf callers can omit `groupInfo`, crafted transaction bytes could trigger a nil-pointer panic during basic validation before the handler is reached.

## Verification
- `go1.24.7 test ./x/megroup/types -count=1`
- `git diff --check`

Fixes #200