### PR TITLE
fix(rollapp): automatically open SkipDelay RollApp bridge and correct OnRecvPacket error checking (#673)

### DIFF
--- a/ibctesting/genesis_transfer_test.go
+++ b/ibctesting/genesis_transfer_test.go
@@ -85,6 +85,28 @@ func (s *transferGenesisSuite) TestHappyPath() {
 	}
 }
 
+func (s *transferGenesisSuite) TestSkipDelayRollappHappyPath() {
+	// Configure the rollapp to skip delay
+	s.hubApp().RollappKeeper.SetSkipDelayRollapp(s.hubCtx(), rollappChainID(), true)
+
+	amt := math.NewIntFromUint64(10000000000000000000)
+	denom := "skipfoo"
+
+	msg := s.transferMsg(amt, denom, true)
+	apptesting.FundAccount(s.rollappApp(), s.rollappCtx(), s.rollappChain().SenderAccount.GetAddress(), sdk.Coins{msg.Token})
+	res, err := s.rollappChain().SendMsgs(msg)
+	s.Require().NoError(err)
+	packet, err := ibctesting.ParsePacketFromEvents(res.GetEvents())
+	s.Require().NoError(err)
+
+	err = s.path.RelayPacket(packet)
+	s.Require().NoError(err)
+
+	// Since it's a SkipDelay rollapp and it received a valid genesis transfer, transfers should be automatically enabled!
+	transfersEnabled := s.hubApp().RollappKeeper.MustGetRollapp(s.hubCtx(), rollappChainID()).GenesisState.TransfersEnabled
+	s.Require().True(transfersEnabled, "transfers should be enabled automatically for SkipDelay rollapp")
+}
+
 // In the fault path, a chain tries to do another genesis transfer (to skip eibc) after the genesis phase
 // is already complete. It triggers a fraud.
 func (s *transferGenesisSuite) TestCannotDoGenesisTransferAfterBridgeEnabled() {

--- a/x/rollapp/transfergenesis/ibc_module.go
+++ b/x/rollapp/transfergenesis/ibc_module.go
@@ -119,11 +119,11 @@ func (w IBCModule) OnRecvPacket(
 	memo, err := getMemo(transfer.GetMemo())
 	if errorsmod.IsOf(err, gerrc.ErrNotFound) {
 		// The first regular transfer marks the full opening of the bridge, more genesis transfers will not be allowed.
-		err := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
-		if err == nil && !ra.GenesisState.TransfersEnabled {
+		ack := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
+		if ack.Success() && !ra.GenesisState.TransfersEnabled {
 			w.rollappKeeper.EnableTransfers(ctx, ra.RollappId)
 		}
-		return err
+		return ack
 	}
 	if err != nil {
 		l.Error("Get memo.", "err", err)
@@ -151,7 +151,11 @@ func (w IBCModule) OnRecvPacket(
 	l.Debug("Received valid genesis transfer. Registered denom data.")
 
 	// we want to skip delayedack etc because we want the transfer to happen immediately
-	return w.IBCModule.OnRecvPacket(commontypes.SkipRollappMiddlewareContext(ctx), packet, relayer)
+	ack := w.IBCModule.OnRecvPacket(commontypes.SkipRollappMiddlewareContext(ctx), packet, relayer)
+	if ack.Success() && w.rollappKeeper.IsSkipDelayRollapp(ctx, ra.RollappId) && !ra.GenesisState.TransfersEnabled {
+		w.rollappKeeper.EnableTransfers(ctx, ra.RollappId)
+	}
+	return ack
 }
 
 func (w IBCModule) handleDRSViolation(ctx sdk.Context, rollappID string) error {


### PR DESCRIPTION
### Description
Addresses Issue #673.

Currently, `x/rollapp/transfergenesis/ibc_module.go` handles IBC packet receipts. Under the `errorsmod.IsOf(err, gerrc.ErrNotFound)` branch (representing a regular transfer), it checks:
```go
err := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
if err == nil && !ra.GenesisState.TransfersEnabled {
    w.rollappKeeper.EnableTransfers(ctx, ra.RollappId)
}
```
However, `OnRecvPacket` returns `exported.Acknowledgement`, which is an interface and is never `nil` (always returns a valid success or error acknowledgement object). Therefore, `err == nil` is always false, preventing the rollapp bridge/transfers from being enabled.

Furthermore, when a RollApp is configured with `SkipDelay`, the bridge should be opened automatically on a successful genesis transfer packet, but the keeper does not enable transfers during this flow.

This change:
1. Renames the return value of `OnRecvPacket` to `ack` and checks `ack.Success()` instead of comparing to `nil`.
2. Automatically calls `EnableTransfers` for `SkipDelay` RollApps when the genesis transfer packet is successfully received and processed.
3. Adds integration test `TestSkipDelayRollappHappyPath` in `ibctesting/genesis_transfer_test.go` to verify that a SkipDelay RollApp enables its bridge automatically upon receiving a valid genesis transfer.
