### PR TITLE
fix(gravity): reject duplicate bridge tokens in genesis validation and initialization (#421)

### DIFF
--- a/x/gravity/keeper/genesis.go
+++ b/x/gravity/keeper/genesis.go
@@ -39,7 +39,20 @@ func InitGenesis(ctx sdk.Context, k Keeper, state *types.GenesisState) {
 	}
 	k.SetLastRelayerSetNonce(ctx, latestRelayerSetNonce)
 
+	denoms := make(map[string]bool)
+	contracts := make(map[string]bool)
 	for _, bridgeToken := range state.BridgeTokens {
+		if bridgeToken.Denom == "" || bridgeToken.ContractAddress == "" {
+			panic("empty denom or contract address in bridge token genesis")
+		}
+		if denoms[bridgeToken.Denom] {
+			panic("duplicate bridge token denom: " + bridgeToken.Denom)
+		}
+		if contracts[bridgeToken.ContractAddress] {
+			panic("duplicate bridge token contract address: " + bridgeToken.ContractAddress)
+		}
+		denoms[bridgeToken.Denom] = true
+		contracts[bridgeToken.ContractAddress] = true
 		k.SetBridgeToken(ctx, &bridgeToken)
 	}
 

--- a/x/gravity/keeper/genesis_audit_test.go
+++ b/x/gravity/keeper/genesis_audit_test.go
@@ -1,0 +1,121 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/openmetaearth/me-hub/testutil/helpers"
+	"github.com/openmetaearth/me-hub/x/gravity/keeper"
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateBasic_BridgeTokenDuplicates(t *testing.T) {
+	contract1 := helpers.GenerateAddress().Hex()
+	contract2 := helpers.GenerateAddress().Hex()
+
+	// Test 1: Duplicate denom across different contracts
+	state1 := &types.GenesisState{
+		Params: types.DefaultParams(),
+		BridgeTokens: []types.BridgeToken{
+			{
+				ContractAddress: contract1,
+				Denom:           "udup",
+				Supply:          sdkmath.NewInt(100),
+			},
+			{
+				ContractAddress: contract2,
+				Denom:           "udup",
+				Supply:          sdkmath.NewInt(200),
+			},
+		},
+	}
+	err := state1.ValidateBasic()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate bridge token denom")
+
+	// Test 2: Duplicate contract address across different denoms
+	state2 := &types.GenesisState{
+		Params: types.DefaultParams(),
+		BridgeTokens: []types.BridgeToken{
+			{
+				ContractAddress: contract1,
+				Denom:           "uone",
+				Supply:          sdkmath.NewInt(100),
+			},
+			{
+				ContractAddress: contract1,
+				Denom:           "utwo",
+				Supply:          sdkmath.NewInt(200),
+			},
+		},
+	}
+	err = state2.ValidateBasic()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate bridge token contract address")
+
+	// Test 3: Valid bridge tokens
+	state3 := &types.GenesisState{
+		Params: types.DefaultParams(),
+		BridgeTokens: []types.BridgeToken{
+			{
+				ContractAddress: contract1,
+				Denom:           "uone",
+				Supply:          sdkmath.NewInt(100),
+			},
+			{
+				ContractAddress: contract2,
+				Denom:           "utwo",
+				Supply:          sdkmath.NewInt(200),
+			},
+		},
+	}
+	err = state3.ValidateBasic()
+	require.NoError(t, err)
+}
+
+func (suite *KeeperTestSuite) TestInitGenesis_BridgeTokenDuplicates() {
+	suite.SetupTest()
+	contract1 := helpers.GenerateAddress().Hex()
+	contract2 := helpers.GenerateAddress().Hex()
+
+	// Duplicate denom should panic during InitGenesis
+	state1 := &types.GenesisState{
+		Params: types.DefaultParams(),
+		BridgeTokens: []types.BridgeToken{
+			{
+				ContractAddress: contract1,
+				Denom:           "udup",
+				Supply:          sdkmath.NewInt(100),
+			},
+			{
+				ContractAddress: contract2,
+				Denom:           "udup",
+				Supply:          sdkmath.NewInt(200),
+			},
+		},
+	}
+	suite.Panics(func() {
+		keeper.InitGenesis(suite.Ctx, suite.Keeper(), state1)
+	})
+
+	// Duplicate contract address should panic during InitGenesis
+	state2 := &types.GenesisState{
+		Params: types.DefaultParams(),
+		BridgeTokens: []types.BridgeToken{
+			{
+				ContractAddress: contract1,
+				Denom:           "uone",
+				Supply:          sdkmath.NewInt(100),
+			},
+			{
+				ContractAddress: contract1,
+				Denom:           "utwo",
+				Supply:          sdkmath.NewInt(200),
+			},
+		},
+	}
+	suite.Panics(func() {
+		keeper.InitGenesis(suite.Ctx, suite.Keeper(), state2)
+	})
+}

--- a/x/gravity/types/genesis.go
+++ b/x/gravity/types/genesis.go
@@ -1,10 +1,42 @@
 package types
 
+import (
+	"fmt"
+	errorsmod "cosmossdk.io/errors"
+	"github.com/openmetaearth/me-hub/utils"
+)
+
 // ValidateBasic validates genesis state by looping through the params and
 // calling their validation functions
 func (m *GenesisState) ValidateBasic() error {
 	if err := m.Params.ValidateBasic(); err != nil {
 		return err
 	}
+
+	denoms := make(map[string]bool)
+	contracts := make(map[string]bool)
+	for i, token := range m.BridgeTokens {
+		if token.Denom == "" {
+			return errorsmod.Wrapf(ErrEmpty, "bridge token %d denom is empty", i)
+		}
+		if token.ContractAddress == "" {
+			return errorsmod.Wrapf(ErrEmpty, "bridge token %d contract address is empty", i)
+		}
+		if err := utils.ValidateEthereumAddress(token.ContractAddress); err != nil {
+			return errorsmod.Wrapf(err, "bridge token %d contract address %s is invalid", i, token.ContractAddress)
+		}
+		if token.Supply.IsNegative() {
+			return errorsmod.Wrapf(ErrInvalid, "bridge token %d supply %s cannot be negative", i, token.Supply.String())
+		}
+		if denoms[token.Denom] {
+			return errorsmod.Wrapf(ErrDuplicate, "duplicate bridge token denom: %s", token.Denom)
+		}
+		if contracts[token.ContractAddress] {
+			return errorsmod.Wrapf(ErrDuplicate, "duplicate bridge token contract address: %s", token.ContractAddress)
+		}
+		denoms[token.Denom] = true
+		contracts[token.ContractAddress] = true
+	}
+
 	return nil
 }


### PR DESCRIPTION
### Description
Addresses Issue #421.

Currently, `GenesisState.ValidateBasic` does not validate the `BridgeTokens` array. Duplicate voucher denoms or duplicate contract addresses are accepted, but `SetBridgeToken` overwrites the corresponding key indexing mapping, leading to index disagreement (denom index vs contract index split-brain), supply mismatch, and AppHash/export-import issues.

This change:
1. Updates `GenesisState.ValidateBasic` to check and reject duplicate voucher denoms or contract addresses in `BridgeTokens`.
2. Updates keeper's `InitGenesis` to defensively panic if any duplicate voucher denoms or contract addresses are detected during initialization.
3. Adds unit tests in `x/gravity/keeper/genesis_audit_test.go` to verify this behavior.