### PR TITLE
fix(wstaking): call SetInviterReward after sending invite reward

### DIFF
--- a/x/wstaking/keeper/invite_reward.go
+++ b/x/wstaking/keeper/invite_reward.go
@@ -38,6 +38,7 @@ func (k Keeper) SendInviteReward(ctx sdk.Context, inviter, invitee, regionId str
 			sdk.NewAttribute(types.AttributeKeyKycInviterReward, types.InviteReward.String()),
 		),
 	)
+	k.SetInviterReward(ctx, invitee)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Add missing `SetInviterReward(ctx, invitee)` call after sending invite reward in `SendInviteReward`.

## Root Cause
`x/wstaking/keeper/invite_reward.go`: `SendInviteReward()` checks `HasInviterReward(invitee)` to prevent duplicate payments, but `SetInviterReward(invitee)` is never called after sending the reward. The function exists (line 45) but has zero call sites — confirmed by full-repo grep. `HasInviterReward` always returns `false`, allowing unlimited reward claims for the same invitee.

## Impact
- **Severity**: Critical — direct treasury drain, no rate limit or cap
- Every KYC approval at level >= 2 for the same invitee sends `InviteReward` from region treasury
- Attacker can re-approve the same invitee repeatedly to drain treasury

## Fix
One line: `k.SetInviterReward(ctx, invitee)` after the event emission, before `return nil`.

Closes #605
