### PR TITLE
fix(eibc): resolve errack timeout demand order denom

### DIFF
--- a/x/eibc/keeper/handler.go
+++ b/x/eibc/keeper/handler.go
@@ -113,8 +113,7 @@ func (k Keeper) CreateDemandOrderOnErrAckOrTimeout(ctx sdk.Context, fungibleToke
 	}
 	demandOrderPrice := amt.Sub(fee)
 
-	trace := transfertypes.ParseDenomTrace(fungibleTokenPacketData.Denom)
-	demandOrderDenom := trace.IBCDenom()
+	demandOrderDenom := k.getEIBCTransferDenom(*rollappPacket.Packet, fungibleTokenPacketData)
 	demandOrderRecipient := fungibleTokenPacketData.Sender // and who tried to send it (refund because it failed)
 
 	order := types.NewDemandOrder(*rollappPacket, demandOrderPrice, fee, demandOrderDenom, demandOrderRecipient)

--- a/x/eibc/keeper/handler_test.go
+++ b/x/eibc/keeper/handler_test.go
@@ -3,6 +3,8 @@ package keeper_test
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/openmetaearth/me-hub/utils/uibc"
+	commontypes "github.com/openmetaearth/me-hub/x/common/types"
 	dacktypes "github.com/openmetaearth/me-hub/x/delayedack/types"
 )
 
@@ -79,4 +81,24 @@ func (suite *KeeperTestSuite) TestCreateDemandOrderOnRecv() {
 			}
 		})
 	}
+}
+
+func (suite *KeeperTestSuite) TestCreateDemandOrderOnErrAckOrTimeoutUsesTransferDenom() {
+	params := suite.App.EIBCKeeper.GetParams(suite.Ctx)
+	params.ErrackFee = sdk.NewDecWithPrec(1, 1) // 10%
+	suite.App.EIBCKeeper.SetParams(suite.Ctx, params)
+
+	ackPacket := *rollappPacket
+	ackPacket.Type = commontypes.RollappPacket_ON_ACK
+	ackPacket.Packet = &packet
+
+	order, err := suite.App.EIBCKeeper.CreateDemandOrderOnErrAckOrTimeout(suite.Ctx, transferPacketData, &ackPacket)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(order)
+
+	expectedDenom := uibc.GetForeignDenomTrace(packet.GetDestChannel(), transferPacketData.Denom).IBCDenom()
+	suite.Require().Equal(expectedDenom, order.Price[0].Denom)
+	suite.Require().Equal(expectedDenom, order.Fee[0].Denom)
+	suite.Require().Equal("100", order.Fee[0].Amount.String())
+	suite.Require().Equal("900", order.Price[0].Amount.String())
 }


### PR DESCRIPTION
Fixes #685.

Summary:
- uses the existing eIBC transfer denom resolver for errack/timeout demand orders;
- keeps fee and price calculation unchanged;
- adds regression coverage proving the demand order fee and price use the packet-derived transfer denom.

Verification:
- go test ./x/eibc/keeper -run 'TestKeeperTestSuite/TestCreateDemandOrderOnErrAckOrTimeoutUsesTransferDenom' -count=1
- go test ./x/eibc/keeper -run 'TestKeeperTestSuite/TestCreateDemandOrder' -count=1

If eligible for a bounty, payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099