### PR TITLE
fix: reject none level KYC approvals

### DIFF
--- a/x/kyc/keeper/msg_server.go
+++ b/x/kyc/keeper/msg_server.go
@@ -30,6 +30,9 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 var _ types.MsgServer = msgServer{}
 
 func (m msgServer) Approve(goCtx context.Context, msg *types.MsgApprove) (*types.MsgApproveResponse, error) {
+	if err := types.ValidateApproveLevel(msg.GetLevel()); err != nil {
+		return &types.MsgApproveResponse{}, err
+	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// check credential service

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -4,8 +4,10 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	"github.com/openmetaearth/me-hub/app/params"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/kyc/types"
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
@@ -58,6 +60,14 @@ func (s *KeeperTestSuite) TestApprove() {
 	s.Require().True(f)
 	s.Require().Equal(msg.Uri, kyc.Uri)
 	s.Require().Equal(msg.Hash, kyc.Hash)
+}
+
+func (s *KeeperTestSuite) TestApproveRejectsKycLevelNone() {
+	_, err := s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+		Level: didtypes.KYC_LEVEL_NONE,
+	})
+
+	s.Require().ErrorIs(err, sdkerrors.ErrInvalidType)
 }
 
 func (s *KeeperTestSuite) TestRemove() {

--- a/x/kyc/types/msg_approve.go
+++ b/x/kyc/types/msg_approve.go
@@ -53,6 +53,16 @@ func (m *MsgApprove) GetKYC() didtypes.Credential {
 	return didtypes.NewCredential(m.Did, ModuleName, m.Hash, m.Uri, []byte(m.RegionId))
 }
 
+func ValidateApproveLevel(level didtypes.KycLevel) error {
+	if level == didtypes.KYC_LEVEL_NONE {
+		return errors.Wrap(sdkerrors.ErrInvalidType, "the level must represent an approved KYC credential")
+	}
+	if _, ok := didtypes.KycLevel_name[int32(level)]; !ok {
+		return errors.Wrap(sdkerrors.ErrInvalidType, "the level is not valid")
+	}
+	return nil
+}
+
 func (m *MsgApprove) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(m.Issuer); err != nil {
 		return errors.Wrap(sdkerrors.ErrInvalidAddress, "the issuer is not a valid bech32 address")
@@ -69,8 +79,8 @@ func (m *MsgApprove) ValidateBasic() error {
 	if m.Pubkey == "" {
 		return errors.Wrap(sdkerrors.ErrInvalidPubKey, "the pubkey is empty")
 	}
-	if _, ok := didtypes.KycLevel_name[int32(m.Level)]; !ok {
-		return errors.Wrap(sdkerrors.ErrInvalidType, "the level is not valid")
+	if err := ValidateApproveLevel(m.Level); err != nil {
+		return err
 	}
 	//if len(m.Hash) == 0 || len(m.Hash) > 128 {
 	//	return errors.Wrap(sdkerrors.ErrInvalidType, "hash length must be between 0 and 128")

--- a/x/kyc/types/msg_approve_test.go
+++ b/x/kyc/types/msg_approve_test.go
@@ -1,0 +1,64 @@
+package types
+
+import (
+	"strings"
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateApproveLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level didtypes.KycLevel
+		err   error
+	}{
+		{
+			name:  "rejects none",
+			level: didtypes.KYC_LEVEL_NONE,
+			err:   sdkerrors.ErrInvalidType,
+		},
+		{
+			name:  "rejects unknown enum",
+			level: didtypes.KycLevel(999),
+			err:   sdkerrors.ErrInvalidType,
+		},
+		{
+			name:  "accepts level one",
+			level: didtypes.KYC_LEVEL_ONE,
+		},
+		{
+			name:  "accepts level two",
+			level: didtypes.KYC_LEVEL_TWO,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateApproveLevel(tt.level)
+
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestMsgApproveValidateBasicRejectsKycLevelNone(t *testing.T) {
+	msg := MsgApprove{
+		Issuer:   sample.AccAddress(),
+		Did:      strings.Repeat("1", didtypes.DidLength),
+		RegionId: wstakingtypes.MeEarthRegionName,
+		Address:  sample.AccAddress(),
+		Pubkey:   "pubkey",
+		Level:    didtypes.KYC_LEVEL_NONE,
+	}
+
+	require.ErrorIs(t, msg.ValidateBasic(), sdkerrors.ErrInvalidType)
+}


### PR DESCRIPTION
## Summary
- reject `KYC_LEVEL_NONE` at the `MsgApprove` validation boundary
- enforce the same rule in the `Approve` msg-server handler before any active DID, credential, filter, or reward write
- preserve accepted approved levels and unknown-enum rejection through a shared validator
- add focused type regressions plus a keeper-suite regression

## Root cause
`KYC_LEVEL_NONE` is a known enum value, so the previous enum-membership check accepted it. `Approve` could then create an active DID and KYC credential for a holder with no approved KYC level.

## Verification
- `go1.24.7 test ./x/kyc/types -run 'Test(ValidateApproveLevel|MsgApproveValidateBasicRejectsKycLevelNone)$' -count=1 -v`
- `git diff --check`

The complete `x/kyc/types` suite still has existing unrelated failures in `genesis_test.go`. The keeper integration regression is included, but the package cannot link locally on Windows because the project-specific `-lwasmvm` library is unavailable; Linux CI can execute it.

Fixes #283