### PR TITLE
fix(gravity): mint delegate coins to module accounts during v2.0.13 upgrade (#680)

### DIFF
--- a/app/upgrades/v2_0_13/upgrade.go
+++ b/app/upgrades/v2_0_13/upgrade.go
@@ -8,6 +8,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	appkeepers "github.com/openmetaearth/me-hub/app/keepers"
+	appparams "github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/app/upgrades"
 	"github.com/openmetaearth/me-hub/utils"
 	bsctypes "github.com/openmetaearth/me-hub/x/bsc/types"
@@ -58,16 +59,15 @@ func CreateUpgradeHandler(
 
 		// delegate total amount to module account
 		delegateAmount := sdk.NewInt(1 * 1e8)
-		//for _, relayerAddr := range proposalRelayers {
-		//if err := keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, sdk.MustAccAddressFromBech32(relayerAddr), bsctypes.ModuleName,
-		//	sdk.NewCoins(sdk.NewCoin(params.BaseDenom, delegateAmount))); err != nil {
-		//	panic(fmt.Sprintf("failed to delegate coins to relayer %s: %s", relayerAddr, err.Error()))
-		//}
-		//if err := keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, sdk.MustAccAddressFromBech32(relayerAddr), trontypes.ModuleName,
-		//	sdk.NewCoins(sdk.NewCoin(params.BaseDenom, delegateAmount))); err != nil {
-		//	panic(fmt.Sprintf("failed to delegate coins to relayer %s: %s", relayerAddr, err.Error()))
-		//}
-		//}
+		// Mint delegate total amount directly to module accounts to back the phantom delegations
+		totalDelegateAmount := delegateAmount.MulRaw(int64(len(proposalRelayers)))
+		totalCoins := sdk.NewCoins(sdk.NewCoin(appparams.BaseDenom, totalDelegateAmount))
+		if err := keepers.BankKeeper.MintCoins(ctx, bsctypes.ModuleName, totalCoins); err != nil {
+			panic(fmt.Sprintf("failed to mint coins for bsc module account: %s", err.Error()))
+		}
+		if err := keepers.BankKeeper.MintCoins(ctx, trontypes.ModuleName, totalCoins); err != nil {
+			panic(fmt.Sprintf("failed to mint coins for tron module account: %s", err.Error()))
+		}
 
 		bscGenState := GenGravityGenesis(ctx.BlockHeight(), proposalRelayers, bsctypes.DefaultGenesisState(), delegateAmount, bsctypes.ModuleName)
 		gravitykeeper.InitGenesis(ctx, keepers.BscKeeper, bscGenState)

--- a/x/gravity/keeper/abci_test.go
+++ b/x/gravity/keeper/abci_test.go
@@ -553,3 +553,45 @@ func (s *KeeperTestSuite) TestSlashRelayer() {
 		s.Require().Equal(int64(1), relayer.SlashTimes)
 	}
 }
+
+func (s *KeeperTestSuite) TestUnbondedRelayer_PhantomStake() {
+	// Initialize a relayer directly in the store, mirroring the genesis/upgrade behavior
+	// (i.e. delegateAmount is set in store, but the module account is not funded via BondedRelayer)
+	relayerAddr := s.relayerAddrs[0]
+	externalAddress := s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)
+	delegateAmount := sdk.NewInt(1 * 1e8)
+
+	relayer := types.Relayer{
+		RelayerAddress:  relayerAddr.String(),
+		ExternalAddress: externalAddress,
+		DelegateAmount:  delegateAmount,
+		StartHeight:     s.Ctx.BlockHeight(),
+		Online:          false, // offline so we can unbond
+		SlashTimes:      0,
+	}
+	s.Keeper().SetRelayer(s.Ctx, relayerAddr, relayer)
+	s.Keeper().SetRelayerByExternalAddress(s.Ctx, externalAddress, relayerAddr)
+
+	// Attempting to unbond now should fail because module account has 0 funds
+	_, err := s.MsgServer().UnbondedRelayer(s.Ctx, &types.MsgUnbondedRelayer{
+		ChainName:      s.chainName,
+		RelayerAddress: relayerAddr.String(),
+	})
+	s.Require().Error(err)
+
+	// Now fund the module account directly (simulating the fix in upgrade handler)
+	err = s.App.BankKeeper.MintCoins(s.Ctx, s.chainName, sdk.NewCoins(sdk.NewCoin(params.BaseDenom, delegateAmount)))
+	s.Require().NoError(err)
+
+	// Unbond should now succeed
+	_, err = s.MsgServer().UnbondedRelayer(s.Ctx, &types.MsgUnbondedRelayer{
+		ChainName:      s.chainName,
+		RelayerAddress: relayerAddr.String(),
+	})
+	s.Require().NoError(err)
+
+	// Verify relayer was deleted
+	_, found := s.Keeper().GetRelayer(s.Ctx, relayerAddr)
+	s.Require().False(found)
+}
+


### PR DESCRIPTION
Addresses Issue #680

## Problem

During the `v2.0.13` upgrade in `app/upgrades/v2_0_13/upgrade.go`, the proposal relayers were initialized with a default `DelegateAmount` of `1e8` in the store, but the actual bank transfers of native coins (`umec`) from the relayer accounts to the module accounts (`bsc` and `tron`) were commented out.

Consequently, when any of these proposal relayers go offline and later attempt to unbond (`UnbondedRelayer`), the system computes a positive `slashAmount` and attempts to send coins from the module account to the `SlashingModuleAccount`, and the remaining `unbondAmount` back to the relayer. Since the module account holds zero or insufficient coins, this bank transfer fails, preventing the relayers from unbonding and locking their statuses indefinitely.

## Solution

To back the delegations with actual native coins without requiring the relayer accounts (which might be new or unbacked at upgrade time) to hold the funds initially, we:
1. Mint the total required delegate amount (`5 * 1e8 umec`) directly to the `bsc` and `tron` module accounts during the `v2.0.13` upgrade handler using `keepers.BankKeeper.MintCoins`. This matches the total power recorded in the state.
2. Added a unit test `TestUnbondedRelayer_PhantomStake` in `x/gravity/keeper/abci_test.go` to verify that unbonding fails when the module account is unfunded and succeeds once the module account is funded.
