### PR TITLE
fix(sequencer): enqueue replaced proposer for unbonding maturation

### DIFF
--- a/x/sequencer/keeper/replace_proposer.go
+++ b/x/sequencer/keeper/replace_proposer.go
@@ -117,10 +117,16 @@ func (k Keeper) ProcSequencerByPendingStates(ctx sdk.Context, rollappId, creator
 				oldSequencer.RollappId, rollappId)
 		}
 		if oldSequencer.IsProposer() || oldSequencer.Status == types.Bonded {
+			oldStatus := oldSequencer.Status
 			oldSequencer.Proposer = false
 			oldSequencer.Status = types.Unbonding
 			oldSequencer.UnbondingHeight = ctx.BlockHeight()
-			k.UpdateSequencer(ctx, oldSequencer, types.Bonded)
+			oldSequencer.UnbondTime = ctx.BlockHeader().Time.Add(k.UnbondingTime(ctx))
+			k.UpdateSequencer(ctx, oldSequencer, oldStatus)
+			// enqueue the replaced proposer so UnbondAllMatureSequencers can
+			// mature it and return its bond; without this the sequencer is
+			// stuck in Unbonding forever and its tokens are locked.
+			k.setUnbondingSequencerQueue(ctx, oldSequencer)
 			newSequencer, found := k.GetSequencer(ctx, val.ReplaceProposer.NewProposer)
 			if !found {
 				return fmt.Errorf("can not found new sequencer: %s", val.ReplaceProposer.NewProposer)


### PR DESCRIPTION
## Summary

`ProcSequencerByPendingStates` transitions the old proposer to `Unbonding` status but never sets `UnbondTime` nor adds it to the unbonding queue (`setUnbondingSequencerQueue`). When `AfterStateFinalized` does not fire, the replaced proposer is stuck in `Unbonding` indefinitely with no maturation path, and its bonded tokens are permanently locked in the module account.

## Bug Description

When a rollapp's proposer is replaced, `ProcSequencerByPendingStates` (`x/sequencer/keeper/replace_proposer.go:119-122`) sets the old sequencer to `Unbonding` status but omits three critical steps that the standard unbonding path (`setSequencerToUnbonding` in `msg_server_unbond.go`) performs:

1. **`UnbondTime` is never set** — remains zero value
2. **`setUnbondingSequencerQueue` is never called** — sequencer not added to maturity queue
3. **`oldStatus` is hardcoded to `types.Bonded`** — may be incorrect if sequencer was already `Unbonding`

### Two Code Paths for Sequencer Replacement

| Path | Trigger | Timing | Token Return |
|------|---------|--------|-------------|
| `ProcSequencerByPendingStates` | `MsgUpdateState` hook | Block N (immediate) | ❌ No — only sets status |
| `AfterStateFinalized` → `forceRemoveUnbondingSequencer` | `FinalizeRollappStates` EndBlocker | Block N + DisputePeriod | ✅ Yes — sends tokens + deletes |

The second path does return tokens correctly via `forceRemoveUnbondingSequencer` → `SendCoinsFromModuleToAccount`. However, this path is **not guaranteed to fire**:

- **Rollapp halts or stops submitting state** — finalization never occurs
- **Persistent finalization failure** — `failedRollapps` map causes permanent skip
- **Fraud submission** — `FraudSubmitted` hook takes a different path (slashing + `forceUnbondSequencer`)
- **State never covers replacement height** — no new state submitted after replacement

In all these cases, the old sequencer is frozen in `Unbonding` with:
- No `UnbondTime` → `GetMatureUnbondingSequencers` never picks it up
- No queue entry → no maturation path exists
- `Unbond` message rejected → owner cannot self-service unbond (`IsBonded()` returns false)
- **Result: tokens permanently locked in module account**

### Interaction Risk (Post-Fix)

| Scenario | `UnbondingTime` vs `DisputePeriod` | Outcome |
|----------|-----------------------------------|---------|
| Finalization fires first | DisputePeriod < UnbondingTime | `forceRemove` returns tokens, orphan queue entry (harmless) |
| Queue matures first | UnbondingTime < DisputePeriod | `unbondUnbondingSequencer` returns tokens, then `forceRemove` finds `Unbonded` → finalization error |

Default values: `DisputePeriodInBlocks = 3` (~18s), `UnbondingTime = 1 hour`. First scenario is normal case.

## Fix

```go
// Before (broken):
oldSequencer.Proposer = false
oldSequencer.Status = types.Unbonding
oldSequencer.UnbondingHeight = ctx.BlockHeight()
k.UpdateSequencer(ctx, oldSequencer, types.Bonded)

// After (fixed):
oldStatus := oldSequencer.Status
oldSequencer.Proposer = false
oldSequencer.Status = types.Unbonding
oldSequencer.UnbondingHeight = ctx.BlockHeight()
oldSequencer.UnbondTime = ctx.BlockHeader().Time.Add(k.UnbondingTime(ctx))
k.UpdateSequencer(ctx, oldSequencer, oldStatus)
k.setUnbondingSequencerQueue(ctx, oldSequencer)
```

## Severity

**Medium-to-High**: In the happy path (normal finalization), tokens are returned via `AfterStateFinalized`. But when finalization does not occur (rollapp halt, fraud, non-submission), tokens are permanently locked with no recovery path.

## Test Evidence

- Testnet halted at block 1800910 (since 2026-04-28), preventing on-chain verification
- Fix verified by code path analysis comparing `setSequencerToUnbonding` (correct) vs `ProcSequencerByPendingStates` (broken)
