### PR TITLE
fix(gravity): enforce proposal relayer unbonding governance gate check (#679)

### DIFF
--- a/x/gravity/keeper/abci_test.go
+++ b/x/gravity/keeper/abci_test.go
@@ -553,3 +553,37 @@ func (s *KeeperTestSuite) TestSlashRelayer() {
 		s.Require().Equal(int64(1), relayer.SlashTimes)
 	}
 }
+
+func (s *KeeperTestSuite) TestUnbondedRelayer_GovernanceGate() {
+	// Initialize and bond 1 relayer
+	msgBondedRelayer := &types.MsgBondedRelayer{
+		RelayerAddress:  s.relayerAddrs[0].String(),
+		ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[0].PublicKey),
+		DelegateAmount:  sdk.NewCoin(params.BaseDenom, sdk.NewInt(10*1e8)),
+		ChainName:       s.chainName,
+	}
+	s.Require().NoError(msgBondedRelayer.ValidateBasic())
+	_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msgBondedRelayer)
+	s.Require().NoError(err)
+
+	s.App.EndBlock(abci.RequestEndBlock{Height: s.Ctx.BlockHeight()})
+	s.Ctx = s.Ctx.WithBlockHeight(s.Ctx.BlockHeight() + 1)
+
+	// Make the relayer offline so they are eligible to unbond (online relayers are blocked anyway)
+	relayer, found := s.Keeper().GetRelayer(s.Ctx, s.relayerAddrs[0])
+	s.Require().True(found)
+	relayer.Online = false
+	s.Keeper().SetRelayer(s.Ctx, s.relayerAddrs[0], relayer)
+
+	// Set BlockHeight above governance gate threshold
+	s.Ctx = s.Ctx.WithBlockHeight(10167305)
+
+	// Attempting to unbond should now fail because they are a proposal relayer and block height is > 10167300
+	_, err = s.MsgServer().UnbondedRelayer(s.Ctx, &types.MsgUnbondedRelayer{
+		ChainName:      s.chainName,
+		RelayerAddress: s.relayerAddrs[0].String(),
+	})
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "need to pass a proposal to unbond")
+}
+

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -139,6 +139,12 @@ func (s MsgServer) UnbondedRelayer(c context.Context, msg *types.MsgUnbondedRela
 	relayerAddress := sdk.MustAccAddressFromBech32(msg.RelayerAddress)
 	ctx := sdk.UnwrapSDKContext(c)
 
+	if ctx.BlockHeight() > 10167300 {
+		if s.IsProposalRelayer(ctx, msg.RelayerAddress) {
+			return nil, errorsmod.Wrap(types.ErrInvalid, "need to pass a proposal to unbond")
+		}
+	}
+
 	relayer, found := s.GetRelayer(ctx, relayerAddress)
 	if !found {
 		return nil, types.ErrNotFoundRelayer


### PR DESCRIPTION
### Description
Addresses Issue #679.

Currently, the governance gate check in `UnbondedRelayer` of `x/gravity/keeper/msg_server.go` is commented out. This allows any hardcoded bridge relayer to unbond and exit the bridge unilaterally without a governance proposal, which undermines bridge security and trust assumptions.

This change:
1. Uncomments the block height and proposal relayer unbonding validation checks in `UnbondedRelayer`.
2. Adds a comprehensive unit test `TestUnbondedRelayer_GovernanceGate` in `x/gravity/keeper/abci_test.go` to verify that when block height is above the activation threshold, calling `UnbondedRelayer` on a proposed relayer returns the expected governance proposal requirement error.
