### PR TITLE
fix(gravity): add per-token supply cap for SendToMeClaim minting

### DIFF
--- a/x/gravity/keeper/attestation_handler.go
+++ b/x/gravity/keeper/attestation_handler.go
@@ -27,6 +27,19 @@ func (k Keeper) AttestationHandler(ctx sdk.Context, externalClaim types.External
 		}
 
 		mintAmount := types.GetMintCoin(claim.Amount, claim.ChainName, bridgeToken)
+
+		// Guard: enforce per-token supply cap to prevent unbounded minting
+		maxSupply, ok := sdkmath.NewIntFromString(types.MaxMintPerClaim)
+		if !ok {
+			return errorsmod.Wrap(types.ErrInvalid, "invalid MaxMintPerClaim constant")
+		}
+		newSupply := bridgeToken.Supply.Add(mintAmount.Amount)
+		if newSupply.GT(maxSupply) {
+			return errorsmod.Wrapf(types.ErrInvalid,
+				"mint would exceed supply cap: current=%s, mint=%s, cap=%s",
+				bridgeToken.Supply, mintAmount.Amount, maxSupply)
+		}
+
 		if err := k.bankKeeper.MintCoins(ctx, k.moduleName, sdk.NewCoins(mintAmount)); err != nil {
 			return errorsmod.Wrapf(err, "mint vouchers coins")
 		}

--- a/x/gravity/types/params.go
+++ b/x/gravity/types/params.go
@@ -14,6 +14,7 @@ const (
 	MaxGasLimit                = 30_000_000
 	MaxResults                 = 100
 	PowerBase           uint64 = 10000
+	MaxMintPerClaim               = "1000000000000000" // 1 quadrillion uME cap per claim
 )
 
 var (


### PR DESCRIPTION
## Summary

Adds per-token supply cap (`MaxMintPerClaim = 1 quadrillion uME`) in `SendToMeClaim` attestation handler to prevent unbounded minting if relayer set is compromised.

## Problem

`SendToMeClaim` trusted `claim.Amount` without any upper bound. `BridgeToken.Supply` tracked total minted but was never enforced. If 66.66% of relayer delegate power was compromised, unlimited unbacked tokens could be minted.

## Fix

**`x/gravity/types/params.go`** — Added `MaxMintPerClaim` constant (1 quadrillion uME)

**`x/gravity/keeper/attestation_handler.go`** — Added cap check before `MintCoins`:
```go
maxSupply, ok := sdkmath.NewIntFromString(types.MaxMintPerClaim)
if !ok {
    return errorsmod.Wrap(types.ErrInvalid, "invalid MaxMintPerClaim constant")
}
newSupply := bridgeToken.Supply.Add(mintAmount.Amount)
if newSupply.GT(maxSupply) {
    return errorsmod.Wrapf(types.ErrInvalid,
        "mint would exceed supply cap: current=%s, mint=%s, cap=%s",
        bridgeToken.Supply, mintAmount.Amount, maxSupply)
}
```

## Severity

**Low-Medium** — Requires 66.66% relayer power compromise (max 10 relayers, delegation-gated). Consequence is unlimited unbacked minting. Slashing mechanism only marks offline, does not burn delegate tokens.

Fixes #719