### PR TITLE
fix: reject oversized EIP155 rollapp ids

### DIFF
--- a/x/rollapp/types/chain_id.go
+++ b/x/rollapp/types/chain_id.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"regexp"
 	"strconv"
@@ -76,6 +77,9 @@ func getEIP155ID(chainID string) (*big.Int, error) {
 	chainIDInt, ok := new(big.Int).SetString(matches[2], 10)
 	if !ok {
 		return nil, errorsmod.Wrapf(ErrInvalidRollappID, "epoch %s must be base-10 integer format", matches[2])
+	}
+	if chainIDInt.BitLen() > 64 {
+		return nil, errorsmod.Wrapf(ErrInvalidRollappID, "EIP155 id %s exceeds uint64 max %d", matches[2], uint64(math.MaxUint64))
 	}
 
 	return chainIDInt, nil

--- a/x/rollapp/types/chain_id_test.go
+++ b/x/rollapp/types/chain_id_test.go
@@ -1,0 +1,25 @@
+package types
+
+import "testing"
+
+func TestNewChainIDRejectsEIP155AboveUint64(t *testing.T) {
+	_, err := NewChainID("evil_18446744073709551616-1")
+	if err == nil {
+		t.Fatal("expected EIP155 chain id above uint64 max to be rejected")
+	}
+}
+
+func TestNewChainIDAcceptsMaxUint64EIP155(t *testing.T) {
+	chainID, err := NewChainID("max_18446744073709551615-1")
+	if err != nil {
+		t.Fatalf("expected max uint64 EIP155 chain id to be accepted: %v", err)
+	}
+
+	if !chainID.IsEIP155() {
+		t.Fatal("expected chain id to be detected as EIP155")
+	}
+
+	if got := chainID.GetEIP155ID(); got != 18446744073709551615 {
+		t.Fatalf("expected max uint64 EIP155 id, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes the RollApp EIP155 secondary-index truncation described in #306.
- Rejects EIP155 numeric components that do not fit in `uint64` before any `big.Int.Uint64()` conversion can silently truncate them.
- Keeps the existing `uint64` index key format unchanged for valid EIP155 IDs.

## Scope alignment
Issue #306 specifically reports that `types.NewChainID()` accepts arbitrary-size EIP155 integers, while `ChainID.GetEIP155ID()` later converts them with `Uint64()` for `RollappByEIP155Key(...)`. This patch addresses that exact boundary: oversized values are rejected during chain-id parsing, so the keeper never receives a truncated EIP155 index.

## Tests
Added focused regression coverage for:
- `2^64` / `18446744073709551616` being rejected.
- `uint64` max / `18446744073709551615` still being accepted and returned unchanged.

## Validation
- `/home/adjie/.hermes/toolchains/go/bin/go test ./x/rollapp/types -run 'TestNewChainIDRejectsEIP155AboveUint64|TestNewChainIDAcceptsMaxUint64EIP155'`
- `/home/adjie/.hermes/toolchains/go/bin/go test ./x/rollapp/types`
- `git diff --check`

Fixes #306
