### PR TITLE
fix(megroup): remove uncapped admin reward per join

### DIFF
--- a/x/megroup/keeper/msg_server_join_group.go
+++ b/x/megroup/keeper/msg_server_join_group.go
@@ -84,12 +84,9 @@ func (k msgServer) JoinGroup(goCtx context.Context, msg *types.MsgJoinGroup) (*t
 			return nil, errors.Wrap(types.ErrProcData, fmt.Sprintf("transfer rewards coins error. err = %s,fromAddr = %s,toAddr = %s",
 				err.Error(), region.GetRegionTreasureAddr(), msg.ApplicantAddress))
 		}
-		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()),
-			sdk.MustAccAddressFromBech32(groupInfo.Admin), sdk.NewCoins(rewardsCoin), fmt.Sprintf("JoinGroup_SendAdminRewards_%s", region.RegionId))
-		if err != nil {
-			return nil, errors.Wrap(types.ErrProcData, fmt.Sprintf("transfer rewards coins error. err = %s,fromAddr = %s,toAddr = %s",
-				err.Error(), region.GetRegionTreasureAddr(), groupInfo.Admin))
-		}
+			// Admin reward removed: unlimited per-join reward with no cap allows
+		// a malicious admin to drain the region treasury via repeated join/leave.
+		// The applicant reward alone is sufficient incentive.
 		ctx.EventManager().EmitEvent(sdk.NewEvent(types.EvtJoinGroupReward,
 			sdk.NewAttribute("applicant", msg.ApplicantAddress),
 			sdk.NewAttribute("admin", groupInfo.Admin),


### PR DESCRIPTION
## Summary
Remove the uncapped admin reward in `JoinGroup`. Previously each join sent 1 MEC from region treasury to the group admin with no cap, allowing a malicious admin to drain the treasury via multiple fake account joins.

## Root Cause
`x/megroup/keeper/msg_server_join_group.go:87-90`: `SendCoinsWithTag` sends 1 MEC (1000000 ume) from region treasury to `groupInfo.Admin` on every `JoinGroup` call. There is no cap on how many times this can be triggered.

## Fix
Remove the `SendCoinsWithTag` admin reward call. The applicant reward is sufficient incentive for group admins.

Closes #586