### PR TITLE
fix(rollapp): preserve frozen height revision order

### DIFF
--- a/x/rollapp/keeper/fraud_handler.go
+++ b/x/rollapp/keeper/fraud_handler.go
@@ -97,7 +97,8 @@ func (k Keeper) freezeClientState(ctx sdk.Context, clientId string) error {
 		return errorsmod.Wrapf(types.ErrInvalidClientState, "client state with ID %s is not a tendermint client state", clientId)
 	}
 
-	tmClientState.FrozenHeight = clienttypes.NewHeight(tmClientState.GetLatestHeight().GetRevisionHeight(), tmClientState.GetLatestHeight().GetRevisionNumber())
+	latestHeight := tmClientState.GetLatestHeight()
+	tmClientState.FrozenHeight = clienttypes.NewHeight(latestHeight.GetRevisionNumber(), latestHeight.GetRevisionHeight())
 	k.ibcClientKeeper.SetClientState(ctx, clientId, tmClientState)
 
 	return nil


### PR DESCRIPTION
## Summary

- Preserve the IBC height field order when freezing a Tendermint client after fraud handling.
- Pass `RevisionNumber` as the first `clienttypes.NewHeight` argument and `RevisionHeight` as the second argument.

Fixes #81.

## Verification

- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestHandleFraud' -count=1`\n\nNote: `go test ./x/rollapp/keeper` currently fails on pre-existing unrelated create-rollapp/finalization tests in this checkout; the targeted fraud handler test passes.\n\n## Bounty/payment\n\nIf this public bug-bounty fix is eligible for a reward, payment address: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`.