### PR TITLE
fix(eibc): reject malformed fee amounts

### DIFF
--- a/x/eibc/keeper/msg_server.go
+++ b/x/eibc/keeper/msg_server.go
@@ -39,7 +39,10 @@ func (m msgServer) FulfillOrder(goCtx context.Context, msg *types.MsgFulfillOrde
 	}
 
 	// Check that the fulfiller expected fee is equal to the demand order fee
-	expectedFee, _ := sdk.NewIntFromString(msg.ExpectedFee)
+	expectedFee, ok := sdk.NewIntFromString(msg.ExpectedFee)
+	if !ok {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid expected fee amount: %s", msg.ExpectedFee)
+	}
 	orderFee := demandOrder.GetFeeAmount()
 	if !orderFee.Equal(expectedFee) {
 		return nil, types.ErrExpectedFeeNotMet
@@ -107,8 +110,14 @@ func (m msgServer) UpdateDemandOrder(goCtx context.Context, msg *types.MsgUpdate
 	}
 
 	// calculate the new price: transferTotal - newFee - bridgingFee
-	newFeeInt, _ := sdk.NewIntFromString(msg.NewFee)
-	transferTotal, _ := sdk.NewIntFromString(data.Amount)
+	newFeeInt, ok := sdk.NewIntFromString(msg.NewFee)
+	if !ok {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid fee amount: %s", msg.NewFee)
+	}
+	transferTotal, ok := sdk.NewIntFromString(data.Amount)
+	if !ok {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid transfer amount: %s", data.Amount)
+	}
 	newPrice, err := types.CalcPriceWithBridgingFee(transferTotal, newFeeInt, bridgingFeeMultiplier)
 	if err != nil {
 		return nil, err

--- a/x/eibc/keeper/msg_server_test.go
+++ b/x/eibc/keeper/msg_server_test.go
@@ -50,6 +50,15 @@ func (suite *KeeperTestSuite) TestMsgFulfillOrder() {
 			expectedDemandOrdefFulfillmentStatus: false,
 		},
 		{
+			name:                                 "Test demand order fulfillment - malformed expected fee",
+			demandOrderPrice:                     150,
+			demandOrderFee:                       50,
+			fulfillmentExpectedFee:               "not_a_number",
+			expectedFulfillmentError:             sdkerrors.ErrInvalidRequest,
+			eIBCdemandAddrBalance:                math.NewInt(1000),
+			expectedDemandOrdefFulfillmentStatus: false,
+		},
+		{
 			name:                                 "Test demand order fulfillment - insufficient balance same denom",
 			demandOrderPrice:                     150,
 			demandOrderFee:                       50,
@@ -222,6 +231,7 @@ func (suite *KeeperTestSuite) TestMsgUpdateDemandOrder() {
 	testCases := []struct {
 		name          string
 		newFee        sdk.Int
+		newFeeText    string
 		submittedBy   string
 		expectError   bool
 		expectedPrice sdk.Int
@@ -252,6 +262,13 @@ func (suite *KeeperTestSuite) TestMsgUpdateDemandOrder() {
 			submittedBy: eibcSupplyAddr.String(),
 			expectError: true,
 		},
+		{
+			name:        "malformed fee",
+			newFee:      sdk.ZeroInt(),
+			newFeeText:  "not_a_number",
+			submittedBy: eibcSupplyAddr.String(),
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -261,10 +278,18 @@ func (suite *KeeperTestSuite) TestMsgUpdateDemandOrder() {
 		suite.Require().NoError(err)
 
 		// try to update the demand order
-		msg := types.NewMsgUpdateDemandOrder(tc.submittedBy, demandOrder.Id, tc.newFee.String())
+		newFeeText := tc.newFeeText
+		if newFeeText == "" {
+			newFeeText = tc.newFee.String()
+		}
+		msg := types.NewMsgUpdateDemandOrder(tc.submittedBy, demandOrder.Id, newFeeText)
 		_, err = suite.msgServer.UpdateDemandOrder(suite.Ctx, msg)
 		if tc.expectError {
 			suite.Require().Error(err, tc.name)
+			updatedDemandOrder, getErr := suite.App.EIBCKeeper.GetDemandOrder(suite.Ctx, rollappPacket.Status, demandOrder.Id)
+			suite.Require().NoError(getErr, tc.name)
+			suite.Assert().Equal(initialFee, updatedDemandOrder.Fee.AmountOf(denom), tc.name)
+			suite.Assert().Equal(initialPrice, updatedDemandOrder.Price.AmountOf(denom), tc.name)
 			continue
 		}
 		suite.Require().NoError(err, tc.name)


### PR DESCRIPTION
Fixes #91.

Summary:
- checks the sdk.NewIntFromString success flag for MsgFulfillOrder expected_fee;
- checks the sdk.NewIntFromString success flag for MsgUpdateDemandOrder new_fee;
- rejects malformed transfer packet amounts before calculating the updated order price;
- adds regression coverage for malformed fee input and verifies failed updates keep the original order price and fee.

Verification:
- go test ./x/eibc/keeper -run 'TestKeeperTestSuite/TestMsgUpdateDemandOrder' -count=1
- go test ./x/eibc/keeper -run 'TestKeeperTestSuite/TestMsgFulfillOrder/Test_demand_order_fulfillment_-_malformed_expected_fee' -count=1

Note:
- A broader local run that included all TestMsgFulfillOrder subtests still hits existing insufficient-funds failures in the success cases. The new malformed expected_fee subtest passes when run directly.

If eligible for a bounty, payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099