### PR TITLE
fix(did): replace VC filter indexes on update

### DIFF
--- a/x/did/keeper/filter_test.go
+++ b/x/did/keeper/filter_test.go
@@ -1,10 +1,13 @@
 package keeper_test
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/openmetaearth/me-hub/testutil/keeper"
+	didkeeper "github.com/openmetaearth/me-hub/x/did/keeper"
 	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -46,4 +49,53 @@ func TestKeeper_Filter(t *testing.T) {
 	assert.Equal(t, 0, len(vcs))
 	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f2, &pr)
 	assert.Equal(t, 0, len(vcs))
+}
+
+func TestMsgServer_UpdateVCRemovesStaleFilterIndex(t *testing.T) {
+	k, ctx := keeper.DidKeeper(t)
+
+	issuerAddr := sdk.MustAccAddressFromBech32("me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4")
+	issuerDid := "1000000000001"
+	holderDid := "1000000000002"
+	sid := "test"
+	oldFilter := []byte("old-kyc-scope")
+	newFilter := []byte("new-kyc-scope")
+
+	k.SetDID(ctx, issuerAddr, issuerDid)
+	k.SetDidInfo(ctx, issuerDid, didtypes.NewDidInfo(issuerDid, issuerAddr.String(), "issuer-pubkey", didtypes.DID_STATUS_ACTIVE))
+	k.SetDidInfo(ctx, holderDid, didtypes.NewDidInfo(holderDid, "holder-address", "holder-pubkey", didtypes.DID_STATUS_ACTIVE))
+	k.SetService(ctx, sid, didtypes.NewService(sid, "test", "this is a test service.", didtypes.SERVICE_STATUS_ACTIVE, []string{issuerDid}))
+
+	msgServer := didkeeper.NewMsgServerImpl(k)
+	goCtx := sdk.WrapSDKContext(ctx)
+
+	_, err := msgServer.CreateVC(goCtx, &didtypes.MsgCreateVC{
+		Issuer:  issuerAddr.String(),
+		Did:     holderDid,
+		Sid:     sid,
+		Hash:    "hash-before",
+		Uri:     "https://www.example.com/before",
+		Filters: [][]byte{oldFilter},
+	})
+	require.NoError(t, err)
+
+	_, err = msgServer.UpdateVC(goCtx, &didtypes.MsgUpdateVC{
+		Issuer:  issuerAddr.String(),
+		Did:     holderDid,
+		Sid:     sid,
+		Hash:    "hash-after",
+		Uri:     "https://www.example.com/after",
+		Filters: [][]byte{newFilter},
+	})
+	require.NoError(t, err)
+
+	pr := query.PageRequest{}
+	vcs, _, err := k.GetCredentialsByFilter(ctx, sid, oldFilter, &pr)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(vcs))
+
+	vcs, _, err = k.GetCredentialsByFilter(ctx, sid, newFilter, &pr)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(vcs))
+	assert.Equal(t, "hash-after", vcs[0].Hash)
 }

--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -201,6 +201,9 @@ func (m msgServer) UpdateVC(goCtx context.Context, msg *types.MsgUpdateVC) (*typ
 	}
 
 	// update VC
+	oldFilters, _ := m.GetFilters(ctx, msg.Did, msg.Sid)
+	m.DeleteFilters(ctx, msg.Did, msg.Sid, oldFilters)
+
 	vc := msg.GetCredential()
 	m.SetCredential(ctx, msg.Did, msg.Sid, vc)
 


### PR DESCRIPTION
Fixes #190.\n\n## Summary\n- Remove the existing VC filter index entries before writing replacement filters in MsgUpdateVC.\n- Keep the updated credential indexed only under the new filter set.\n- Add regression coverage proving the old filter returns zero credentials and the new filter returns the updated credential.\n\n## Tests\n\n```bash\ngo test ./x/did/keeper -run 'TestMsgServer_UpdateVCRemovesStaleFilterIndex|TestKeeper_Filter' -count=1 -v\ngit diff --check\n```\n\nIf this fix is eligible for a bounty, payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`.