### PR TITLE
fix(bridgingfee): reject transfers when fee charge fails

### DIFF
--- a/x/bridgingfee/ibc_module.go
+++ b/x/bridgingfee/ibc_module.go
@@ -91,8 +91,8 @@ func (w *IBCModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 	err = w.transferKeeper.OnRecvPacket(ctx, packet, feeData.FungibleTokenPacketData)
 	if err != nil {
 		l.Error("Charge bridging fee.", "err", err)
-		// we continue as we don't want the fee charge to fail the transfer in any case
-		fee = sdk.ZeroInt()
+		err = errorsmod.Wrapf(err, "%s: charge bridging fee", ModuleName)
+		return channeltypes.NewErrorAcknowledgement(err)
 	} else {
 		ctx.EventManager().EmitEvent(
 			sdk.NewEvent(


### PR DESCRIPTION
## Summary

- Stop silently zeroing the bridging fee when the fee transfer fails.
- Return an IBC error acknowledgement instead of forwarding the full amount fee-free.
- Preserve the existing success path and bridging fee event emission.

Fixes #94.

## Verification

- `go test ./x/bridgingfee`

## Bounty/payment

If this public bug-bounty fix is eligible for a reward, payment address: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`.