### PR TITLE
fix: validate claims by event nonce query

### DIFF
--- a/x/gravity/keeper/grpc_query.go
+++ b/x/gravity/keeper/grpc_query.go
@@ -377,6 +377,13 @@ func (k QueryServer) BatchFees(c context.Context, req *types.QueryBatchFeeReques
 }
 
 func (k QueryServer) ClaimsByEventNonce(c context.Context, req *types.QueryClaimsByEventNonceRequest) (*types.QueryClaimsByEventNonceResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	if req.EventNonce == 0 {
+		return nil, status.Error(codes.InvalidArgument, "event nonce must be positive")
+	}
+
 	attestations := []types.Attestation{}
 	k.IterateAttestationsByNonce(sdk.UnwrapSDKContext(c), req.EventNonce, func(attestation *types.Attestation) bool {
 		attestations = append(attestations, *attestation)

--- a/x/gravity/keeper/grpc_query_test.go
+++ b/x/gravity/keeper/grpc_query_test.go
@@ -2,11 +2,14 @@ package keeper_test
 
 import (
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/openmetaearth/me-hub/testutil/helpers"
 	"github.com/openmetaearth/me-hub/x/gravity/keeper"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *KeeperTestSuite) TestQueryUnbatchedTxs() {
@@ -73,4 +76,28 @@ func (s *KeeperTestSuite) TestQueryUnbatchedTxs() {
 	s.Require().Len(res.Txs, numTxs-pageLimit)
 	s.Require().NotNil(res.Pagination)
 	s.Require().Nil(res.Pagination.NextKey)
+}
+
+func (s *KeeperTestSuite) TestClaimsByEventNonceRejectsInvalidRequests() {
+	queryServer := keeper.NewQueryServerImpl(s.Keeper())
+
+	_, err := queryServer.ClaimsByEventNonce(s.Ctx, nil)
+	s.Require().Error(err)
+	s.Require().Equal(codes.InvalidArgument, status.Code(err))
+
+	_, err = queryServer.ClaimsByEventNonce(s.Ctx, &types.QueryClaimsByEventNonceRequest{})
+	s.Require().Error(err)
+	s.Require().Equal(codes.InvalidArgument, status.Code(err))
+	s.Require().ErrorContains(err, "event nonce must be positive")
+}
+
+func (s *KeeperTestSuite) TestClaimsByEventNonceAllowsPositiveNonce() {
+	queryServer := keeper.NewQueryServerImpl(s.Keeper())
+
+	res, err := queryServer.ClaimsByEventNonce(s.Ctx, &types.QueryClaimsByEventNonceRequest{
+		EventNonce: 1,
+	})
+
+	s.Require().NoError(err)
+	s.Require().Empty(res.Claims)
 }


### PR DESCRIPTION
/claim #242

Fixes #242.

## Summary

- Reject nil `ClaimsByEventNonce` requests with `InvalidArgument` instead of dereferencing `req`.
- Reject `EventNonce == 0` before iterating attestations, matching the positive nonce requirement used by nearby Gravity query handlers.
- Keep positive nonce queries on the existing attestation iteration path.
- Add regression coverage for nil, zero nonce, and positive empty-result requests.

## Tests

```bash
gofmt -w x/gravity/keeper/grpc_query.go x/gravity/keeper/grpc_query_test.go
go test ./x/gravity/keeper -run "TestGravityKeeperTestSuite/TestClaimsByEventNonce" -count=1 -v
go test ./x/gravity/keeper -run "TestGravityKeeperTestSuite/Test(ClaimsByEventNonce|QueryUnbatchedTxs)" -count=1 -v
go test ./x/gravity/types -count=1
git diff --check
git diff --cached --check
```