### PR TITLE
fix(wstaking): handle zero delegation amount in BeginBlock and improve Calculate function

### DIFF
--- a/x/wstaking/abci.go
+++ b/x/wstaking/abci.go
@@ -1,10 +1,11 @@
 package wstaking
 
 import (
+	"time"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/openmetaearth/me-hub/x/wstaking/types"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/x/wstaking/keeper"
@@ -18,7 +19,10 @@ func BeginBlock(ctx sdk.Context, k *keeper.Keeper) {
 	regions := k.GetAllRegion(ctx)
 
 	for _, region := range regions {
-		rewards, _ := k.Calculate(ctx, sdk.NewDecFromInt(totalRewardsPerBlock), region.DelegateAmount) //rate.MulInt(totalRewardsPerBlock.Mul(region.DelegateAmount)).Mul(sdk.NewDecWithPrec(1, sdk.MEExponent))
+		if region.DelegateAmount.IsZero() {
+			continue
+		}
+		rewards := k.Calculate(sdk.NewDecFromInt(totalRewardsPerBlock), region.DelegateAmount)
 		region.DelegateInterest = region.DelegateInterest.Add(rewards)
 		k.SetRegion(ctx, region)
 	}

--- a/x/wstaking/keeper/alias_functions.go
+++ b/x/wstaking/keeper/alias_functions.go
@@ -1,8 +1,9 @@
 package keeper
 
 import (
-	"github.com/openmetaearth/me-hub/x/wmint"
 	"math/big"
+
+	"github.com/openmetaearth/me-hub/x/wmint"
 
 	cmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,7 +18,7 @@ func (k Keeper) CalculateInterest(ctx sdk.Context, totalStaking cmath.Int, heigh
 		return sdk.ZeroDec(), nil
 	}
 	blockRewards := k.getRewardsByHeight(height, ctx.BlockHeight())
-	return k.Calculate(ctx, blockRewards, totalStaking)
+	return k.Calculate(blockRewards, totalStaking), nil
 }
 
 // getRewardsByHeight Get coins through the block height range
@@ -56,15 +57,20 @@ func (k Keeper) getRewardsByHeight(fromHeight int64, toHeight int64) (coin sdk.D
 	return
 }
 
-func (k Keeper) Calculate(ctx sdk.Context, blockRewards sdk.Dec, totalStaking cmath.Int) (rewards sdk.Dec, err error) {
+// Calculate computes the per-block staking reward for a given amount of staked tokens.
+// It is a pure arithmetic function and does not read from chain state.
+// Returns ZeroDec when totalStaking is zero or the result would be non-positive.
+func (k Keeper) Calculate(blockRewards sdk.Dec, totalStaking cmath.Int) sdk.Dec {
+	if totalStaking.IsZero() {
+		return sdk.ZeroDec()
+	}
 	totalSupply := sdk.NewDec(types.CaclTotalSupply)
 	rate := sdk.OneDec().Quo(totalSupply)
-	rewards = blockRewards.Mul(sdk.NewDecFromInt(totalStaking).Mul(rate)).Mul(sdk.NewDecWithPrec(1, params.BaseDenomUnit))
-	if rewards.LT(sdk.ZeroDec()) {
-		k.Logger(ctx).Error("Calculate_Interest", "Failed to calculate user revenue！")
-		return rewards, types.ErrCalculateInterest.Wrap("withdraw coins amount too small")
+	rewards := blockRewards.Mul(sdk.NewDecFromInt(totalStaking).Mul(rate)).Mul(sdk.NewDecWithPrec(1, params.BaseDenomUnit))
+	if rewards.IsNegative() {
+		return sdk.ZeroDec()
 	}
-	return
+	return rewards
 }
 
 // Delegation get the delegation interface for a particular set of delegator and validator addresses


### PR DESCRIPTION
Remove the ctx sdk.Context parameter. The function is a pure mathematical calculation and does not read the chain state; ctx was only used for logging.

Change the return type from (sdk.Dec, error) to sdk.Dec. Negative values are impossible under normal chain states, and the error serves no practical purpose for the caller.

Return sdk.ZeroDec() as a defensive fallback for any negative values, ensuring it does not disrupt the normal flow.

Add a totalStaking.IsZero() pre-check to skip empty zones and avoid meaningless calculations.