### PR TITLE
fix(did): ignore filter prefix collisions

### DIFF
--- a/x/did/keeper/credential.go
+++ b/x/did/keeper/credential.go
@@ -64,6 +64,10 @@ func (k Keeper) GetCredentialsByFilter(
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.GetFilterPrefixBySidAndFilter(sid, filter))
 
 	pageRes, err = query.Paginate(store, pageReq, func(key []byte, value []byte) error {
+		if !types.IsExactFilterIndexSuffix(key) {
+			return nil
+		}
+
 		var vc types.Credential
 		if err := k.cdc.Unmarshal(value, &vc); err != nil {
 			return err // todo: warp error
@@ -94,6 +98,10 @@ func (k Keeper) IteratorCredentialsByFilter(ctx sdk.Context, sid string, filter 
 	defer iterator.Close()
 
 	for ; iterator.Valid(); iterator.Next() {
+		if !types.IsExactFilterIndexSuffix(iterator.Key()) {
+			continue
+		}
+
 		var vc types.Credential
 		k.cdc.MustUnmarshal(iterator.Value(), &vc)
 		if cb(vc) {

--- a/x/did/keeper/filter_test.go
+++ b/x/did/keeper/filter_test.go
@@ -5,13 +5,14 @@ import (
 	"github.com/openmetaearth/me-hub/testutil/keeper"
 	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestKeeper_Filter(t *testing.T) {
 	k, ctx := keeper.DidKeeper(t)
 
-	did := "1000000000000001"
+	did := "1000000000001"
 	sid := "test"
 	vc := didtypes.Credential{
 		Did:  did,
@@ -46,4 +47,31 @@ func TestKeeper_Filter(t *testing.T) {
 	assert.Equal(t, 0, len(vcs))
 	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f2, &pr)
 	assert.Equal(t, 0, len(vcs))
+}
+
+func TestKeeper_GetCredentialsByFilterDoesNotMatchLongerRegionPrefix(t *testing.T) {
+	k, ctx := keeper.DidKeeper(t)
+
+	sid := "kyc"
+	did := "1000000000002"
+	parentRegion := []byte("me_earth")
+	childRegion := []byte("me_earth-usa")
+	vc := didtypes.Credential{
+		Did:  did,
+		Sid:  sid,
+		Hash: "hash-earth-usa",
+		Uri:  "https://www.example.com/earth-usa",
+	}
+
+	k.AddFilters(ctx, did, sid, [][]byte{childRegion}, vc)
+
+	pr := query.PageRequest{}
+	vcs, _, err := k.GetCredentialsByFilter(ctx, sid, parentRegion, &pr)
+	require.NoError(t, err)
+	require.Empty(t, vcs)
+
+	vcs, _, err = k.GetCredentialsByFilter(ctx, sid, childRegion, &pr)
+	require.NoError(t, err)
+	require.Len(t, vcs, 1)
+	assert.Equal(t, did, vcs[0].Did)
 }

--- a/x/did/keeper/grpc_query.go
+++ b/x/did/keeper/grpc_query.go
@@ -162,6 +162,10 @@ func (k Keeper) Credentials(goCtx context.Context, req *types.QueryCredentials) 
 	filterStore := prefix.NewStore(store, types.GetFilterPrefixBySidAndFilter(req.Sid, req.Filter))
 
 	pageRes, err := query.Paginate(filterStore, req.Pagination, func(key []byte, value []byte) error {
+		if !types.IsExactFilterIndexSuffix(key) {
+			return nil
+		}
+
 		var vc types.Credential
 		if err := k.cdc.Unmarshal(value, &vc); err != nil {
 			return err

--- a/x/did/types/keys.go
+++ b/x/did/types/keys.go
@@ -71,3 +71,7 @@ func GetFilterPrefixBySidAndFilter(sid string, filter []byte) []byte {
 func GetFilterKey(sid, did string, filter []byte) []byte {
 	return append(GetFilterPrefixBySidAndFilter(sid, filter), did...)
 }
+
+func IsExactFilterIndexSuffix(key []byte) bool {
+	return len(key) == DidLength
+}


### PR DESCRIPTION
Fixes #172.\n\n## Summary\n- Ignore DID filter index entries whose suffix is not an exact DID-length suffix after the requested filter prefix.\n- Apply the same exact-filter guard to keeper filtered reads, iterator reads, and the public credentials gRPC query.\n- Add regression coverage proving a credential indexed under `me_earth-usa` is not returned by a `me_earth` filter query.\n\n## Tests\n\n```bash\ngo test ./x/did/keeper -run 'TestKeeper_(Filter|GetCredentialsByFilterDoesNotMatchLongerRegionPrefix)' -count=1 -v\ngit diff --check\n```\n\nIf this fix is eligible for a bounty, payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`.