### PR TITLE
fix(wstaking): reject stake when region is missing

### DIFF
--- a/x/wstaking/keeper/msg_server_stake.go
+++ b/x/wstaking/keeper/msg_server_stake.go
@@ -46,18 +46,19 @@ func (k MsgServer) Stake(goCtx context.Context, msg *types.MsgStake) (*types.Msg
 			sdkerrors.ErrInvalidRequest, "invalid coin amount: got %s, expected %s integer multiple", msg.Amount.Amount.Int64(), int64(gomath.Pow10(params.BaseDenomUnit)),
 		)
 	}
+	region, found := k.Keeper.GetRegion(ctx, validator.Description.RegionID)
+	if !found {
+		return nil, sdkerrors.Wrapf(types.ErrRegionNotExist, "region %s not found", validator.Description.RegionID)
+	}
+
 	// should before modified region shared
 	err := k.WstakingHooks().BeforeValidatorStakingModified(ctx, valAddr)
 	if err != nil {
 		return nil, sdkerrors.Wrapf(types.ErrHooks, "before stake:%+v", err)
 	}
 
-	region, found := k.Keeper.GetRegion(ctx, validator.Description.RegionID)
-	if found {
-		region.RegionShare = region.RegionShare.Add(msg.Amount.Amount)
-		k.Keeper.SetRegion(ctx, region)
-		//return nil, types.ErrValidatorRegion.Wrapf("%s not found", validator.Description.RegionID)
-	}
+	region.RegionShare = region.RegionShare.Add(msg.Amount.Amount)
+	k.Keeper.SetRegion(ctx, region)
 
 	// NOTE: source funds are always unbonded
 	newShares, err := k.Keeper.Stake(ctx, sdk.MustAccAddressFromBech32(msg.StakerAddress), msg.Amount.Amount, stakingtypes.Unbonded, validator, true, "stake_"+validator.Description.RegionID)

--- a/x/wstaking/keeper/msg_server_stake_test.go
+++ b/x/wstaking/keeper/msg_server_stake_test.go
@@ -115,6 +115,46 @@ func (s *KeeperTestSuite) TestStake() {
 	}
 }
 
+func (s *KeeperTestSuite) TestStakeRejectsMissingRegion() {
+	s.SetupTest()
+
+	newRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            types.MeEarthRegionName,
+		OperatorAddress: s.meEarthValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	stakeAmount := sdk.NewCoin(params.BaseDenom, sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(params.BaseDenomUnit), nil)))
+
+	valAddress, err := sdk.ValAddressFromBech32(s.meEarthValidator.OperatorAddress)
+	s.Require().NoError(err)
+
+	validatorBefore, found := s.Keeper().GetValidator(s.Ctx, valAddress)
+	s.Require().True(found)
+
+	s.Keeper().RemoveRegion(s.Ctx, strings.ToLower(types.MeEarthRegionName))
+
+	_, err = s.msgServer.Stake(s.Ctx, &types.MsgStake{
+		StakerAddress:    s.Dao.GlobalDao,
+		ValidatorAddress: s.meEarthValidator.OperatorAddress,
+		Amount:           stakeAmount,
+	})
+	s.Require().ErrorIs(err, types.ErrRegionNotExist)
+
+	_, found = s.Keeper().GetRegion(s.Ctx, strings.ToLower(types.MeEarthRegionName))
+	s.Require().False(found)
+
+	validatorAfter, found := s.Keeper().GetValidator(s.Ctx, valAddress)
+	s.Require().True(found)
+	s.Require().Equal(validatorBefore.Tokens.String(), validatorAfter.Tokens.String())
+	s.Require().Equal(validatorBefore.DelegatorShares.String(), validatorAfter.DelegatorShares.String())
+
+	_, found = s.Keeper().GetStake(s.Ctx, sdk.MustAccAddressFromBech32(s.Dao.GlobalDao), valAddress)
+	s.Require().False(found)
+}
+
 func (s *KeeperTestSuite) TestUnStake() {
 	s.SetupTest()
 


### PR DESCRIPTION
Fixes #305.\n\n## Summary\n- Make MsgStake fail fast when the validator-linked region is missing.\n- Return ErrRegionNotExist before the staking hook and before any validator or stake state mutation.\n- Add regression coverage proving the missing-region path leaves the region missing, the validator unchanged, and no stake record created.\n\n## Tests\n\n```bash\ngo test ./x/wstaking/keeper -run '^TestKeeperTestSuite$/^TestStakeRejectsMissingRegion$' -count=1 -v\ngit diff --check\n```\n\n## Baseline note\n\n`go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestStake/No_error' -count=1 -v` still fails on a clean main checkout at `x/wstaking/keeper/msg_server_stake_test.go:99` with expected `1` vs actual `200000000`. I verified this separately in `/mnt/projects/.tmp/paid-work/me-hub-main-check` from main commit `9ca8f8f`, so that failure is not introduced by this PR.\n\nIf this fix is eligible for a bounty, payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`.