### PR TITLE
fix(eibc): propagate fee parsing error in FulfillOrder

### DIFF
--- a/x/eibc/keeper/msg_server.go
+++ b/x/eibc/keeper/msg_server.go
@@ -39,7 +39,10 @@ func (m msgServer) FulfillOrder(goCtx context.Context, msg *types.MsgFulfillOrde
 	}
 
 	// Check that the fulfiller expected fee is equal to the demand order fee
-	expectedFee, _ := sdk.NewIntFromString(msg.ExpectedFee)
+	expectedFee, ok := sdk.NewIntFromString(msg.ExpectedFee)
+	if !ok {
+		return nil, types.ErrExpectedFeeNotMet
+	}
 	orderFee := demandOrder.GetFeeAmount()
 	if !orderFee.Equal(expectedFee) {
 		return nil, types.ErrExpectedFeeNotMet


### PR DESCRIPTION
## Summary
Propagate the error from `sdk.NewIntFromString(msg.ExpectedFee)` in EIBC `FulfillOrder`. Previously the error was silently discarded, allowing fulfillment with zero or invalid expected fee.

## Root Cause
`x/eibc/keeper/msg_server.go:42`:
```go
expectedFee, _ := sdk.NewIntFromString(msg.ExpectedFee)
```
The `_` discards the error. If `msg.ExpectedFee` is invalid (empty, non-numeric), `expectedFee` defaults to `0`. The subsequent `orderFee.Equal(expectedFee)` check is then bypassed when the order has a non-zero fee.

## Fix
```go
expectedFee, ok := sdk.NewIntFromString(msg.ExpectedFee)
if !ok {
    return nil, types.ErrExpectedFeeNotMet
}
```

Closes #581