### PR TITLE
fix(rollapp): trim rollapp-id in CreateRollapp to prevent namespace squatting (#451)

### DIFF
--- a/x/rollapp/keeper/msg_server_create_rollapp.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"strings"
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -10,6 +11,8 @@ import (
 
 func (k msgServer) CreateRollapp(goCtx context.Context, msg *types.MsgCreateRollapp) (*types.MsgCreateRollappResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	msg.RollappId = strings.TrimSpace(msg.RollappId)
 
 	if !k.RollappsEnabled(ctx) {
 		return nil, types.ErrRollappsDisabled

--- a/x/rollapp/keeper/msg_server_create_rollapp_test.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	fmt "fmt"
+	"strings"
 
 	"github.com/cometbft/cometbft/libs/rand"
 
@@ -377,3 +378,52 @@ func (suite *RollappTestSuite) TestOverwriteEIP155Key() {
 		})
 	}
 }
+
+func (suite *RollappTestSuite) TestWhitespaceRollappID() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	whitespaceID := " evil_1-1 "
+	_, err := suite.msgServer.CreateRollapp(goCtx, &types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             whitespaceID,
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{},
+	})
+	suite.Require().NoError(err)
+
+	// Verify that the rollapp is stored with the trimmed ID
+	_, foundRaw := suite.App.RollappKeeper.GetRollapp(suite.Ctx, whitespaceID)
+	suite.Require().False(foundRaw, "should not store raw untrimmed rollapp id")
+
+	stored, foundTrimmed := suite.App.RollappKeeper.GetRollapp(suite.Ctx, "evil_1-1")
+	suite.Require().True(foundTrimmed, "should store trimmed rollapp id")
+	suite.Require().Equal("evil_1-1", stored.RollappId)
+
+	// Try to register the same ID with whitespace again
+	_, err = suite.msgServer.CreateRollapp(goCtx, &types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             "evil_1-1",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{},
+	})
+	suite.Require().ErrorIs(err, types.ErrRollappExists, "should not allow duplicate registration")
+
+	// Try to register " dup " and then "dup"
+	_, err = suite.msgServer.CreateRollapp(goCtx, &types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             " dup ",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{},
+	})
+	suite.Require().NoError(err)
+
+	_, err = suite.msgServer.CreateRollapp(goCtx, &types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             "dup",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{},
+	})
+	suite.Require().ErrorIs(err, types.ErrRollappExists, "should reject duplicate trimmed namespaced rollapp")
+}
+


### PR DESCRIPTION
### Description
Addresses Issue #451.

Currently, `NewChainID` validates a trimmed version of the `RollappId` but the raw untrimmed `RollappId` is used to index and store the RollApp in `SetRollapp`. Since the exact-key check uses the trimmed `ChainID.GetChainID()`, it fails to find an existing RollApp with leading/trailing whitespace, letting malicious users squat or duplicate the namespace.

This change:
1. Applies `strings.TrimSpace(msg.RollappId)` at the entry point of `CreateRollapp` to ensure the stored ID matches the validated canonical ID.
2. Adds unit tests in `x/rollapp/keeper/msg_server_create_rollapp_test.go` to verify that whitespace-padded RollApp IDs are normalized and do not bypass existing check bounds.