### PR TITLE
fix: bind DID credentials to original issuer

### DIFF
--- a/x/did/keeper/credential.go
+++ b/x/did/keeper/credential.go
@@ -83,9 +83,25 @@ func (k Keeper) SetCredential(ctx sdk.Context, did, sid string, credential types
 	store.Set(types.GetCredentialKey(did, sid), k.cdc.MustMarshal(&credential))
 }
 
+func (k Keeper) GetCredentialIssuer(ctx sdk.Context, did, sid string) (issuer string, found bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.GetCredentialIssuerKey(did, sid))
+	if bz == nil {
+		return "", false
+	}
+
+	return string(bz), true
+}
+
+func (k Keeper) SetCredentialIssuer(ctx sdk.Context, did, sid, issuer string) {
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.GetCredentialIssuerKey(did, sid), []byte(issuer))
+}
+
 func (k Keeper) DeleteCredential(ctx sdk.Context, did, sid string) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetCredentialKey(did, sid))
+	store.Delete(types.GetCredentialIssuerKey(did, sid))
 }
 
 func (k Keeper) IteratorCredentialsByFilter(ctx sdk.Context, sid string, filter []byte, cb func(delegation types.Credential) (stop bool)) {

--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -163,6 +163,7 @@ func (m msgServer) CreateVC(goCtx context.Context, msg *types.MsgCreateVC) (*typ
 	// create VC
 	vc := msg.GetCredential()
 	m.SetCredential(ctx, msg.Did, msg.Sid, vc)
+	m.SetCredentialIssuer(ctx, msg.Did, msg.Sid, issuer)
 
 	// add filters to VC
 	m.AddFilters(ctx, msg.Did, msg.Sid, msg.Filters, vc)
@@ -193,6 +194,9 @@ func (m msgServer) UpdateVC(goCtx context.Context, msg *types.MsgUpdateVC) (*typ
 	issuerInfo, found := m.GetDidInfo(ctx, issuer)
 	if !found || issuerInfo.Status != types.DID_STATUS_ACTIVE {
 		return &types.MsgUpdateVCResponse{}, types.ErrIssuerNotActive
+	}
+	if credentialIssuer, found := m.GetCredentialIssuer(ctx, msg.Did, msg.Sid); found && credentialIssuer != issuer {
+		return &types.MsgUpdateVCResponse{}, types.ErrInvalidIssuer
 	}
 
 	// check holder

--- a/x/did/keeper/msg_server_vc_issuer_test.go
+++ b/x/did/keeper/msg_server_vc_issuer_test.go
@@ -1,0 +1,75 @@
+package keeper_test
+
+import (
+	"testing"
+
+	secp256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/testutil/keeper"
+	didkeeper "github.com/openmetaearth/me-hub/x/did/keeper"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	"github.com/stretchr/testify/require"
+)
+
+func didTestAddress(seed byte) sdk.AccAddress {
+	priv := secp256k1.GenPrivKeyFromSecret([]byte{seed})
+	return sdk.AccAddress(priv.PubKey().Address())
+}
+
+func TestUpdateVCRejectsDifferentActiveIssuer(t *testing.T) {
+	k, ctx := keeper.DidKeeper(t)
+	msgServer := didkeeper.NewMsgServerImpl(k)
+
+	issuerAAddr := didTestAddress(1)
+	issuerBAddr := didTestAddress(2)
+	issuerADid := "1000000000001"
+	issuerBDid := "1000000000002"
+	holderDid := "1000000000003"
+	sid := "kyc"
+
+	k.SetDID(ctx, issuerAAddr, issuerADid)
+	k.SetDID(ctx, issuerBAddr, issuerBDid)
+	k.SetDidInfo(ctx, issuerADid, didtypes.NewDidInfo(issuerADid, issuerAAddr.String(), "", didtypes.DID_STATUS_ACTIVE))
+	k.SetDidInfo(ctx, issuerBDid, didtypes.NewDidInfo(issuerBDid, issuerBAddr.String(), "", didtypes.DID_STATUS_ACTIVE))
+	k.SetDidInfo(ctx, holderDid, didtypes.NewDidInfo(holderDid, "", "", didtypes.DID_STATUS_ACTIVE))
+	k.SetService(ctx, sid, didtypes.NewService(sid, "KYC", "test service", didtypes.SERVICE_STATUS_ACTIVE, []string{issuerADid, issuerBDid}))
+
+	goCtx := sdk.WrapSDKContext(ctx)
+	_, err := msgServer.CreateVC(goCtx, didtypes.NewMsgCreateVC(issuerAAddr.String(), holderDid, sid, "hash-from-issuer-a", "ipfs://issuer-a", nil, nil))
+	require.NoError(t, err)
+
+	_, err = msgServer.UpdateVC(goCtx, didtypes.NewMsgUpdateVC(issuerBAddr.String(), holderDid, sid, "hash-from-issuer-b", "ipfs://issuer-b", nil, nil))
+	require.ErrorIs(t, err, didtypes.ErrInvalidIssuer)
+
+	vc, found := k.GetCredential(ctx, holderDid, sid)
+	require.True(t, found)
+	require.Equal(t, "hash-from-issuer-a", vc.Hash)
+	require.Equal(t, "ipfs://issuer-a", vc.Uri)
+}
+
+func TestUpdateVCAllowsOriginalIssuer(t *testing.T) {
+	k, ctx := keeper.DidKeeper(t)
+	msgServer := didkeeper.NewMsgServerImpl(k)
+
+	issuerAddr := didTestAddress(1)
+	issuerDid := "1000000000001"
+	holderDid := "1000000000003"
+	sid := "kyc"
+
+	k.SetDID(ctx, issuerAddr, issuerDid)
+	k.SetDidInfo(ctx, issuerDid, didtypes.NewDidInfo(issuerDid, issuerAddr.String(), "", didtypes.DID_STATUS_ACTIVE))
+	k.SetDidInfo(ctx, holderDid, didtypes.NewDidInfo(holderDid, "", "", didtypes.DID_STATUS_ACTIVE))
+	k.SetService(ctx, sid, didtypes.NewService(sid, "KYC", "test service", didtypes.SERVICE_STATUS_ACTIVE, []string{issuerDid}))
+
+	goCtx := sdk.WrapSDKContext(ctx)
+	_, err := msgServer.CreateVC(goCtx, didtypes.NewMsgCreateVC(issuerAddr.String(), holderDid, sid, "hash-original", "ipfs://original", nil, nil))
+	require.NoError(t, err)
+
+	_, err = msgServer.UpdateVC(goCtx, didtypes.NewMsgUpdateVC(issuerAddr.String(), holderDid, sid, "hash-updated", "ipfs://updated", nil, nil))
+	require.NoError(t, err)
+
+	vc, found := k.GetCredential(ctx, holderDid, sid)
+	require.True(t, found)
+	require.Equal(t, "hash-updated", vc.Hash)
+	require.Equal(t, "ipfs://updated", vc.Uri)
+}

--- a/x/did/types/keys.go
+++ b/x/did/types/keys.go
@@ -27,9 +27,10 @@ var (
 	IssuerPrefix  = []byte{0x20}
 	ServicePrefix = []byte{0x30}
 	//ServiceIssuerPrefix   = []byte{0x31}
-	CredentialPrefix   = []byte{0x40}
-	FilterLoggerPrefix = []byte{0x50}
-	FilterPrefix       = []byte{0x51}
+	CredentialPrefix       = []byte{0x40}
+	CredentialIssuerPrefix = []byte{0x41}
+	FilterLoggerPrefix     = []byte{0x50}
+	FilterPrefix           = []byte{0x51}
 )
 
 func GetDIDKey(addr sdk.AccAddress) []byte {
@@ -58,6 +59,10 @@ func GetCredentialPrefixByDid(did string) []byte {
 
 func GetCredentialKey(did, sid string) []byte {
 	return append(GetCredentialPrefixByDid(did), sid...)
+}
+
+func GetCredentialIssuerKey(did, sid string) []byte {
+	return append(append(CredentialIssuerPrefix, did...), sid...)
 }
 
 func GetFilterLoggerKey(did, sid string) []byte {


### PR DESCRIPTION
/claim #304

Fixes #304.

## Summary
- Store the original DID issuer for each created credential in a dedicated module key.
- Reject `MsgUpdateVC` when another active issuer in the same service tries to overwrite that credential.
- Remove the issuer binding when the credential is deleted.
- Add regression coverage for both the cross-issuer overwrite denial and the original issuer update path.

## Scope alignment
This follows the issue report's root cause: existing credentials were keyed by `(holder DID, service id)` but did not retain the issuer that originally created them, so service membership alone was enough to overwrite another issuer's VC.

## Validation
- `go test ./x/did/keeper -run 'TestUpdateVCRejectsDifferentActiveIssuer|TestUpdateVCAllowsOriginalIssuer' -count=1 -v`
- `git diff --check`

## Baseline note
- `go test ./x/did -count=1` currently fails on upstream `TestInitExportGenesis` with `panic: empty address string is not allowed`; this is unrelated to the touched DID VC issuer ownership path.
