### PR TITLE
fix(kyc): prevent empty region entries in GetAllRegions response (#671)

### DIFF
--- a/x/kyc/keeper/keeper_test.go
+++ b/x/kyc/keeper/keeper_test.go
@@ -107,3 +107,15 @@ func (s *KeeperTestSuite) TestPubKeyFromString() {
 	secpAccAddr, _ := s.Keeper().MustAccAddressFromPubkeyString(secp256k1Pubkey)
 	s.Require().Equal("me1kj3emedrrq66vdqf3pzpfjmytympl4j2a4xd0c", secpAccAddr.String())
 }
+
+func (s *KeeperTestSuite) TestGetAllRegions() {
+	s.SetupTest()
+	regions := s.Keeper().GetAllRegions(s.Ctx)
+	// We expect exactly 3 regions that were set up in SetupTest
+	s.Require().Equal(3, len(regions))
+	for _, reg := range regions {
+		s.Require().NotEmpty(reg.Id)
+		s.Require().NotEmpty(reg.Name)
+	}
+}
+

--- a/x/kyc/keeper/protocol.go
+++ b/x/kyc/keeper/protocol.go
@@ -25,13 +25,14 @@ func (k *Keeper) GetRegion(ctx sdk.Context, regionId string) (reg types.Region, 
 
 func (k *Keeper) GetAllRegions(ctx sdk.Context) (regs []types.Region) {
 	raws := k.stkKeeper.GetAllRegion(ctx)
-	regions := make([]types.Region, len(raws))
+	regions := make([]types.Region, 0, len(raws))
 	for _, rew := range raws {
 		regions = append(regions, types.Region{Id: rew.RegionId, Name: rew.Name})
 	}
 
 	return regions
 }
+
 
 func (k *Keeper) GetProtocol(ctx sdk.Context) (types.Protocol, bool) {
 	svc, found := k.GetService(ctx)


### PR DESCRIPTION
Addresses Issue #671

## Problem

The function `GetAllRegions` in `x/kyc/keeper/protocol.go` preallocated the result slice with `make([]types.Region, len(raws))` (which fills it with zero-value regions) and then used `append` to populate it. This resulted in `2n` entries inside responses, where the first `n` entries were empty, zero-value region objects.

## Solution

We initialized the result slice with length 0 and capacity `len(raws)` instead:
```go
regions := make([]types.Region, 0, len(raws))
```
This ensures that only the actual regions in state are returned in the query response.

We also added a unit test `TestGetAllRegions` in `x/kyc/keeper/keeper_test.go` to verify that `GetAllRegions` returns exactly the correct list of regions without empty values.
