### PR TITLE
fix: require dao update addresses

### DIFF
--- a/x/dao/keeper/msg_server.go
+++ b/x/dao/keeper/msg_server.go
@@ -21,6 +21,10 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 var _ types.MsgServer = msgServer{}
 
 func (k msgServer) UpdateDao(goCtx context.Context, msg *types.MsgUpdateDao) (*types.MsgUpdateDaoResponse, error) {
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	isGlobalDao := k.IsGlobalDao(ctx, msg.Creator)

--- a/x/dao/types/msg.go
+++ b/x/dao/types/msg.go
@@ -40,25 +40,31 @@ func (msg *MsgUpdateDao) GetSignBytes() []byte {
 }
 
 func (msg *MsgUpdateDao) ValidateBasic() error {
-	if len(msg.DaoAddresses.GlobalDao) > 0 {
-		if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.GlobalDao); err != nil {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.DaoAddresses.GlobalDao)
-		}
+	if _, err := sdk.AccAddressFromBech32(msg.Creator); err != nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Creator)
 	}
-	if len(msg.DaoAddresses.MeidDao) > 0 {
-		if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.MeidDao); err != nil {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.DaoAddresses.MeidDao)
-		}
+
+	if err := validateDaoAddress("global dao", msg.DaoAddresses.GlobalDao); err != nil {
+		return err
 	}
-	if len(msg.DaoAddresses.DevOperator) > 0 {
-		if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.DevOperator); err != nil {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.DaoAddresses.DevOperator)
-		}
+	if err := validateDaoAddress("meid dao", msg.DaoAddresses.MeidDao); err != nil {
+		return err
 	}
-	if len(msg.DaoAddresses.AirdropAddress) > 0 {
-		if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.AirdropAddress); err != nil {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.DaoAddresses.AirdropAddress)
-		}
+	if err := validateDaoAddress("dev operator", msg.DaoAddresses.DevOperator); err != nil {
+		return err
+	}
+	if err := validateDaoAddress("airdrop", msg.DaoAddresses.AirdropAddress); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateDaoAddress(field, address string) error {
+	if address == "" {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, fmt.Sprintf("%s address is empty", field))
+	}
+	if _, err := sdk.AccAddressFromBech32(address); err != nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, fmt.Sprintf("%s address %s", field, address))
 	}
 	return nil
 }

--- a/x/dao/types/msg_test.go
+++ b/x/dao/types/msg_test.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	_ "github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgUpdateDaoValidateBasic(t *testing.T) {
+	validAddresses := DaoAddresses{
+		GlobalDao:      sample.AccAddress(),
+		MeidDao:        sample.AccAddress(),
+		DevOperator:    sample.AccAddress(),
+		AirdropAddress: sample.AccAddress(),
+	}
+
+	tests := []struct {
+		name      string
+		creator   string
+		addresses DaoAddresses
+		wantError string
+	}{
+		{
+			name:      "valid dao address update",
+			creator:   sample.AccAddress(),
+			addresses: validAddresses,
+		},
+		{
+			name:      "invalid creator",
+			creator:   "not-a-bech32-address",
+			addresses: validAddresses,
+			wantError: "not-a-bech32-address",
+		},
+		{
+			name:      "all dao addresses empty",
+			creator:   sample.AccAddress(),
+			addresses: DaoAddresses{},
+			wantError: "global dao address is empty",
+		},
+		{
+			name:    "empty global dao",
+			creator: sample.AccAddress(),
+			addresses: DaoAddresses{
+				MeidDao:        validAddresses.MeidDao,
+				DevOperator:    validAddresses.DevOperator,
+				AirdropAddress: validAddresses.AirdropAddress,
+			},
+			wantError: "global dao address is empty",
+		},
+		{
+			name:    "empty meid dao",
+			creator: sample.AccAddress(),
+			addresses: DaoAddresses{
+				GlobalDao:      validAddresses.GlobalDao,
+				DevOperator:    validAddresses.DevOperator,
+				AirdropAddress: validAddresses.AirdropAddress,
+			},
+			wantError: "meid dao address is empty",
+		},
+		{
+			name:    "empty dev operator",
+			creator: sample.AccAddress(),
+			addresses: DaoAddresses{
+				GlobalDao:      validAddresses.GlobalDao,
+				MeidDao:        validAddresses.MeidDao,
+				AirdropAddress: validAddresses.AirdropAddress,
+			},
+			wantError: "dev operator address is empty",
+		},
+		{
+			name:    "empty airdrop address",
+			creator: sample.AccAddress(),
+			addresses: DaoAddresses{
+				GlobalDao:   validAddresses.GlobalDao,
+				MeidDao:     validAddresses.MeidDao,
+				DevOperator: validAddresses.DevOperator,
+			},
+			wantError: "airdrop address is empty",
+		},
+		{
+			name:    "invalid dao address",
+			creator: sample.AccAddress(),
+			addresses: DaoAddresses{
+				GlobalDao:      validAddresses.GlobalDao,
+				MeidDao:        "not-a-bech32-address",
+				DevOperator:    validAddresses.DevOperator,
+				AirdropAddress: validAddresses.AirdropAddress,
+			},
+			wantError: "meid dao address not-a-bech32-address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := MsgUpdateDao{
+				Creator:      tt.creator,
+				DaoAddresses: tt.addresses,
+			}
+
+			err := msg.ValidateBasic()
+			if tt.wantError != "" {
+				require.ErrorIs(t, err, sdkerrors.ErrInvalidAddress)
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #232

## Summary
- require `MsgUpdateDao` creator and every DAO address to be valid bech32 addresses
- reject empty GlobalDao, MeidDao, DevOperator, and AirdropAddress values before they can be stored
- validate `MsgUpdateDao` again in the message server so direct handler calls cannot bypass the same guard
- add regression coverage for the all-empty bricking case, each individual empty DAO field, and malformed addresses

## Validation
- `go test ./x/dao/types -run TestMsgUpdateDaoValidateBasic -count=1`
- `go test ./x/dao/types -count=1`
- `go test ./x/dao/... -count=1`
- `git diff --check`

## Payment
Meta Earth bug bounty payout: `$MEC` via ME Pass.

MEC address: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`