### PR TITLE
fix(gravity): atomic batch cancellation with CacheContext

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -189,13 +189,19 @@ func (k Keeper) CancelOutgoingTxBatch(ctx sdk.Context, contractAddress string, b
 	if batch == nil {
 		return types.ErrUnknown
 	}
+
+	// Use cache context for atomicity: all txs must be added back before
+	// any state change is committed. Prevents partial state corruption where
+	// some txs end up in unbatched pool while batch still exists.
+	cacheCtx, writeCache := ctx.CacheContext()
 	for _, tx := range batch.Transactions {
-		if err := k.AddUnbatchedTx(ctx, tx); err != nil {
+		if err := k.AddUnbatchedTx(cacheCtx, tx); err != nil {
 			return errorsmod.Wrapf(err, "unable to add batched transaction back into pool %v", tx)
 		}
 	}
 
-	// Delete batch since it is finished
+	// All txs added successfully - commit the atomic state changes
+	writeCache()
 	k.DeleteBatch(ctx, batch)
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(


### PR DESCRIPTION
## Summary
Wrap `CancelOutgoingTxBatch` in `ctx.CacheContext()` to ensure atomic state transitions. Previously if `AddUnbatchedTx` failed midway through re-queuing batched transactions, some txs were already committed back to the unbatched pool while others were not, leaving the batch in a corrupted state.

## Root Cause
`x/gravity/keeper/batch.go:189-195`: The loop iterates over batch transactions and calls `AddUnbatchedTx` one by one. Each call commits individually. If one fails after several succeeded, the successfully-added ones are already committed and cannot be rolled back.

## Fix
Use `ctx.CacheContext()` so all `AddUnbatchedTx` calls are staged in a cache, and only committed when the entire loop succeeds:
```go
cacheCtx, writeCache := ctx.CacheContext()
for _, tx := range batch.Transactions {
    if err := k.AddUnbatchedTx(cacheCtx, tx); err != nil {
        return errorsmod.Wrapf(err, "unable to add batched transaction back into pool %v", tx)
    }
}
writeCache()
k.DeleteBatch(ctx, *batch)
```

Closes #584