### PR TITLE
fix: check authz rollapp transfers

### DIFF
--- a/x/rollapp/transfergenesis/ante_decorator.go
+++ b/x/rollapp/transfergenesis/ante_decorator.go
@@ -3,6 +3,7 @@ package transfergenesis
 import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/openmetaearth/me-hub/utils/gerrc"
 	"github.com/openmetaearth/me-hub/utils/uibc"
 
@@ -38,22 +39,49 @@ func (h TransferEnabledDecorator) transfersEnabled(ctx sdk.Context, transfer *tr
 	return ra.GenesisState.TransfersEnabled, nil
 }
 
+func (h TransferEnabledDecorator) validateMsgTransfersEnabled(ctx sdk.Context, msg sdk.Msg) error {
+	switch msg := msg.(type) {
+	case *transferTypes.MsgTransfer:
+		return h.validateTransferEnabled(ctx, msg)
+	case *authztypes.MsgExec:
+		return h.validateAuthzExecTransfersEnabled(ctx, *msg)
+	default:
+		return nil
+	}
+}
+
+func (h TransferEnabledDecorator) validateAuthzExecTransfersEnabled(ctx sdk.Context, msg authztypes.MsgExec) error {
+	msgs, err := msg.GetMessages()
+	if err != nil {
+		return errorsmod.Wrap(err, "authz exec messages")
+	}
+	for i, innerMsg := range msgs {
+		if err := h.validateMsgTransfersEnabled(ctx, innerMsg); err != nil {
+			return errorsmod.Wrapf(err, "authz exec message %d", i)
+		}
+	}
+	return nil
+}
+
+func (h TransferEnabledDecorator) validateTransferEnabled(ctx sdk.Context, msg *transferTypes.MsgTransfer) error {
+	if msg == nil {
+		return errorsmod.Wrap(gerrc.ErrUnknown, "nil transfer message")
+	}
+	enabled, err := h.transfersEnabled(ctx, msg)
+	if err != nil {
+		return errorsmod.Wrap(err, "transfer genesis: transfers enabled")
+	}
+	if !enabled {
+		return errorsmod.Wrap(gerrc.ErrFailedPrecondition, "transfers to/from rollapp are disabled")
+	}
+	return nil
+}
+
 // AnteHandle will return an error if the tx contains an ibc transfer message to a rollapp that has not finished the transfer genesis protocol.
 func (h TransferEnabledDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	for _, msg := range tx.GetMsgs() {
-		typeURL := sdk.MsgTypeURL(msg)
-		if typeURL == sdk.MsgTypeURL(&transferTypes.MsgTransfer{}) {
-			m, ok := msg.(*transferTypes.MsgTransfer)
-			if !ok {
-				return ctx, errorsmod.Wrap(gerrc.ErrUnknown, "type url matched transfer type url but could not type cast")
-			}
-			ok, err := h.transfersEnabled(ctx, m)
-			if err != nil {
-				return ctx, errorsmod.Wrap(err, "transfer genesis: transfers enabled")
-			}
-			if !ok {
-				return ctx, errorsmod.Wrap(gerrc.ErrFailedPrecondition, "transfers to/from rollapp are disabled")
-			}
+		if err := h.validateMsgTransfersEnabled(ctx, msg); err != nil {
+			return ctx, err
 		}
 	}
 

--- a/x/rollapp/transfergenesis/ante_decorator_test.go
+++ b/x/rollapp/transfergenesis/ante_decorator_test.go
@@ -1,0 +1,144 @@
+package transfergenesis
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
+	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/stretchr/testify/require"
+)
+
+type transferEnabledTestTx struct {
+	msgs []sdk.Msg
+}
+
+func (tx transferEnabledTestTx) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx transferEnabledTestTx) ValidateBasic() error {
+	return nil
+}
+
+type transferEnabledChannelKeeper struct {
+	chainID string
+}
+
+func (k transferEnabledChannelKeeper) GetChannelClientState(
+	sdk.Context,
+	string,
+	string,
+) (string, exported.ClientState, error) {
+	return "client-0", &ibctmtypes.ClientState{ChainId: k.chainID}, nil
+}
+
+func TestTransferEnabledDecoratorRejectsDirectTransfer(t *testing.T) {
+	transfer := newTestTransfer()
+	decorator := newTestTransferEnabledDecorator(false)
+
+	nextCalled := false
+	_, err := decorator.AnteHandle(sdk.Context{}, transferEnabledTestTx{msgs: []sdk.Msg{transfer}}, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		nextCalled = true
+		return ctx, nil
+	})
+
+	require.ErrorContains(t, err, "transfers to/from rollapp are disabled")
+	require.False(t, nextCalled)
+}
+
+func TestTransferEnabledDecoratorRejectsAuthzWrappedTransfer(t *testing.T) {
+	transfer := newTestTransfer()
+	exec := newTestMsgExec(t, transfer)
+	decorator := newTestTransferEnabledDecorator(false)
+
+	nextCalled := false
+	_, err := decorator.AnteHandle(sdk.Context{}, transferEnabledTestTx{msgs: []sdk.Msg{&exec}}, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		nextCalled = true
+		return ctx, nil
+	})
+
+	require.ErrorContains(t, err, "transfers to/from rollapp are disabled")
+	require.False(t, nextCalled)
+}
+
+func TestTransferEnabledDecoratorAllowsAuthzWrappedTransferWhenEnabled(t *testing.T) {
+	transfer := newTestTransfer()
+	exec := newTestMsgExec(t, transfer)
+	decorator := newTestTransferEnabledDecorator(true)
+
+	nextCalled := false
+	_, err := decorator.AnteHandle(sdk.Context{}, transferEnabledTestTx{msgs: []sdk.Msg{&exec}}, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		nextCalled = true
+		return ctx, nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, nextCalled)
+}
+
+func TestTransferEnabledDecoratorRejectsNestedAuthzWrappedTransfer(t *testing.T) {
+	transfer := newTestTransfer()
+	innerExec := newTestMsgExec(t, transfer)
+	outerExec := newTestMsgExec(t, &innerExec)
+	decorator := newTestTransferEnabledDecorator(false)
+
+	nextCalled := false
+	_, err := decorator.AnteHandle(sdk.Context{}, transferEnabledTestTx{msgs: []sdk.Msg{&outerExec}}, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		nextCalled = true
+		return ctx, nil
+	})
+
+	require.ErrorContains(t, err, "transfers to/from rollapp are disabled")
+	require.False(t, nextCalled)
+}
+
+func newTestTransfer() *transfertypes.MsgTransfer {
+	return transfertypes.NewMsgTransfer(
+		transfertypes.PortID,
+		"channel-0",
+		sdk.NewCoin("foo", math.NewInt(1)),
+		"sender",
+		"receiver",
+		clienttypes.NewHeight(1, 1),
+		0,
+		"",
+	)
+}
+
+func newTestTransferEnabledDecorator(transfersEnabled bool) *TransferEnabledDecorator {
+	const rollappID = "rollapp_1-1"
+	return NewTransferEnabledDecorator(
+		func(ctx sdk.Context, rollappID string) (rollapptypes.Rollapp, bool) {
+			return rollapptypes.Rollapp{
+				RollappId: rollappID,
+				GenesisState: rollapptypes.RollappGenesisState{
+					TransfersEnabled: transfersEnabled,
+				},
+			}, true
+		},
+		transferEnabledChannelKeeper{chainID: rollappID},
+	)
+}
+
+func newTestMsgExec(t *testing.T, msgs ...sdk.Msg) authztypes.MsgExec {
+	t.Helper()
+
+	anyMsgs := make([]*codectypes.Any, len(msgs))
+	for i, msg := range msgs {
+		anyMsg, err := codectypes.NewAnyWithValue(msg)
+		require.NoError(t, err)
+		anyMsgs[i] = anyMsg
+	}
+
+	return authztypes.MsgExec{
+		Grantee: "me1grantee",
+		Msgs:    anyMsgs,
+	}
+}


### PR DESCRIPTION
Closes #224

## Summary
- apply the Rollapp transfer-genesis enabled check to `MsgTransfer` messages nested inside `authz.MsgExec`
- recurse through nested `MsgExec` wrappers so an executable transfer cannot bypass the ante policy by being wrapped
- preserve the existing direct-transfer behavior and allow authz-wrapped transfers once the Rollapp transfer gate is enabled

## Tests
- `go test ./x/rollapp/transfergenesis -run TestTransferEnabledDecorator -count=1`
- `go test ./x/rollapp/transfergenesis -count=1`
- `git diff --check`

Broader checks still hit existing unrelated failures:
- `go test ./app/ante` does not build because `app/ante/mock.MockDaoKeeper` is missing `IsDao`
- `go test ./x/rollapp/...` fails in existing `x/rollapp/keeper` expectation tests outside `transfergenesis`
- `go test ./ibctesting -run TestTransfersEnabledTestSuite/TestHubToRollappDisabled -count=1` panics during suite setup on an existing genesis fixture mismatch: `unknown field "stakes" in types.GenesisState`

## Payment
Meta Earth bug bounty payout: `$MEC` via ME Pass.

MEC address: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`