### PR TITLE
fix(wstaking): validate region DelegateInterest balance before KYC reward settlements (#519)

### DIFF
--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -106,6 +106,11 @@ func (k Keeper) RemoveKycReward(ctx sdk.Context, account sdk.AccAddress, regionI
 		return types.ErrCalculateInterest.Wrap(err.Error())
 	}
 
+	err = k.subtractDelegateInterest(&region, rewards)
+	if err != nil {
+		return fmt.Errorf("settle interest error: %v", err)
+	}
+
 	// settle interest
 	err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
 		sdk.MustAccAddressFromBech32(region.RegionTreasureAddr),
@@ -115,10 +120,6 @@ func (k Keeper) RemoveKycReward(ctx sdk.Context, account sdk.AccAddress, regionI
 	)
 	if err != nil {
 		return fmt.Errorf("settle interest error: %v", err)
-	}
-
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
 	}
 
 	if delegation.Unmovable.LTE(sdk.ZeroInt()) {
@@ -182,6 +183,10 @@ func (k Keeper) sendKycRewards(ctx sdk.Context, delAddr sdk.AccAddress, validato
 		}
 		// add coins to user account
 		if interest.GT(sdk.ZeroDec()) {
+			err = k.subtractDelegateInterest(&experienceRegion, interest)
+			if err != nil {
+				return err
+			}
 			err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
 				sdk.MustAccAddressFromBech32(experienceRegion.RegionTreasureAddr),
 				sdk.MustAccAddressFromBech32(delegation.DelegatorAddress),
@@ -191,9 +196,6 @@ func (k Keeper) sendKycRewards(ctx sdk.Context, delAddr sdk.AccAddress, validato
 			if err != nil {
 				return err
 			}
-		}
-		if experienceRegion.DelegateInterest.GTE(interest) {
-			experienceRegion.DelegateInterest = experienceRegion.DelegateInterest.Sub(interest)
 		}
 		experienceRegion.DelegateAmount = experienceRegion.DelegateAmount.Sub(delegation.UnMeidAmount)
 		k.SetRegion(ctx, experienceRegion)
@@ -425,8 +427,9 @@ func (k Keeper) transferUnRegisterMeid(ctx sdk.Context, delAddr sdk.AccAddress, 
 		return amount, err
 	}
 
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
+	err = k.subtractDelegateInterest(region, rewards)
+	if err != nil {
+		return amount, err
 	}
 
 	if delegation.Unmovable.LTE(sdk.ZeroInt()) {
@@ -451,4 +454,12 @@ func (k Keeper) transferUnRegisterMeid(ctx sdk.Context, delAddr sdk.AccAddress, 
 		),
 	})
 	return amount, nil
+}
+
+func (k Keeper) subtractDelegateInterest(region *types.Region, rewards sdk.Dec) error {
+	if region.DelegateInterest.LT(rewards) {
+		return fmt.Errorf("insufficient delegate interest in region %s: %s < %s", region.RegionId, region.DelegateInterest, rewards)
+	}
+	region.DelegateInterest = region.DelegateInterest.Sub(rewards)
+	return nil
 }

--- a/x/wstaking/keeper/kyc_reward_test.go
+++ b/x/wstaking/keeper/kyc_reward_test.go
@@ -312,3 +312,35 @@ func (s *KeeperTestSuite) TestRemoveKycReward_WithFixedDeposit() {
 	err = s.Keeper().RemoveKycReward(s.Ctx, userAccount, s.usaValidator.Description.RegionID)
 	s.Require().ErrorContains(err, types.ErrRemoveKyc.Error())
 }
+
+func (s *KeeperTestSuite) TestRemoveKycReward_InsufficientDelegateInterest() {
+	s.SetupTest()
+
+	newRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            "USA",
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	kycAccount := sdk.MustAccAddressFromBech32(s.Dao.DevOperator)
+	inviter, _ := s.NewAccount()
+	err = s.Keeper().KycReward(s.Ctx, inviter, s.usaValidator.Description.RegionID, s.Dao.GlobalDao)
+	s.Require().NoError(err)
+
+	// Artificially set USA region's DelegateInterest to 0
+	region, found := s.Keeper().GetRegion(s.Ctx, "usa")
+	s.Require().True(found)
+	region.DelegateInterest = sdk.ZeroDec()
+	s.Keeper().SetRegion(s.Ctx, region)
+
+	// Remove KYC should error due to insufficient delegate interest
+	err = s.Keeper().RemoveKycReward(s.Ctx, kycAccount, s.usaValidator.Description.RegionID)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "insufficient delegate interest")
+}


### PR DESCRIPTION
This PR fixes a bug where KYC reward remove/transfer and approval settlements paid out interest from the region treasury without validating that the region's tracked `DelegateInterest` ledger balance is sufficient. This resulted in ledger divergence and tracking drift.