### PR TITLE
fix(wstaking): remove MeID NFT region index entries

### DIFF
--- a/x/wstaking/keeper/meid_nft.go
+++ b/x/wstaking/keeper/meid_nft.go
@@ -32,7 +32,7 @@ func (k Keeper) RemoveMeidNFT(ctx sdk.Context, account, regionId string) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MeidNFTKeyPrefix))
 	store.Delete(types.MeidNFTKey(account))
 
-	storeReg := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MeidNFTAccountKeyPrefix+account))
+	storeReg := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MeidNFTAccountKeyPrefix+regionId))
 	storeReg.Delete(types.MeidNFTKey(account))
 }
 

--- a/x/wstaking/keeper/meid_nft_test.go
+++ b/x/wstaking/keeper/meid_nft_test.go
@@ -1,0 +1,32 @@
+package keeper_test
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestRemoveMeidNFTDeletesRegionIndex() {
+	s.SetupTest()
+
+	account := s.TestAccs[0].String()
+	regionId := "alpha"
+	meidNFT := types.MeidNFT{
+		Creator:    s.Dao.GlobalDao,
+		Account:    account,
+		RegionId:   regionId,
+		RegionName: "Alpha",
+		Umeid:      "umeid-alpha-1",
+		NftId:      "nft-alpha-1",
+	}
+
+	s.Keeper().SetMeidNFT(s.Ctx, meidNFT)
+
+	regionStore := prefix.NewStore(s.Ctx.KVStore(s.Keeper().GetStoreKey()), types.KeyPrefix(types.MeidNFTAccountKeyPrefix+regionId))
+	s.Require().True(regionStore.Has(types.MeidNFTKey(account)))
+
+	s.Keeper().RemoveMeidNFT(s.Ctx, account, regionId)
+
+	_, found := s.Keeper().GetMeidNFT(s.Ctx, account)
+	s.Require().False(found)
+	s.Require().False(regionStore.Has(types.MeidNFTKey(account)))
+}


### PR DESCRIPTION
Fixes #88.\n\n## Summary\n- Delete the MeID NFT region index entry using the same region-id prefix used by SetMeidNFT.\n- Keep the primary MeID NFT deletion behavior unchanged.\n- Add regression coverage proving RemoveMeidNFT clears both the primary record and the region index entry.\n\n## Tests\n\n```bash\ngo test ./x/wstaking/keeper -run '^TestKeeperTestSuite$/^TestRemoveMeidNFTDeletesRegionIndex$' -count=1 -v\ngit diff --check\n```\n\nIf this fix is eligible for a bounty, payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`.