### PR TITLE
fix(eibc): delete pending demand orders when packets are removed

### DIFF
--- a/x/eibc/keeper/hooks.go
+++ b/x/eibc/keeper/hooks.go
@@ -64,8 +64,8 @@ func (d delayedAckHooks) AfterPacketDeleted(ctx sdk.Context, rollappPacket *comm
 	packetKey := commontypes.RollappPacketKey(rollappPacket)
 	demandOrderID := types.BuildDemandIDFromPacketKey(string(packetKey))
 
-	// Check for demand order in both FINALIZED and REVERTED statuses
-	statuses := []commontypes.Status{commontypes.Status_FINALIZED, commontypes.Status_REVERTED}
+	// Check every status a demand order can have when its packet is deleted.
+	statuses := []commontypes.Status{commontypes.Status_PENDING, commontypes.Status_FINALIZED, commontypes.Status_REVERTED}
 	for _, status := range statuses {
 		demandOrder, err := d.GetDemandOrder(ctx, status, demandOrderID)
 		if err != nil {

--- a/x/eibc/keeper/hooks_test.go
+++ b/x/eibc/keeper/hooks_test.go
@@ -80,3 +80,21 @@ func (suite *KeeperTestSuite) TestAfterRollappPacketDeleted() {
 		})
 	}
 }
+
+func (suite *KeeperTestSuite) TestAfterPendingRollappPacketDeleted() {
+	// Set a rollapp packet and a demand order that still tracks it as PENDING.
+	suite.App.DelayedAckKeeper.SetRollappPacket(suite.Ctx, *rollappPacket)
+
+	demandOrderFulfillerAddr := apptesting.AddTestAddrs(suite.App, suite.Ctx, 1, math.NewInt(1000))[0].String()
+	demandOrder := types.NewDemandOrder(*rollappPacket, math.NewIntFromUint64(100), math.NewIntFromUint64(50), sdk.DefaultBondDenom, demandOrderFulfillerAddr)
+	suite.Require().Equal(commontypes.Status_PENDING, demandOrder.TrackingPacketStatus)
+	err := suite.App.EIBCKeeper.SetDemandOrder(suite.Ctx, demandOrder)
+	suite.Require().NoError(err)
+
+	hooks := suite.App.EIBCKeeper.GetDelayedAckHooks()
+	err = hooks.AfterPacketDeleted(suite.Ctx, rollappPacket)
+	suite.Require().NoError(err)
+
+	_, err = suite.App.EIBCKeeper.GetDemandOrder(suite.Ctx, commontypes.Status_PENDING, demandOrder.Id)
+	suite.Require().ErrorIs(err, types.ErrDemandOrderDoesNotExist)
+}


### PR DESCRIPTION
Fixes #684.

Summary:
- includes PENDING demand orders in AfterPacketDeleted cleanup;
- keeps the existing FINALIZED and REVERTED cleanup behavior;
- adds a regression test proving a pending demand order is removed when its tracked packet is deleted.

Verification:
- go test ./x/eibc/keeper -run 'TestKeeperTestSuite/TestAfter(PendingRollappPacketDeleted|RollappPacketDeleted)' -count=1

If eligible for a bounty, payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099