### PR TITLE
fix: reject sequencer self replacement

### DIFF
--- a/x/sequencer/keeper/msg_repalce_proposer.go
+++ b/x/sequencer/keeper/msg_repalce_proposer.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (k msgServer) ReplaceProposer(goCtx context.Context, msg *types.MsgReplaceProposerRequest) (*types.MsgReplaceProposerResponse, error) {
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	// check to see if the rollapp has been registered before

--- a/x/sequencer/keeper/msg_server_replace_proposer_test.go
+++ b/x/sequencer/keeper/msg_server_replace_proposer_test.go
@@ -1,0 +1,27 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/openmetaearth/me-hub/x/sequencer/types"
+)
+
+func (suite *SequencerTestSuite) TestReplaceProposerRejectsSelfReplacementBeforeStateLookup() {
+	suite.SetupTest()
+
+	proposer := sample.AccAddress()
+	msg := &types.MsgReplaceProposerRequest{
+		Creator: sample.AccAddress(),
+		ReplaceProposer: &types.MsgRepalceProposer{
+			RollappId:   "rollapp_1234-1",
+			OldProposer: proposer,
+			NewProposer: proposer,
+			BlockHeight: 10,
+		},
+	}
+
+	_, err := suite.msgServer.ReplaceProposer(sdk.WrapSDKContext(suite.Ctx), msg)
+	suite.Require().ErrorIs(err, sdkerrors.ErrInvalidRequest)
+	suite.Require().ErrorContains(err, "old proposer and new proposer cannot be the same address")
+}

--- a/x/sequencer/types/messages.go
+++ b/x/sequencer/types/messages.go
@@ -174,16 +174,19 @@ func (msg *MsgReplaceProposerRequest) ValidateBasic() error {
 	if msg.ReplaceProposer.RollappId == "" {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "rollapp id cannot be empty")
 	}
-	_, err = sdk.AccAddressFromBech32(msg.ReplaceProposer.OldProposer)
+	oldProposer, err := sdk.AccAddressFromBech32(msg.ReplaceProposer.OldProposer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid OldProposer address.addr = %s,err = %s",
 			msg.ReplaceProposer.OldProposer, err.Error())
 	}
 
-	_, err = sdk.AccAddressFromBech32(msg.ReplaceProposer.NewProposer)
+	newProposer, err := sdk.AccAddressFromBech32(msg.ReplaceProposer.NewProposer)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid NewProposer address.addr = %s,err = %s",
 			msg.ReplaceProposer.NewProposer, err.Error())
+	}
+	if oldProposer.Equals(newProposer) {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "old proposer and new proposer cannot be the same address (%s)", msg.ReplaceProposer.OldProposer)
 	}
 
 	if msg.ReplaceProposer.BlockHeight < 1 {

--- a/x/sequencer/types/messages_test.go
+++ b/x/sequencer/types/messages_test.go
@@ -11,6 +11,7 @@ import (
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/openmetaearth/me-hub/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
@@ -144,6 +145,120 @@ func TestMsgCreateSequencer_ValidateBasic(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
 				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestMsgReplaceProposerRequestValidateBasic(t *testing.T) {
+	creator := sample.AccAddress()
+	oldProposer := sample.AccAddress()
+	newProposer := sample.AccAddress()
+
+	tests := []struct {
+		name      string
+		msg       MsgReplaceProposerRequest
+		wantErr   error
+		errSubstr string
+	}{
+		{
+			name: "valid replace proposer",
+			msg: MsgReplaceProposerRequest{
+				Creator: creator,
+				ReplaceProposer: &MsgRepalceProposer{
+					RollappId:   "rollapp_1234-1",
+					OldProposer: oldProposer,
+					NewProposer: newProposer,
+					BlockHeight: 10,
+				},
+			},
+		},
+		{
+			name: "reject self replacement",
+			msg: MsgReplaceProposerRequest{
+				Creator: creator,
+				ReplaceProposer: &MsgRepalceProposer{
+					RollappId:   "rollapp_1234-1",
+					OldProposer: oldProposer,
+					NewProposer: oldProposer,
+					BlockHeight: 10,
+				},
+			},
+			wantErr:   sdkerrors.ErrInvalidRequest,
+			errSubstr: "old proposer and new proposer cannot be the same address",
+		},
+		{
+			name: "reject missing replace proposer",
+			msg: MsgReplaceProposerRequest{
+				Creator: creator,
+			},
+			wantErr:   sdkerrors.ErrInvalidRequest,
+			errSubstr: "ReplaceProposer can not",
+		},
+		{
+			name: "reject missing rollapp id",
+			msg: MsgReplaceProposerRequest{
+				Creator: creator,
+				ReplaceProposer: &MsgRepalceProposer{
+					OldProposer: oldProposer,
+					NewProposer: newProposer,
+					BlockHeight: 10,
+				},
+			},
+			wantErr:   sdkerrors.ErrInvalidRequest,
+			errSubstr: "rollapp id cannot be empty",
+		},
+		{
+			name: "reject invalid old proposer",
+			msg: MsgReplaceProposerRequest{
+				Creator: creator,
+				ReplaceProposer: &MsgRepalceProposer{
+					RollappId:   "rollapp_1234-1",
+					OldProposer: "not-a-bech32-address",
+					NewProposer: newProposer,
+					BlockHeight: 10,
+				},
+			},
+			wantErr:   sdkerrors.ErrInvalidAddress,
+			errSubstr: "invalid OldProposer address",
+		},
+		{
+			name: "reject invalid new proposer",
+			msg: MsgReplaceProposerRequest{
+				Creator: creator,
+				ReplaceProposer: &MsgRepalceProposer{
+					RollappId:   "rollapp_1234-1",
+					OldProposer: oldProposer,
+					NewProposer: "not-a-bech32-address",
+					BlockHeight: 10,
+				},
+			},
+			wantErr:   sdkerrors.ErrInvalidAddress,
+			errSubstr: "invalid NewProposer address",
+		},
+		{
+			name: "reject invalid block height",
+			msg: MsgReplaceProposerRequest{
+				Creator: creator,
+				ReplaceProposer: &MsgRepalceProposer{
+					RollappId:   "rollapp_1234-1",
+					OldProposer: oldProposer,
+					NewProposer: newProposer,
+				},
+			},
+			wantErr:   sdkerrors.ErrInvalidRequest,
+			errSubstr: "invalid block number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.ErrorContains(t, err, tt.errSubstr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
Fixes #227

## Summary
- reject `MsgReplaceProposerRequest` when `OldProposer` and `NewProposer` resolve to the same address
- run the same `ValidateBasic()` guard in the message server before rollapp/sequencer state lookup
- add message validation coverage for valid replacement, self-replacement, nil payload, missing rollapp id, invalid proposer addresses, and invalid height
- add message-server coverage proving self-replacement is rejected before any rollapp state lookup

## Validation
- `go test ./x/sequencer/types -run TestMsgReplaceProposerRequestValidateBasic -count=1`
- `go test ./x/sequencer/types -count=1`
- `go test ./x/sequencer/keeper -run TestSequencerKeeperTestSuite/TestReplaceProposerRejectsSelfReplacementBeforeStateLookup -count=1`
- `git diff --check`

Broader check: `go test ./x/sequencer/... -count=1` still fails in existing keeper tests unrelated to this change: `TestMinBond` nil-vs-empty coins, `TestRotatingSequencerByBond`, and `TestTokensRefundOnUnbond`. These same keeper failures were reproduced from a separate branch based on `origin/main`.

## Payment
Meta Earth bug bounty payout: `$MEC` via ME Pass.

MEC address: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`