### PR TITLE
fix(did): delete old DID filters on VC update (#669)

### DIFF
--- a/x/did/keeper/filter_test.go
+++ b/x/did/keeper/filter_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/openmetaearth/me-hub/testutil/keeper"
 	didtypes "github.com/openmetaearth/me-hub/x/did/types"
@@ -46,4 +47,72 @@ func TestKeeper_Filter(t *testing.T) {
 	assert.Equal(t, 0, len(vcs))
 	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f2, &pr)
 	assert.Equal(t, 0, len(vcs))
+}
+
+func TestMsgServer_UpdateVC(t *testing.T) {
+	k, ctx := keeper.DidKeeper(t)
+	srv := keeper.NewMsgServerImpl(k)
+
+	did := "1000000000000001"
+	issuer := "1000000000000002"
+	sid := "test-service"
+
+	// setup state
+	k.SetDidInfo(ctx, did, didtypes.DidInfo{Did: did, Status: didtypes.DID_STATUS_ACTIVE})
+	k.SetDidInfo(ctx, issuer, didtypes.DidInfo{Did: issuer, Status: didtypes.DID_STATUS_ACTIVE})
+	issuerAddr := sdk.MustAccAddressFromBech32("me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4")
+	k.SetDID(ctx, issuerAddr, issuer)
+	k.SetService(ctx, sid, didtypes.Service{
+		Sid:     sid,
+		Status:  didtypes.SERVICE_STATUS_ACTIVE,
+		Issuers: []string{issuer},
+	})
+
+	// create initial credential and filters
+	f1 := []byte("filter1")
+	f2 := []byte("filter2")
+
+	msgCreate := &didtypes.MsgCreateVC{
+		Did:     did,
+		Sid:     sid,
+		Issuer:  issuerAddr.String(),
+		Filters: [][]byte{f1, f2},
+	}
+	_, err := srv.CreateVC(sdk.WrapSDKContext(ctx), msgCreate)
+	assert.NoError(t, err)
+
+	// verify filters added
+	fs, found := k.GetFilters(ctx, did, sid)
+	assert.True(t, found)
+	assert.Equal(t, 2, len(fs))
+
+	// update VC with new filters (f3, f4)
+	f3 := []byte("filter3")
+	f4 := []byte("filter4")
+	msgUpdate := &didtypes.MsgUpdateVC{
+		Did:     did,
+		Sid:     sid,
+		Issuer:  issuerAddr.String(),
+		Filters: [][]byte{f3, f4},
+	}
+	_, err = srv.UpdateVC(sdk.WrapSDKContext(ctx), msgUpdate)
+	assert.NoError(t, err)
+
+	// verify new filters are active and old ones are deleted
+	fs, found = k.GetFilters(ctx, did, sid)
+	assert.True(t, found)
+	assert.Equal(t, 2, len(fs))
+	assert.Contains(t, fs, f3)
+	assert.Contains(t, fs, f4)
+
+	// verify old credentials by filter returns 0
+	pr := query.PageRequest{}
+	vcs, _, _ := k.GetCredentialsByFilter(ctx, sid, f1, &pr)
+	assert.Equal(t, 0, len(vcs))
+	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f2, &pr)
+	assert.Equal(t, 0, len(vcs))
+
+	// verify new credentials by filter returns 1
+	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f3, &pr)
+	assert.Equal(t, 1, len(vcs))
 }

--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -200,6 +200,11 @@ func (m msgServer) UpdateVC(goCtx context.Context, msg *types.MsgUpdateVC) (*typ
 		return &types.MsgUpdateVCResponse{}, types.ErrHolderNotActive
 	}
 
+	// delete old filters
+	if oldFilters, found := m.GetFilters(ctx, msg.Did, msg.Sid); found {
+		m.DeleteFilters(ctx, msg.Did, msg.Sid, oldFilters)
+	}
+
 	// update VC
 	vc := msg.GetCredential()
 	m.SetCredential(ctx, msg.Did, msg.Sid, vc)


### PR DESCRIPTION
Addresses Issue #669

## Problem

The function `UpdateVC` in `x/did/keeper/msg_server.go` registers filter indexes for the new credential values, but it does not remove the filter indexes associated with the previous credential values. This leaves stale DID filter index entries that return outdated credential matches for updated credentials.

## Solution

We query and delete the old filters associated with the VC prior to adding the updated filters in `UpdateVC`:
```go
	// delete old filters
	if oldFilters, found := m.GetFilters(ctx, msg.Did, msg.Sid); found {
		m.DeleteFilters(ctx, msg.Did, msg.Sid, oldFilters)
	}
```

We also added a unit test `TestMsgServer_UpdateVC` in `x/did/keeper/filter_test.go` to assert that updating a VC deletes the old filter indexes and adds the new ones, ensuring the old filters no longer return the VC.
