### PR TITLE
fix(gravity): re-enable relayer slashing in EndBlocker

### DIFF
--- a/x/gravity/keeper/abci.go
+++ b/x/gravity/keeper/abci.go
@@ -13,7 +13,7 @@ import (
 func (k Keeper) EndBlocker(ctx sdk.Context) {
 	k.cleanupTimedOutBatches(ctx)
 	signedWindow := k.GetSignedWindow(ctx)
-	//k.slashing(ctx, signedWindow)
+	k.slashing(ctx, signedWindow)
 	k.createRelayerSetChangeRequest(ctx)
 	k.pruneRelayerSet(ctx, signedWindow)
 }


### PR DESCRIPTION
## Summary
Re-enable the relayer slashing mechanism in `x/gravity/keeper/abci.go` by uncommenting the `k.slashing(ctx, signedWindow)` call at line 16.

## Root Cause
The slashing call was commented out, leaving relayers free to skip attestations and batch confirmations with zero penalty. This undermines the trust model of the gravity bridge.

## Fix
Uncomment the slashing call:
```go
// Before:
//k.slashing(ctx, signedWindow)
// After:
k.slashing(ctx, signedWindow)
```

Closes #580