### PR TITLE
fix(wdistri): remove Int64 overflow in AllocateBlockReward

### DIFF
--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -101,7 +101,7 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		// calculate every region coins: RegionShare * totalMintCoins / totalRegionShare
 		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(totalMintCoin.AmountOf(params.BaseDenom).ToLegacyDec()).Quo(totalRegionShareDec)
 		regionAmount := amount.TruncateInt()
-		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
+		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, regionAmount))
 		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()), regionCoins)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
Remove unsafe `Int64()` conversion in `AllocateBlockReward`. `regionAmount.Int64()` silently truncates values exceeding `math.MaxInt64`, causing incorrect reward distribution.

## Root Cause
`x/wdistri/keeper/keeper.go:104`:
```go
regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
```
When `regionAmount` exceeds 9.2e18, `Int64()` wraps to a small or negative number, causing region treasuries to receive 0 or wrong amounts.

## Fix
Use `regionAmount` directly (already `sdkmath.Int`):
```go
regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, regionAmount))
```

Closes #565