### PR TITLE
fix(bridgingfee): fail packet receipt on charge bridging fee failure (#683)

### DIFF
--- a/ibctesting/bridging_fee_test.go
+++ b/ibctesting/bridging_fee_test.go
@@ -1,12 +1,15 @@
 package ibctesting_test
 
 import (
+	"reflect"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
+	"github.com/openmetaearth/me-hub/x/bridgingfee"
 	"github.com/osmosis-labs/osmosis/v15/x/txfees"
 	"github.com/stretchr/testify/suite"
 )
@@ -105,3 +108,74 @@ func (s *bridgingFeeSuite) TestBridgingFee() {
 	txFeesBalance := s.hubApp().BankKeeper.GetBalance(s.hubCtx(), addr.GetAddress(), denom)
 	s.Equal(expectedFee, txFeesBalance.Amount)
 }
+
+func (s *bridgingFeeSuite) TestBridgingFeeChargeFailure() {
+	path := s.newTransferPath(s.hubChain(), s.rollappChain())
+	s.coordinator.Setup(path)
+	s.createRollappWithFinishedGenesis(path.EndpointA.ChannelID)
+	s.registerSequencer()
+
+	rollappEndpoint := path.EndpointB
+
+	// Update rollapp state
+	currentRollappBlockHeight := uint64(s.rollappCtx().BlockHeight())
+	s.updateRollappState(currentRollappBlockHeight)
+
+	// Traverse the TransferStack to find the bridging fee module
+	var bfModule *bridgingfee.IBCModule
+	curr := s.hubApp().TransferStack
+	for curr != nil {
+		if bf, ok := curr.(*bridgingfee.IBCModule); ok {
+			bfModule = bf
+			break
+		}
+		v := reflect.ValueOf(curr)
+		if v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+		f := v.FieldByName("IBCModule")
+		if f.IsValid() && f.CanInterface() {
+			if next, ok := f.Interface().(porttypes.IBCModule); ok {
+				curr = next
+				continue
+			}
+		}
+		break
+	}
+	s.Require().NotNil(bfModule)
+
+	// Modify FeeModuleAddr to a invalid address to force fee transfer failure
+	bfModule.FeeModuleAddr = sdk.AccAddress("invalid_address_here")
+
+	timeoutHeight := clienttypes.NewHeight(100, 110)
+	amount, ok := sdk.NewIntFromString("10000000000000000000") // 10DYM
+	s.Require().True(ok)
+	coinToSendToB := sdk.NewCoin(sdk.DefaultBondDenom, amount)
+
+	// Initiate transfer on rollapp
+	msg := types.NewMsgTransfer(
+		rollappEndpoint.ChannelConfig.PortID,
+		rollappEndpoint.ChannelID,
+		coinToSendToB,
+		s.rollappChain().SenderAccount.GetAddress().String(),
+		s.hubChain().SenderAccount.GetAddress().String(),
+		timeoutHeight,
+		0,
+		"",
+	)
+	res, err := s.rollappChain().SendMsgs(msg)
+	s.Require().NoError(err)
+	packet, err := ibctesting.ParsePacketFromEvents(res.GetEvents())
+	s.Require().NoError(err)
+
+	err = path.RelayPacket(packet)
+	s.Require().Error(err)
+
+	// Finalize the rollapp state
+	currentRollappBlockHeight = uint64(s.rollappCtx().BlockHeight())
+	_, err = s.finalizeRollappState(1, currentRollappBlockHeight)
+	// Finalization should fail or fail to process/release the packet because the bridging fee transfer fails, returning an error acknowledgement
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "charge bridging fee failed")
+}
+

--- a/x/bridgingfee/ibc_module.go
+++ b/x/bridgingfee/ibc_module.go
@@ -27,7 +27,7 @@ type IBCModule struct {
 	rollappKeeper    rollappkeeper.Keeper
 	delayedAckKeeper delayedackkeeper.Keeper
 	transferKeeper   transferkeeper.Keeper
-	feeModuleAddr    sdk.AccAddress
+	FeeModuleAddr    sdk.AccAddress
 }
 
 func NewIBCModule(
@@ -41,7 +41,7 @@ func NewIBCModule(
 		IBCModule:        next,
 		delayedAckKeeper: keeper,
 		transferKeeper:   transferKeeper,
-		feeModuleAddr:    feeModuleAddr,
+		FeeModuleAddr:    feeModuleAddr,
 		rollappKeeper:    rollappKeeper,
 	}
 }
@@ -85,26 +85,24 @@ func (w *IBCModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 		return w.IBCModule.OnRecvPacket(ctx, packet, relayer)
 	}
 	feeData.Amount = fee.String()
-	feeData.Receiver = w.feeModuleAddr.String()
+	feeData.Receiver = w.FeeModuleAddr.String()
 
 	// No event emitted, as we called the transfer keeper directly (vs the transfer middleware)
 	err = w.transferKeeper.OnRecvPacket(ctx, packet, feeData.FungibleTokenPacketData)
 	if err != nil {
 		l.Error("Charge bridging fee.", "err", err)
-		// we continue as we don't want the fee charge to fail the transfer in any case
-		fee = sdk.ZeroInt()
-	} else {
-		ctx.EventManager().EmitEvent(
-			sdk.NewEvent(
-				EventTypeBridgingFee,
-				sdk.NewAttribute(AttributeKeyFee, fee.String()),
-				sdk.NewAttribute(sdk.AttributeKeySender, transfer.Sender),
-				sdk.NewAttribute(transfertypes.AttributeKeyReceiver, transfer.Receiver),
-				sdk.NewAttribute(transfertypes.AttributeKeyDenom, transfer.Denom),
-				sdk.NewAttribute(transfertypes.AttributeKeyAmount, transfer.Amount),
-			),
-		)
+		return channeltypes.NewErrorAcknowledgement(errorsmod.Wrapf(err, "%s: charge bridging fee failed", ModuleName))
 	}
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypeBridgingFee,
+			sdk.NewAttribute(AttributeKeyFee, fee.String()),
+			sdk.NewAttribute(sdk.AttributeKeySender, transfer.Sender),
+			sdk.NewAttribute(transfertypes.AttributeKeyReceiver, transfer.Receiver),
+			sdk.NewAttribute(transfertypes.AttributeKeyDenom, transfer.Denom),
+			sdk.NewAttribute(transfertypes.AttributeKeyAmount, transfer.Amount),
+		),
+	)
 
 	// transfer the rest to the original recipient
 	transfer.Amount = transfer.MustAmountInt().Sub(fee).String()


### PR DESCRIPTION
### Description
Addresses Issue #683.

Currently, if the bridging fee transfer fails in `OnRecvPacket` of `x/bridgingfee/ibc_module.go`, the fee is silently set to zero and the full transfer amount is forwarded to the recipient. This allows users/attackers to bypass the bridging fee entirely on every transfer if they can induce a fee transfer failure.

This change:
1. Returns an error acknowledgement when the bridging fee transfer fails, rolling back the IBC transfer and preventing the fee bypass.
2. Renames `feeModuleAddr` to `FeeModuleAddr` (exporting it) to allow test cases to override the fee module address to force/verify failure paths.
3. Adds a comprehensive integration test case `TestBridgingFeeChargeFailure` in `ibctesting/bridging_fee_test.go` to verify that packet receipt and finalization fail when a bridging fee transfer fails.
