### PR TITLE
fix(gravity): atomic CancelOutgoingTxBatch with cache context to prevent split-brain state

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -183,17 +183,23 @@ func (k Keeper) GetOutgoingTxBatch(ctx sdk.Context, contractAddress string, batc
 	return batch
 }
 
-// CancelOutgoingTxBatch releases all TX in the batch and deletes the batch
+// CancelOutgoingTxBatch releases all TX in the batch and deletes the batch.
+// Uses a cache context to guarantee atomicity: if any AddUnbatchedTx fails
+// mid-iteration, previously-added transactions are not left in the pool and
+// the batch is not deleted.
 func (k Keeper) CancelOutgoingTxBatch(ctx sdk.Context, contractAddress string, batchNonce uint64) error {
 	batch := k.GetOutgoingTxBatch(ctx, contractAddress, batchNonce)
 	if batch == nil {
 		return types.ErrUnknown
 	}
+
+	cacheCtx, writeFn := ctx.CacheContext()
 	for _, tx := range batch.Transactions {
-		if err := k.AddUnbatchedTx(ctx, tx); err != nil {
+		if err := k.AddUnbatchedTx(cacheCtx, tx); err != nil {
 			return errorsmod.Wrapf(err, "unable to add batched transaction back into pool %v", tx)
 		}
 	}
+	writeFn()
 
 	// Delete batch since it is finished
 	k.DeleteBatch(ctx, batch)


### PR DESCRIPTION
## 🏆 Bug Bounty Claim

**Discovered & Reported by:** MeowMeow1230
**First Reported:** 2026-05-27T12:00:00Z (Issue #50)
**Fix PR:** [this PR]

This vulnerability was identified and responsibly disclosed as part of the official Meta Earth Bug Bounty program.
I request the team to confirm eligibility and process the reward according to the program's published guidelines.

---

此漏洞由本人於 2026-05-27T12:00:00Z 首次發現並通報，已依賞金計畫進行負責任揭露。
請團隊依計畫規則確認獎勵資格並安排發放。

## Summary

When `CancelOutgoingTxBatch` fails partway through restoring transactions to the unbatched pool, transactions added before the failure are left orphaned in the pool while the batch remains stuck in the store. This creates a split-brain state where duplicate transactions can be included in future batches, risking double execution on the external chain.

## Fix

Use a cache context (`ctx.CacheContext()`) to wrap the entire `AddUnbatchedTx` iteration. If all transactions are successfully added, the cache is committed. If any fails, the cache is discarded and no partial state is written.

This is a cleaner alternative to manual rollback — it leverages the SDK's built-in transactional context rather than tracking and deleting individual transactions.

## Comparison with #61

PR #61 uses manual rollback (collecting successfully-added transactions in a slice and calling `DelUnbatchedTx` on failure). This PR uses `CacheContext`, which is the standard Cosmos SDK pattern also used elsewhere in this codebase (`x/gravity/keeper/attestation.go:133`, `x/wgov/abci.go:77`).

Fixes: #50