### PR TITLE
fix(did): persist updated FilterLogger on partial filter deletion (#670)

### DIFF
--- a/x/did/keeper/filter.go
+++ b/x/did/keeper/filter.go
@@ -57,6 +57,8 @@ func (k Keeper) DeleteFilters(ctx sdk.Context, did, sid string, filters [][]byte
 	// delete empty FilterLogger
 	if len(flog.Filters) == 0 {
 		k.DeleteFilterLogger(ctx, did, sid)
+	} else {
+		k.SetFilterLogger(ctx, did, sid, flog)
 	}
 }
 

--- a/x/did/keeper/filter_test.go
+++ b/x/did/keeper/filter_test.go
@@ -46,4 +46,16 @@ func TestKeeper_Filter(t *testing.T) {
 	assert.Equal(t, 0, len(vcs))
 	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f2, &pr)
 	assert.Equal(t, 0, len(vcs))
+
+	// partial delete
+	k.AddFilters(ctx, did, sid, filters, vc)
+	k.DeleteFilters(ctx, did, sid, [][]byte{f1})
+	fs, found = k.GetFilters(ctx, did, sid)
+	assert.True(t, found)
+	assert.Equal(t, 1, len(fs))
+	assert.Equal(t, f2, fs[0])
+
+	k.DeleteFilters(ctx, did, sid, [][]byte{f2})
+	fs, found = k.GetFilters(ctx, did, sid)
+	assert.False(t, found)
 }


### PR DESCRIPTION
Addresses Issue #670

## Problem

The function `DeleteFilters` in `x/did/keeper/filter.go` deletes filters and updates the in-memory `FilterLogger` struct. However, it only called the keeper method to delete the empty logger when `len(flog.Filters) == 0`. In case of a partial filter deletion (where `len(flog.Filters) > 0`), it did not call `SetFilterLogger` to write the updated logger structure back to the store, leaving stale filter logger entries.

## Solution

We added an `else` block to call `SetFilterLogger` and persist the modified `FilterLogger` in case of partial filter deletion:
```go
	// delete empty FilterLogger
	if len(flog.Filters) == 0 {
		k.DeleteFilterLogger(ctx, did, sid)
	} else {
		k.SetFilterLogger(ctx, did, sid, flog)
	}
```

We also added a unit test case `TestKeeper_Filter` in `x/did/keeper/filter_test.go` to assert that partial filter deletion updates the `FilterLogger` correctly.
