### PR TITLE
fix(eibc): implement rollappHasPacketCommitment verification in tests (#677)

### DIFF
--- a/ibctesting/eibc_test.go
+++ b/ibctesting/eibc_test.go
@@ -367,11 +367,15 @@ func (s *eibcSuite) TestEIBCDemandOrderFulfillment() {
 }
 
 func (s *eibcSuite) rollappHasPacketCommitment(packet channeltypes.Packet) bool {
-	// TODO: this should be used to check that a commitment does (or doesn't) exist, when it should
-	// TODO: this is important to check that things actually work as expected and dont just look ok on the outside
-	// TODO: finish implementing, true is a temporary placeholder
-	return true
+	rollappIBCKeeper := s.rollappApp().GetIBCKeeper()
+	return rollappIBCKeeper.ChannelKeeper.HasPacketCommitment(
+		s.rollappCtx(),
+		packet.GetSourcePort(),
+		packet.GetSourceChannel(),
+		packet.GetSequence(),
+	)
 }
+
 
 // TestTimeoutEIBCDemandOrderFulfillment: when a packet hub->rollapp times out, or gets an error ack, than eIBC can be used to recover quickly.
 func (s *eibcSuite) TestTimeoutEIBCDemandOrderFulfillment() {


### PR DESCRIPTION
Addresses Issue #677

## Problem

The function `rollappHasPacketCommitment` in `ibctesting/eibc_test.go` was hardcoded to always return `true` as a placeholder, meaning any packet commitment assertions in the eIBC test suite were bypassable and did not perform actual verification against the rollapp's chain state.

## Solution

We replaced the placeholder return value in `rollappHasPacketCommitment` with an actual query to the rollapp's IBC channel keeper:
```go
func (s *eibcSuite) rollappHasPacketCommitment(packet channeltypes.Packet) bool {
	rollappIBCKeeper := s.rollappApp().GetIBCKeeper()
	return rollappIBCKeeper.ChannelKeeper.HasPacketCommitment(
		s.rollappCtx(),
		packet.GetSourcePort(),
		packet.GetSourceChannel(),
		packet.GetSequence(),
	)
}
```
This ensures packet commitment status is correctly checked in all test cases.
