### PR TITLE
fix(eibc): validate demand order after fee/price updates in UpdateDemandOrder (#709)

### DIFF
--- a/x/eibc/keeper/msg_server.go
+++ b/x/eibc/keeper/msg_server.go
@@ -118,6 +118,11 @@ func (m msgServer) UpdateDemandOrder(goCtx context.Context, msg *types.MsgUpdate
 	demandOrder.Fee = sdk.NewCoins(sdk.NewCoin(denom, newFeeInt))
 	demandOrder.Price = sdk.NewCoins(sdk.NewCoin(denom, newPrice))
 
+	err = demandOrder.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	err = m.SetDemandOrder(ctx, demandOrder)
 	if err != nil {
 		return nil, err

--- a/x/eibc/keeper/msg_server_test.go
+++ b/x/eibc/keeper/msg_server_test.go
@@ -252,6 +252,12 @@ func (suite *KeeperTestSuite) TestMsgUpdateDemandOrder() {
 			submittedBy: eibcSupplyAddr.String(),
 			expectError: true,
 		},
+		{
+			name:        "negative fee",
+			newFee:      sdk.NewInt(-100),
+			submittedBy: eibcSupplyAddr.String(),
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Description
Addresses Issue #709.

Currently, `UpdateDemandOrder` in `x/eibc/keeper/msg_server.go` modifies a demand order's Fee and Price fields, and saves it without calling `demandOrder.Validate()`. This is inconsistent with the creation flow (which validates the order structure first) and allows storing invalid demand orders in state (e.g. invalid coins, negative fee values, inconsistent denoms).

This change:
1. Adds a validation call to `demandOrder.Validate()` in `UpdateDemandOrder` before saving the updated order to the keeper store.
2. Adds a validation test case in `x/eibc/keeper/msg_server_test.go` to verify that invalid fee values (like negative numbers) are now successfully validated and rejected during updates.
