### PR TITLE
fix(wstaking): error on insufficient DelegateInterest in sendKycRewards

### DIFF
--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -192,9 +192,10 @@ func (k Keeper) sendKycRewards(ctx sdk.Context, delAddr sdk.AccAddress, validato
 				return err
 			}
 		}
-		if experienceRegion.DelegateInterest.GTE(interest) {
-			experienceRegion.DelegateInterest = experienceRegion.DelegateInterest.Sub(interest)
+		if experienceRegion.DelegateInterest.LT(interest) {
+			return fmt.Errorf("experience region DelegateInterest insufficient: %s < %s", experienceRegion.DelegateInterest.String(), interest.String())
 		}
+		experienceRegion.DelegateInterest = experienceRegion.DelegateInterest.Sub(interest)
 		experienceRegion.DelegateAmount = experienceRegion.DelegateAmount.Sub(delegation.UnMeidAmount)
 		k.SetRegion(ctx, experienceRegion)
 


### PR DESCRIPTION
## Summary
Replace silent skip with explicit error when `DelegateInterest < interest` in `sendKycRewards`. Previously, if `experienceRegion.DelegateInterest` was less than the calculated interest, the bank transfer still succeeded but `DelegateInterest` was not decremented — causing treasury accounting drift.

## Root Cause
`x/wstaking/keeper/kyc_reward.go:195-197` — the `GTE` guard silently skips the decrement but does not prevent the bank send. This is the same bug pattern as #519 but in the KYC **approval** path (`sendKycRewards` called from `KycReward`), not the remove/transfer path.

## Fix
Replace conditional decrement with an explicit insufficient-balance error check.

Closes #607
