### PR TITLE
fix: restrict proposal relayer authority

### DIFF
--- a/x/gravity/keeper/abci_test.go
+++ b/x/gravity/keeper/abci_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/testutil/helpers"
 	"github.com/openmetaearth/me-hub/utils"
@@ -179,6 +180,23 @@ func (s *KeeperTestSuite) TestProposalRelayers() {
 		Relayers:  newRelayerList2,
 	})
 	s.Require().NoError(err)
+}
+
+func (s *KeeperTestSuite) TestProposalRelayersRejectsMeidDaoAuthority() {
+	before, found := s.Keeper().GetProposalRelayer(s.Ctx)
+	s.Require().True(found)
+	beforeRelayers := append([]string(nil), before.Relayers...)
+
+	_, err := s.MsgServer().ProposalRelayers(sdk.WrapSDKContext(s.Ctx), &types.MsgProposalRelayers{
+		ChainName: s.chainName,
+		Authority: s.Dao.MeidDao,
+		Relayers:  []string{s.relayerAddrs[0].String()},
+	})
+	s.Require().ErrorIs(err, govtypes.ErrInvalidSigner)
+
+	after, found := s.Keeper().GetProposalRelayer(s.Ctx)
+	s.Require().True(found)
+	s.Require().Equal(beforeRelayers, after.Relayers)
 }
 
 func (s *KeeperTestSuite) TestAttestationAfterRelayerUpdate() {

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -366,7 +366,7 @@ func (s MsgServer) IncreaseBridgeFee(c context.Context, msg *types.MsgIncreaseBr
 
 func (s MsgServer) ProposalRelayers(c context.Context, msg *types.MsgProposalRelayers) (*types.MsgProposalRelayersResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	if !s.daoKeeper.IsDao(ctx, msg.Authority) {
+	if !s.daoKeeper.IsGlobalDao(ctx, msg.Authority) {
 		return nil, errorsmod.Wrapf(govtypes.ErrInvalidSigner, "invalid authority")
 	}
 	if err := s.UpdateProposalRelayers(ctx, msg.Relayers); err != nil {

--- a/x/gravity/types/expected_keepers.go
+++ b/x/gravity/types/expected_keepers.go
@@ -45,5 +45,5 @@ type (
 )
 
 type DaoKeeper interface {
-	IsDao(ctx sdk.Context, address string) bool
+	IsGlobalDao(ctx sdk.Context, address string) bool
 }


### PR DESCRIPTION
## Summary
- restrict `MsgProposalRelayers` to the GlobalDao authority instead of the broader DAO predicate
- narrow the Gravity DAO keeper dependency to `IsGlobalDao`
- add regression coverage that rejects `MeidDao` and confirms the existing proposal relayer set is not mutated

## Validation
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestProposalRelayers' -count=1 -v`
- `go test ./x/gravity/types -count=1`
- `git diff --check`

I also ran `go test ./x/gravity/keeper -count=1`; it still fails on existing unrelated tests:
- `TestGrav004_FailedAttestationMustNotLockNonce`
- `TestMsgBondedRelayer` stale expected error strings
- `TestRelayerSetSlash`

## Bounty payout
Meta Earth bug bounty payout: `$MEC` via ME Pass. MEC address: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.

Fixes #354