### PR TITLE
fix(gravity): enable relayer slashing

### DIFF
--- a/x/gravity/keeper/abci.go
+++ b/x/gravity/keeper/abci.go
@@ -13,7 +13,7 @@ import (
 func (k Keeper) EndBlocker(ctx sdk.Context) {
 	k.cleanupTimedOutBatches(ctx)
 	signedWindow := k.GetSignedWindow(ctx)
-	//k.slashing(ctx, signedWindow)
+	k.slashing(ctx, signedWindow)
 	k.createRelayerSetChangeRequest(ctx)
 	k.pruneRelayerSet(ctx, signedWindow)
 }

--- a/x/gravity/keeper/abci_test.go
+++ b/x/gravity/keeper/abci_test.go
@@ -507,6 +507,65 @@ func (s *KeeperTestSuite) TestRelayerSetSlash() {
 	s.Require().Equal(int64(1), relayer.SlashTimes)
 }
 
+func (s *KeeperTestSuite) TestBatchConfirmSlash() {
+	for i := 0; i < len(s.relayerAddrs); i++ {
+		msgBondedRelayer := &types.MsgBondedRelayer{
+			RelayerAddress:  s.relayerAddrs[i].String(),
+			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[i].PublicKey),
+			DelegateAmount:  sdk.NewCoin(params.BaseDenom, sdk.NewInt(10*1e8)),
+			ChainName:       s.chainName,
+		}
+		s.Require().NoError(msgBondedRelayer.ValidateBasic())
+		_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msgBondedRelayer)
+		s.Require().NoError(err)
+	}
+
+	s.Ctx = s.Ctx.WithBlockHeight(s.Ctx.BlockHeight() + 1)
+	batchBlock := uint64(s.Ctx.BlockHeight())
+	tokenContract := helpers.GenExternalAddr(s.chainName)
+	batch := &types.OutgoingTxBatch{
+		BatchNonce:    1,
+		BatchTimeout:  1000,
+		TokenContract: tokenContract,
+		Block:         batchBlock,
+		FeeReceive:    helpers.GenExternalAddr(s.chainName),
+		Transactions: types.OutgoingTransferTxs{{
+			Id:          1,
+			Sender:      s.relayerAddrs[0].String(),
+			DestAddress: helpers.GenExternalAddr(s.chainName),
+			Token:       types.NewERC20Token(sdkmath.NewInt(100), tokenContract),
+			Fee:         types.NewERC20Token(sdkmath.NewInt(1), tokenContract),
+		}},
+	}
+	s.Require().NoError(s.Keeper().StoreBatch(s.Ctx, batch))
+
+	for i := 0; i < len(s.relayerAddrs)-1; i++ {
+		s.Keeper().SetBatchConfirm(s.Ctx, s.relayerAddrs[i], &types.MsgConfirmBatch{
+			Nonce:           batch.BatchNonce,
+			TokenContract:   tokenContract,
+			RelayerAddress:  s.relayerAddrs[i].String(),
+			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[i].PublicKey),
+			Signature:       "00",
+			ChainName:       s.chainName,
+		})
+	}
+
+	missingRelayer := s.relayerAddrs[len(s.relayerAddrs)-1]
+	relayer, found := s.Keeper().GetRelayer(s.Ctx, missingRelayer)
+	s.Require().True(found)
+	s.Require().True(relayer.Online)
+	s.Require().Equal(int64(0), relayer.SlashTimes)
+
+	s.Ctx = s.Ctx.WithBlockHeight(int64(batchBlock + s.Keeper().GetParams(s.Ctx).SignedWindow + 1))
+	s.Keeper().EndBlocker(s.Ctx)
+
+	relayer, found = s.Keeper().GetRelayer(s.Ctx, missingRelayer)
+	s.Require().True(found)
+	s.Require().False(relayer.Online)
+	s.Require().Equal(int64(1), relayer.SlashTimes)
+	s.Require().Equal(batchBlock, s.Keeper().GetLastSlashedBatchBlock(s.Ctx))
+}
+
 func (s *KeeperTestSuite) TestSlashRelayer() {
 	for i := 0; i < len(s.relayerAddrs); i++ {
 		msgBondedRelayer := &types.MsgBondedRelayer{


### PR DESCRIPTION
Fixes #580

## Summary
- re-enable the existing Gravity relayer slashing pass from `EndBlocker`
- keep the current end-block ordering intact: cleanup, slashing, relayer-set change request, then pruning
- add regression coverage for both missing relayer-set confirmations and missing outgoing-batch confirmations crossing the signed window

## Validation
- `go test ./x/gravity/keeper -run "TestGravityKeeperTestSuite/TestRelayerSetSlash|TestGravityKeeperTestSuite/TestBatchConfirmSlash|TestGravityKeeperTestSuite/TestSlashRelayer" -count=1 -v`
- `git diff --check`

I also ran `go test ./x/gravity/keeper -count=1`. The targeted slashing cases pass; the broader package still has unrelated existing failures in `TestGrav004_FailedAttestationMustNotLockNonce` and `TestMsgBondedRelayer` expected error strings.

## Bounty payout
Meta Earth bug bounty payout: `$MEC` via ME Pass. MEC address: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.