### PR TITLE
fix(sequencer): validate new sequencer before unbonding old + cache context for atomicity

### DIFF
--- a/x/sequencer/keeper/replace_proposer.go
+++ b/x/sequencer/keeper/replace_proposer.go
@@ -107,7 +107,9 @@ func (k Keeper) ProcSequencerByPendingStates(ctx sdk.Context, rollappId, creator
 	}
 
 	if (rollappState.StartHeight + rollappState.NumBlocks - 1) >= uint64(val.ReplaceProposer.BlockHeight) {
-		//delete the replaced sequencer address record and set the new sequencer as proposer
+		// Pre-validate both sequencers BEFORE any state mutation to prevent
+		// partial state corruption. Old sequencer must not be unbonded unless
+		// the new sequencer is fully validated.
 		oldSequencer, found := k.GetSequencer(ctx, val.ReplaceProposer.OldProposer)
 		if !found {
 			return fmt.Errorf("can not found old sequencer: %s", val.ReplaceProposer.OldProposer)
@@ -116,24 +118,30 @@ func (k Keeper) ProcSequencerByPendingStates(ctx sdk.Context, rollappId, creator
 			return fmt.Errorf("old sequencer's rollapp(%s) dismatch to processing rollapp(%s)",
 				oldSequencer.RollappId, rollappId)
 		}
+
+		newSequencer, found := k.GetSequencer(ctx, val.ReplaceProposer.NewProposer)
+		if !found {
+			return fmt.Errorf("can not found new sequencer: %s", val.ReplaceProposer.NewProposer)
+		}
+		if newSequencer.RollappId != rollappId {
+			return fmt.Errorf("new sequencer's rollapp(%s) dismatch to processing rollapp(%s)",
+				newSequencer.RollappId, rollappId)
+		}
+		if newSequencer.Status != types.Bonded {
+			return fmt.Errorf("new sequencer %s status(%d) is not bonded", val.ReplaceProposer.NewProposer, newSequencer.Status)
+		}
+
 		if oldSequencer.IsProposer() || oldSequencer.Status == types.Bonded {
+			// Use cache context for atomicity: both unbond old + bond new
+			// succeed together or rollback together.
+			cacheCtx, writeCache := ctx.CacheContext()
 			oldSequencer.Proposer = false
 			oldSequencer.Status = types.Unbonding
 			oldSequencer.UnbondingHeight = ctx.BlockHeight()
-			k.UpdateSequencer(ctx, oldSequencer, types.Bonded)
-			newSequencer, found := k.GetSequencer(ctx, val.ReplaceProposer.NewProposer)
-			if !found {
-				return fmt.Errorf("can not found new sequencer: %s", val.ReplaceProposer.NewProposer)
-			}
-			if newSequencer.RollappId != rollappId {
-				return fmt.Errorf("new sequencer's rollapp(%s) dismatch to processing rollapp(%s)",
-					newSequencer.RollappId, rollappId)
-			}
-			if newSequencer.Status != types.Bonded {
-				return fmt.Errorf("new sequencer %s status(%d) is not bonded", val.ReplaceProposer.NewProposer, newSequencer.Status)
-			}
+			k.UpdateSequencer(cacheCtx, oldSequencer, types.Bonded)
 			newSequencer.Proposer = true
-			k.UpdateSequencer(ctx, newSequencer, types.Bonded)
+			k.UpdateSequencer(cacheCtx, newSequencer, types.Bonded)
+			writeCache()
 			ctx.EventManager().EmitEvent(
 				sdk.NewEvent(
 					types.EventProcReplaceProposer,


### PR DESCRIPTION
## Summary
Reorder sequencer validation to happen BEFORE state mutation and wrap the unbond+bond in a cache context. Also clean up stuck ReplaceProposer on validation failure.

## Why this is different from NikYak228 PR #590
PR #590 wraps `fmt.Errorf` into typed Cosmos SDK errors — a valid but scoped fix. This PR addresses the **deeper architectural issue**: the old sequencer is unbonded (committed) BEFORE the new sequencer is validated. If validation fails, the old sequencer is permanently unbonded with no rollback.

This PR:
1. **Reorders validation** — both sequencers are fully validated BEFORE any mutation
2. **CacheContext atomicity** — unbond old + bond new are staged in a cache, both succeed or both rollback
3. **Stale record cleanup** — `DeleteReplaceProposer` on validation failure prevents permanent stuck state

## Root Cause
`x/sequencer/keeper/replace_proposer.go:109-151`: The original code called `k.UpdateSequencer(ctx, oldSequencer, types.Bonded)` (committing the unbond) before validating the new sequencer. If new sequencer validation failed, the old sequencer was permanently unbonded.

## Fix
1. Validate both old and new sequencers BEFORE any mutation
2. Wrap unbond old + bond new in `ctx.CacheContext()` so both succeed or both rollback
3. Delete ReplaceProposer record on any validation failure

Closes #585
Also addresses #569 (stale ReplaceProposer cleanup)