### PR TITLE
fix(gravity): reject zero external address in MsgBondedRelayer and ValidateEthereumAddress (#454)

### DIFF
--- a/utils/eth_validation.go
+++ b/utils/eth_validation.go
@@ -49,6 +49,9 @@ func ValidateEthereumAddress(address string) error {
 	if expectAddress != address {
 		return fmt.Errorf("mismatch expected: %s, got: %s", expectAddress, address)
 	}
+	if IsZeroEthereumAddress(address) {
+		return errors.New("zero address")
+	}
 	return nil
 }
 

--- a/utils/eth_validation_test.go
+++ b/utils/eth_validation_test.go
@@ -70,7 +70,7 @@ func TestValidateEthereumAddress(t *testing.T) {
 			"invalid address", "0x", true,
 		},
 		{
-			"zero address", common.Address{}.String(), false,
+			"zero address", common.Address{}.String(), true,
 		},
 		{
 			"valid address", helpers.GenerateAddress().Hex(), false,


### PR DESCRIPTION
### Description
Addresses Issue #454.

Currently, `ValidateEthereumAddress` accepts the zero Ethereum address because it passes hex validation. This allows relayers to bond with a zero external address, poisoning the relayer set with a signer that cannot sign or confirm checkpoints.

This change:
1. Updates `ValidateEthereumAddress` to reject the zero address using `IsZeroEthereumAddress`.
2. Updates unit tests in `utils/eth_validation_test.go` to assert that the zero address is rejected.