### PR TITLE
fix(ante): enforce minimum base fee policy during DeliverTx (#430)

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -346,13 +346,14 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 	feeCoins := feeTx.GetFee()
 	gas := feeTx.GetGas()
 
+	if !feeCoins.IsAllGTE(minimumFee) {
+		return sdk.Coins{}, 0, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "fee must greater than or equal %s: got %s", minimumFee.String(), feeCoins.String())
+	}
+
 	// Ensure that the provided fees meet a minimum threshold for the validator,
 	// if this is a CheckTx. This is only for local mempool purposes, and thus
 	// is only ran on check tx.
 	if ctx.IsCheckTx() {
-		if !feeCoins.IsAllGTE(minimumFee) {
-			return sdk.Coins{}, 0, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "fee must greater than or equal %s: got %s", minimumFee.String(), feeCoins.String())
-		}
 		minGasPrices := ctx.MinGasPrices()
 		if !minGasPrices.IsZero() {
 			requiredFees := make(sdk.Coins, len(minGasPrices))

--- a/app/ante/fee_policy_audit_test.go
+++ b/app/ante/fee_policy_audit_test.go
@@ -1,0 +1,69 @@
+package ante
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/stretchr/testify/require"
+)
+
+type auditFeeTx struct {
+	fee sdk.Coins
+	gas uint64
+}
+
+func (tx auditFeeTx) GetMsgs() []sdk.Msg         { return nil }
+func (tx auditFeeTx) ValidateBasic() error       { return nil }
+func (tx auditFeeTx) GetGas() uint64             { return tx.gas }
+func (tx auditFeeTx) GetFee() sdk.Coins          { return tx.fee }
+func (tx auditFeeTx) FeePayer() sdk.AccAddress   { return nil }
+func (tx auditFeeTx) FeeGranter() sdk.AccAddress { return nil }
+
+func TestAuditDeliverTxEnforcesMinimumFeePolicy(t *testing.T) {
+	// Test case 1: Fee 100foo (foreign denom, less than minimum)
+	txFoo := auditFeeTx{
+		fee: sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(100))),
+		gas: 200000,
+	}
+
+	// Should reject in CheckTx
+	_, _, err := checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(true), txFoo)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fee must greater than or equal 10000"+params.BaseDenom)
+
+	// Should now also reject in DeliverTx (IsCheckTx = false)
+	_, _, err = checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(false), txFoo)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fee must greater than or equal 10000"+params.BaseDenom)
+
+	// Test case 2: Fee 5000umec (insufficient base fee)
+	txInsuff := auditFeeTx{
+		fee: sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(5000))),
+		gas: 200000,
+	}
+
+	// Should reject in CheckTx
+	_, _, err = checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(true), txInsuff)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fee must greater than or equal 10000"+params.BaseDenom)
+
+	// Should reject in DeliverTx
+	_, _, err = checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(false), txInsuff)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fee must greater than or equal 10000"+params.BaseDenom)
+
+	// Test case 3: Fee 10000umec (valid minimum fee)
+	txValid := auditFeeTx{
+		fee: sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(10000))),
+		gas: 200000,
+	}
+
+	// Should pass in CheckTx
+	_, _, err = checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(true), txValid)
+	require.NoError(t, err)
+
+	// Should pass in DeliverTx
+	_, _, err = checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(false), txValid)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### Description
Addresses Issue #430.

Currently, the default `checkTxFeeWithValidatorMinGasPrices` only validates the `minimumFee` (10000umec) when `ctx.IsCheckTx()` is true. During block execution (`DeliverTx`), it does not check the minimum fee, allowing a block proposer or private inclusion path to bypass the fee structure or pay fees in non-native low-value denoms.

This change:
1. Moves the `minimumFee` check (requiring >= 10000umec) outside the `IsCheckTx` block to enforce the network-level fee threshold for both CheckTx and DeliverTx.
2. Adds unit tests in `app/ante/fee_policy_audit_test.go` to verify correct behavior.