### PR TITLE
fix(did): reserve kyc credential route

### DIFF
--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -21,6 +21,12 @@ func NewMsgServerImpl(keeper *Keeper) types.MsgServer {
 
 var _ types.MsgServer = msgServer{}
 
+const reservedKYCCredentialSID = "kyc"
+
+func isReservedCredentialSID(sid string) bool {
+	return sid == reservedKYCCredentialSID
+}
+
 func (m msgServer) CreateDid(goCtx context.Context, msg *types.MsgCreateDid) (*types.MsgCreateDidResponse, error) {
 
 	// API inactive
@@ -134,6 +140,10 @@ func (m msgServer) UpdateServiceStatus(goCtx context.Context, msg *types.MsgUpda
 func (m msgServer) CreateVC(goCtx context.Context, msg *types.MsgCreateVC) (*types.MsgCreateVCResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	if isReservedCredentialSID(msg.Sid) {
+		return &types.MsgCreateVCResponse{}, types.ErrReservedCredential
+	}
+
 	// check credential service
 	svc, found := m.GetService(ctx, msg.Sid)
 	if !found || svc.Status != types.SERVICE_STATUS_ACTIVE {
@@ -174,6 +184,10 @@ func (m msgServer) CreateVC(goCtx context.Context, msg *types.MsgCreateVC) (*typ
 func (m msgServer) UpdateVC(goCtx context.Context, msg *types.MsgUpdateVC) (*types.MsgUpdateVCResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	if isReservedCredentialSID(msg.Sid) {
+		return &types.MsgUpdateVCResponse{}, types.ErrReservedCredential
+	}
+
 	// check vc
 	if found := m.HasCredential(ctx, msg.Did, msg.Sid); !found {
 		return &types.MsgUpdateVCResponse{}, types.ErrCredentialNotFound
@@ -213,6 +227,10 @@ func (m msgServer) UpdateVC(goCtx context.Context, msg *types.MsgUpdateVC) (*typ
 
 func (m msgServer) RemoveVC(goCtx context.Context, msg *types.MsgRemoveVC) (*types.MsgRemoveVCResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if isReservedCredentialSID(msg.Sid) {
+		return &types.MsgRemoveVCResponse{}, types.ErrReservedCredential
+	}
 
 	// check credential service
 	svc, found := m.GetService(ctx, msg.Sid)

--- a/x/did/keeper/msg_server_test.go
+++ b/x/did/keeper/msg_server_test.go
@@ -1,0 +1,37 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	testkeeper "github.com/openmetaearth/me-hub/testutil/keeper"
+	didkeeper "github.com/openmetaearth/me-hub/x/did/keeper"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgServer_RemoveVCRejectsReservedKYCSID(t *testing.T) {
+	k, ctx := testkeeper.DidKeeper(t)
+	msgServer := didkeeper.NewMsgServerImpl(k)
+
+	issuerAddr := sdk.MustAccAddressFromBech32("me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4")
+	holderAddr := sdk.MustAccAddressFromBech32("me13w3mxrd9tvq3r6gzheqjuzf8pnaruvug5787yu")
+	issuerDID := "1000000000001"
+	holderDID := "1000000000002"
+	const kycSID = "kyc"
+
+	k.SetDID(ctx, issuerAddr, issuerDID)
+	k.SetDidInfo(ctx, issuerDID, didtypes.NewDidInfo(issuerDID, issuerAddr.String(), "", didtypes.DID_STATUS_ACTIVE))
+	k.SetDidInfo(ctx, holderDID, didtypes.NewDidInfo(holderDID, holderAddr.String(), "", didtypes.DID_STATUS_ACTIVE))
+	k.SetService(ctx, kycSID, didtypes.NewService(kycSID, kycSID, "reserved KYC service", didtypes.SERVICE_STATUS_ACTIVE, []string{issuerDID}))
+
+	credential := didtypes.NewCredential(holderDID, kycSID, "hash-before-remove", "https://example.com/kyc", []byte("me_earth"))
+	k.SetCredential(ctx, holderDID, kycSID, credential)
+
+	_, err := msgServer.RemoveVC(ctx, didtypes.NewMsgRemoveVC(issuerAddr.String(), holderDID, kycSID))
+	require.ErrorIs(t, err, didtypes.ErrReservedCredential)
+
+	got, found := k.GetCredential(ctx, holderDID, kycSID)
+	require.True(t, found)
+	require.Equal(t, credential, got)
+}

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -31,4 +31,5 @@ var (
 
 	ErrCredentialExists   = errors.Register(ModuleName, 150, "credential already exists")
 	ErrCredentialNotFound = errors.Register(ModuleName, 151, "credential not found")
+	ErrReservedCredential = errors.Register(ModuleName, 152, "credential service is reserved")
 )


### PR DESCRIPTION
## Summary
- Reject public DID CreateVC, UpdateVC, and RemoveVC calls for the reserved kyc credential SID.
- Keep KYC credential lifecycle changes on the KYC module path, where status, filters, rewards, and derived state are cleaned consistently.
- Add regression coverage proving DID RemoveVC no longer deletes an existing kyc credential.

## Issue
Fixes #365

## Tests
- go test ./x/did/keeper -run TestMsgServer_RemoveVCRejectsReservedKYCSID -count=1 -v
- go test ./x/did/keeper -run 'TestMsgServer_RemoveVCRejectsReservedKYCSID|TestKeeper_(Credential|Filter|GetCredentialsByFilterDoesNotMatchLongerRegionPrefix)' -count=1 -v
- git diff --check

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099