### PR TITLE
[BUG BOUNTY] fix(wstaking): validate fixed deposit interest rate range on update (#532)

### DIFF
--- a/x/wstaking/keeper/msg_server_fixed_deposit_cfg.go
+++ b/x/wstaking/keeper/msg_server_fixed_deposit_cfg.go
@@ -6,6 +6,19 @@ import (
 	"github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 
+func validateFixedDepositCfgRate(rate sdk.Dec) error {
+	if !rate.IsPositive() {
+		return types.ErrFixedDepositConfigRateInvalid.Wrapf("rate must be > 0 (%s)", rate.String())
+	}
+
+	minRate := sdk.MustNewDecFromStr("0.0001")
+	maxRate := sdk.MustNewDecFromStr("10000")
+	if rate.LT(minRate) || rate.GT(maxRate) {
+		return types.ErrFixedDepositConfigRateInvalid.Wrapf("rate(%s) out of range [0.0001, 10000]", rate.String())
+	}
+	return nil
+}
+
 func (k MsgServer) NewFixedDepositCfg(goCtx context.Context, msg *types.MsgNewFixedDepositCfg) (*types.MsgNewFixedDepositCfgResp, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -22,15 +35,8 @@ func (k MsgServer) NewFixedDepositCfg(goCtx context.Context, msg *types.MsgNewFi
 		return nil, types.ErrAddFixedDepositConfig.Wrapf("add fixed deposit config error, term is not positive 0 (%d)", msg.Term)
 	}
 
-	if !msg.Rate.IsPositive() {
-		return nil, types.ErrAddFixedDepositConfig.Wrapf("add fixed deposit config error, rate is not positive 0 (%s)", msg.Rate.String())
-	}
-
-	minRate := sdk.MustNewDecFromStr("0.0001")
-	maxRate := sdk.MustNewDecFromStr("10000")
-	if msg.Rate.LT(minRate) || msg.Rate.GT(maxRate) {
-		return nil, types.ErrAddFixedDepositConfig.Wrapf("add fixed deposit config rate(%s) error (%s)",
-			msg.Rate.String(), types.ErrFixedDepositConfigRateInvalid)
+	if err := validateFixedDepositCfgRate(msg.Rate); err != nil {
+		return nil, types.ErrAddFixedDepositConfig.Wrap(err)
 	}
 
 	_, ok := k.GetFixedDepositCfg(ctx, msg.RegionId, msg.Term)
@@ -99,6 +105,10 @@ func (k MsgServer) SetFixedDepositCfgRate(goCtx context.Context, msg *types.MsgS
 	config, ok := k.GetFixedDepositCfg(ctx, msg.RegionId, msg.Term)
 	if !ok {
 		return nil, types.ErrSetFixedDepositConfigRate.Wrapf("set fixed deposit config rate error (%s)", types.ErrNoFixedDepositCountOfCfgFound)
+	}
+
+	if err := validateFixedDepositCfgRate(msg.Rate); err != nil {
+		return nil, types.ErrSetFixedDepositConfigRate.Wrap(err)
 	}
 
 	config.Rate = msg.Rate

--- a/x/wstaking/keeper/msg_server_fixed_deposit_cfg_test.go
+++ b/x/wstaking/keeper/msg_server_fixed_deposit_cfg_test.go
@@ -47,11 +47,32 @@ func (s *KeeperTestSuite) TestNewFixedDepositCfg() {
 			rate:     sdk.MustNewDecFromStr("0.1"),
 			expErr:   types.ErrAddFixedDepositConfig,
 		}, {
-			name:     "invalid rate",
+			name:     "invalid rate (zero)",
 			creator:  s.Dao.GlobalDao,
 			regionId: strings.ToLower(types.MeEarthRegionName),
 			term:     1,
 			rate:     sdk.MustNewDecFromStr("0"),
+			expErr:   types.ErrAddFixedDepositConfig,
+		}, {
+			name:     "invalid rate (negative)",
+			creator:  s.Dao.GlobalDao,
+			regionId: strings.ToLower(types.MeEarthRegionName),
+			term:     1,
+			rate:     sdk.MustNewDecFromStr("-0.1"),
+			expErr:   types.ErrAddFixedDepositConfig,
+		}, {
+			name:     "invalid rate (too small)",
+			creator:  s.Dao.GlobalDao,
+			regionId: strings.ToLower(types.MeEarthRegionName),
+			term:     1,
+			rate:     sdk.MustNewDecFromStr("0.00009"),
+			expErr:   types.ErrAddFixedDepositConfig,
+		}, {
+			name:     "invalid rate (too large)",
+			creator:  s.Dao.GlobalDao,
+			regionId: strings.ToLower(types.MeEarthRegionName),
+			term:     1,
+			rate:     sdk.MustNewDecFromStr("10000.0001"),
 			expErr:   types.ErrAddFixedDepositConfig,
 		}, {
 			name:     "No error",
@@ -81,6 +102,62 @@ func (s *KeeperTestSuite) TestNewFixedDepositCfg() {
 				s.Require().Equal(int64(1), cfg.RegionFixedDepositCfgs[0].RegionFixedDepositCfg[0].Term)
 				s.Require().True(cfg.RegionFixedDepositCfgs[0].RegionFixedDepositCfg[0].Rate.Equal(sdk.MustNewDecFromStr("0.1")))
 			}
+		})
+	}
+}
+
+func (s *KeeperTestSuite) TestSetFixedDepositCfgRateRejectsInvalidRates() {
+	s.SetupTest()
+
+	newRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            types.MeEarthRegionName,
+		OperatorAddress: s.meEarthValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	newCfg := types.MsgNewFixedDepositCfg{
+		Dao:      s.Dao.GlobalDao,
+		RegionId: strings.ToLower(types.MeEarthRegionName),
+		Term:     1,
+		Rate:     sdk.MustNewDecFromStr("0.1"),
+	}
+	_, err = s.msgServer.NewFixedDepositCfg(s.Ctx, &newCfg)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name string
+		rate sdk.Dec
+	}{
+		{
+			name: "negative rate",
+			rate: sdk.MustNewDecFromStr("-0.1"),
+		},
+		{
+			name: "zero rate",
+			rate: sdk.ZeroDec(),
+		},
+		{
+			name: "too small rate",
+			rate: sdk.MustNewDecFromStr("0.00009"),
+		},
+		{
+			name: "too large rate",
+			rate: sdk.MustNewDecFromStr("10000.0001"),
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			_, err := s.msgServer.SetFixedDepositCfgRate(s.Ctx, &types.MsgSetFixedDepositCfgRate{
+				Admin:    s.Dao.GlobalDao,
+				RegionId: strings.ToLower(types.MeEarthRegionName),
+				Term:     1,
+				Rate:     tc.rate,
+			})
+			s.Require().Error(err)
+			s.Require().ErrorIs(err, types.ErrSetFixedDepositConfigRate)
 		})
 	}
 }


### PR DESCRIPTION
This PR introduces interest rate range and positivity validation (bounds of [0.0001, 10000]) when updating fixed deposit configurations via `SetFixedDepositCfgRate`, preventing zero, negative, or excessive rates that would drain the region treasury upon staker deposits.

Closes https://github.com/openmetaearth/me-hub/issues/517
Closes https://github.com/openmetaearth/me-hub/issues/532
Closes https://github.com/openmetaearth/me-hub/issues/199