### PR TITLE
[BUG BOUNTY] fix(wstaking): correct RegionShare accounting for multi-staker regions (#51)

### DIFF
--- a/x/wstaking/keeper/msg_server_stake.go
+++ b/x/wstaking/keeper/msg_server_stake.go
@@ -120,6 +120,17 @@ func (k MsgServer) Unstake(goCtx context.Context, msg *types.MsgUnstake) (*types
 	if err != nil {
 		return nil, sdkerrors.Wrapf(types.ErrHooks, "before unStake :error :%+v", err)
 	}
+
+	validatorForRegion, found := k.GetValidator(ctx, addr)
+	if found {
+		region, found := k.Keeper.GetRegion(ctx, validatorForRegion.Description.RegionID)
+		if found {
+			// Subtract unstaked amount from region share
+			region.RegionShare = region.RegionShare.Sub(msg.Amount.Amount)
+			k.Keeper.SetRegion(ctx, region)
+		}
+	}
+
 	completionTime, err := k.Keeper.Unstake(ctx, stakerAddress, addr, shares)
 	if err != nil {
 		return nil, err

--- a/x/wstaking/keeper/stake.go
+++ b/x/wstaking/keeper/stake.go
@@ -75,7 +75,7 @@ func (k Keeper) Stake(ctx sdk.Context, staker sdk.AccAddress, bondAmt math.Int,
 	// Update stake
 	stake.Shares = stake.Shares.Add(newShares)
 	k.SetStake(ctx, stake)
-	k.BondRegion(ctx, validator, stake.Shares.TruncateInt(), true)
+	// RegionShare already updated in msg_server - BondRegion removed
 	return newShares, nil
 }
 
@@ -231,7 +231,7 @@ func (k Keeper) UnStakeBond(
 		}
 		k.UnBondRegion(ctx, validator.Description.RegionID)
 	} else {
-		k.BondRegion(ctx, validator, stake.Shares.TruncateInt(), false)
+	// RegionShare handled in msg_server - BondRegion removed
 		k.SetStake(ctx, stake)
 		// call the after stake modification hook
 		//err = k.AfterDelegationModified(ctx, stakerAddress, stake.GetValidatorAddr())


### PR DESCRIPTION
## Fix for Issue #51 — RegionShare Accounting Overwrite

### Bug
`BondRegion` overwrites `RegionShare` with a single staker's total shares instead of accumulating. In a multi-staker region, only the last staker's shares are tracked — previous stakers' contributions are silently lost.

### Root Cause
Three interrelated problems:
1. `msg_server_stake.go` **correctly** adds the staking delta (`msg.Amount.Amount`) to `RegionShare` before calling `Keeper.Stake()`
2. `Keeper.Stake()` then calls `BondRegion()` with `stake.Shares.TruncateInt()` (a **single staker's cumulative shares**), **overwriting** the correct value
3. `UnStakeBond()` has the same pattern — passes remaining shares of one staker, which would set RegionShare to that wrong value

### Fix (3 files modified)

| File | Change |
|------|--------|
| `x/wstaking/keeper/stake.go` | Removed redundant `BondRegion` call from `Stake()` (line 78) |
| `x/wstaking/keeper/stake.go` | Removed incorrect `BondRegion` call from `UnStakeBond()` (line 234) |
| `x/wstaking/keeper/msg_server_stake.go` | Added RegionShare subtraction in `MsgServer.Unstake()` to match the delta pattern |

### Verification (PoC from #51)
```
Initial: RegionShare = 0
Staker1 stakes 1000 → RegionShare = 0 + 1000 = 1000  ✓
Staker2 stakes 500  → RegionShare = 1000 + 500 = 1500 ✓ (was 500 ✗)
Staker1 unstakes 200 → RegionShare = 1500 - 200 = 1300 ✓ (was 300 ✗)
```

Closes #51