### PR TITLE
fix(wstaking): execute transfer region message

### DIFF
--- a/x/wstaking/keeper/kyc_region_test.go
+++ b/x/wstaking/keeper/kyc_region_test.go
@@ -68,3 +68,59 @@ func (s *KeeperTestSuite) TestTransferKycRegion() {
 	s.Require().Equal(delegation.ValidatorAddress, s.usaValidator.OperatorAddress)
 	s.Require().EqualValues(delegation.StartHeight, wmintTypes.OneDayTotalBlocks+1)
 }
+
+func (s *KeeperTestSuite) TestMsgTransferRegion() {
+	s.SetupTest()
+	accounts := s.NewAccounts(1)
+
+	newRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            types.MeEarthRegionName,
+		OperatorAddress: s.meEarthValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	newRegion = types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            "USA",
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	}
+	_, err = s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	kycAccount := accounts[0]
+	err = s.Keeper().KycReward(s.Ctx, kycAccount, types.MeEarthRegionId, s.Dao.GlobalDao)
+	s.Require().NoError(err)
+
+	_, err = s.msgServer.TransferRegion(s.Ctx, &types.MsgTransferRegion{
+		Creator:    s.Dao.MeidDao,
+		FromRegion: types.MeEarthRegionId,
+		ToRegion:   "usa",
+		Address:    []string{kycAccount.String()},
+	})
+	s.Require().ErrorIs(err, types.ErrCheckGlobalDao)
+
+	delegation, found := s.Keeper().GetDelegation(s.Ctx, kycAccount, sdk.ValAddress{})
+	s.Require().True(found)
+	s.Require().Equal(s.meEarthValidator.OperatorAddress, delegation.ValidatorAddress)
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks + 1).WithChainID(apptesting.TestChainID)
+
+	_, err = s.msgServer.TransferRegion(s.Ctx, &types.MsgTransferRegion{
+		Creator:    s.Dao.GlobalDao,
+		FromRegion: types.MeEarthRegionId,
+		ToRegion:   "usa",
+		Address:    []string{kycAccount.String()},
+	})
+	s.Require().NoError(err)
+
+	delegation, found = s.Keeper().GetDelegation(s.Ctx, kycAccount, sdk.ValAddress{})
+	s.Require().True(found)
+	s.Require().Equal(s.usaValidator.OperatorAddress, delegation.ValidatorAddress)
+	s.Require().EqualValues(wmintTypes.OneDayTotalBlocks+1, delegation.StartHeight)
+}

--- a/x/wstaking/keeper/msg_server_region.go
+++ b/x/wstaking/keeper/msg_server_region.go
@@ -189,6 +189,36 @@ func (k MsgServer) WithdrawFromRegion(goCtx context.Context, msg *types.MsgWithd
 }
 
 func (k MsgServer) TransferRegion(goCtx context.Context, msg *types.MsgTransferRegion) (*types.MsgTransferRegionResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if !k.daoKeeper.IsGlobalDao(ctx, msg.Creator) {
+		return nil, types.ErrCheckGlobalDao
+	}
+
+	fromRegionId := strings.ToLower(msg.FromRegion)
+	toRegionId := strings.ToLower(msg.ToRegion)
+	if fromRegionId == "" || toRegionId == "" {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "from_region and to_region must not be empty")
+	}
+	if len(msg.Address) == 0 {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "address list must not be empty")
+	}
+
+	transferAddresses := make([]sdk.AccAddress, 0, len(msg.Address))
+	for _, address := range msg.Address {
+		accAddr, err := sdk.AccAddressFromBech32(address)
+		if err != nil {
+			return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid transfer address %s", address)
+		}
+		transferAddresses = append(transferAddresses, accAddr)
+	}
+
+	for _, accAddr := range transferAddresses {
+		if err := k.Keeper.TransferKycRegion(ctx, accAddr, msg.Creator, fromRegionId, toRegionId); err != nil {
+			return nil, err
+		}
+	}
+
 	return &types.MsgTransferRegionResponse{}, nil
 }
 

--- a/x/wstaking/types/msgs.go
+++ b/x/wstaking/types/msgs.go
@@ -34,6 +34,7 @@ var (
 	_ sdk.Msg = &MsgUnstake{}
 	_ sdk.Msg = &MsgNewRegion{}
 	_ sdk.Msg = &MsgRemoveRegion{}
+	_ sdk.Msg = &MsgTransferRegion{}
 	_ sdk.Msg = &MsgWithdrawDelegatorReward{}
 	_ sdk.Msg = &MsgWithdrawFromRegion{}
 	_ sdk.Msg = &MsgWithdrawFromGlobalDaoFeePool{}
@@ -489,6 +490,20 @@ func (msg *MsgTransferRegion) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+	if msg.FromRegion == "" {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "from_region must not be empty")
+	}
+	if msg.ToRegion == "" {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "to_region must not be empty")
+	}
+	if len(msg.Address) == 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "address list must not be empty")
+	}
+	for _, address := range msg.Address {
+		if _, err := sdk.AccAddressFromBech32(address); err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid transfer address (%s)", err)
+		}
 	}
 	return nil
 }

--- a/x/wstaking/types/msgs_transfer_region_test.go
+++ b/x/wstaking/types/msgs_transfer_region_test.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgTransferRegionValidateBasic(t *testing.T) {
+	validCreator := sample.AccAddress()
+	validAddress := sample.AccAddress()
+
+	tests := []struct {
+		name string
+		msg  MsgTransferRegion
+		err  error
+	}{
+		{
+			name: "valid",
+			msg: MsgTransferRegion{
+				Creator:    validCreator,
+				FromRegion: MeEarthRegionId,
+				ToRegion:   "usa",
+				Address:    []string{validAddress},
+			},
+		},
+		{
+			name: "empty address list",
+			msg: MsgTransferRegion{
+				Creator:    validCreator,
+				FromRegion: MeEarthRegionId,
+				ToRegion:   "usa",
+			},
+			err: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid transfer address",
+			msg: MsgTransferRegion{
+				Creator:    validCreator,
+				FromRegion: MeEarthRegionId,
+				ToRegion:   "usa",
+				Address:    []string{"not-an-address"},
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #299.

Summary:
- makes MsgTransferRegion reject non-GlobalDao callers instead of returning a successful no-op;
- validates non-empty region ids and transfer address list before state changes;
- calls the existing TransferKycRegion keeper flow for each requested account;
- adds regression coverage proving the message handler moves the KYC delegation to the target region;
- adds MsgTransferRegion ValidateBasic coverage for empty and malformed input.

Verification:
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestMsgTransferRegion' -count=1
- go test ./x/wstaking/types -run 'TestMsgTransferRegionValidateBasic' -count=1
- git diff --check

Baseline note:
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestTransferKycRegion' -count=1 currently fails on main-path test expectation at x/wstaking/keeper/kyc_region_test.go:47: inviter balance remains 0 while the test expects InviteReward. The new MsgTransferRegion regression test passes.

If eligible for a bounty, payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099