### PR TITLE
fix(gravity): defer SetLastObservedEventNonce until after processAttestation succeeds

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -102,15 +102,14 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 			continue
 		}
 
-		k.SetLastObservedEventNonce(ctx, claim.GetEventNonce())
-
-		// in case of web3 event is long time ago, we set the last observed me block height need long enough.
-		k.SetLastObservedBlockHeight(ctx, claim.GetBlockHeight(), uint64(ctx.BlockHeight()))
-
 		att.Observed = true
 		k.SetAttestation(ctx, claim.GetEventNonce(), claim.ClaimHash(), att)
 
 		err = k.processAttestation(ctx, claim)
+			if err == nil {
+				k.SetLastObservedEventNonce(ctx, claim.GetEventNonce())
+				k.SetLastObservedBlockHeight(ctx, claim.GetBlockHeight(), uint64(ctx.BlockHeight()))
+			}
 		ctx.EventManager().EmitEvent(sdk.NewEvent(
 			types.EventTypeContractEvent,
 			sdk.NewAttribute(sdk.AttributeKeyModule, k.moduleName),


### PR DESCRIPTION
## Summary
Move `SetLastObservedEventNonce` and `SetLastObservedBlockHeight` to AFTER `processAttestation` succeeds.

## Root Cause
`x/gravity/keeper/attestation.go:105-113`: The observed nonce was committed BEFORE processing the attestation. If `processAttestation` failed, the nonce was still advanced, blocking later attestations.

## Fix
Only advance the observed nonce if processing succeeds:
```go
err = k.processAttestation(ctx, claim)
if err == nil {
    k.SetLastObservedEventNonce(ctx, claim.GetEventNonce())
    k.SetLastObservedBlockHeight(ctx, claim.GetBlockHeight(), uint64(ctx.BlockHeight()))
}
```

Closes #566