### PR TITLE
fix: emit kyc remove events and sync megroup membership (#667)

### DIFF
--- a/x/kyc/keeper/msg_server.go
+++ b/x/kyc/keeper/msg_server.go
@@ -241,6 +241,19 @@ func (m msgServer) Remove(goCtx context.Context, msg *types.MsgRemove) (*types.M
 		return &types.MsgRemoveResponse{}, errors.Wrap(err, "delete reward failed")
 	}
 
+	// emit event and invoke handler
+	event := sdk.NewEvent(types.EventTypeRemove,
+		sdk.NewAttribute(types.AttributeKeyAddress, address.String()),
+		sdk.NewAttribute(types.AttributeKeyRegionId, string(kyc.Data)),
+		sdk.NewAttribute(types.AttributeKeyLevel, didInfo.KycLevel.String()),
+	)
+	ctx.EventManager().EmitEvent(event)
+
+	err := m.handlerReg.HandleEvent(ctx, types.EventTypeRemove, event)
+	if err != nil {
+		return &types.MsgRemoveResponse{}, err
+	}
+
 	return &types.MsgRemoveResponse{}, nil
 }
 

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	"github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/x/kyc/types"
+	megrouptypes "github.com/openmetaearth/me-hub/x/megroup/types"
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
 	wmintTypes "github.com/openmetaearth/me-hub/x/wmint/types"
@@ -94,6 +95,42 @@ func (s *KeeperTestSuite) TestRemove() {
 	s.Require().Equal(msg.Uri, kyc.Uri)
 	s.Require().Equal(msg.Hash, kyc.Hash)
 
+	// 1. Create a group for the region
+	groupInfo := &megrouptypes.GroupInfo{
+		Id:          1,
+		Admin:       s.Dao.GlobalDao,
+		Metadata:    "",
+		Version:     1,
+		TotalWeight: "0",
+		CreatedAt:   s.Ctx.BlockTime(),
+		RegionID:    strings.ToLower(wstakingtypes.MeEarthRegionName),
+	}
+	err = s.App.GroupKeeper.AppendGroup(s.Ctx, groupInfo)
+	s.Require().NoError(err)
+	s.App.GroupKeeper.SetGroupToRegion(s.Ctx, strings.ToLower(wstakingtypes.MeEarthRegionName), 1)
+	s.App.GroupKeeper.SetGroupMemberCount(s.Ctx, 1, 0)
+
+	// 2. Join user to the group
+	newJoin := megrouptypes.MemberJoined{
+		Address: kycAccount.String(),
+		GroupId: 1,
+	}
+	s.App.GroupKeeper.SetMemberJoined(s.Ctx, newJoin)
+	err = s.App.GroupKeeper.AddGroupMember(s.Ctx, &megrouptypes.GroupMember{
+		GroupId: 1,
+		Member: &megrouptypes.Member{
+			Address: kycAccount.String(),
+			AddedAt: s.Ctx.BlockTime(),
+		},
+	})
+	s.Require().NoError(err)
+	s.App.GroupKeeper.SetGroupMemberCount(s.Ctx, 1, 1)
+
+	// 3. Verify user is joined
+	joined, found := s.App.GroupKeeper.GetMemberJoined(s.Ctx, kycAccount.String())
+	s.Require().True(found)
+	s.Require().Equal(uint64(1), joined.GroupId)
+
 	// remove kyc
 	_, err = s.msgServer.Remove(s.Ctx, &types.MsgRemove{
 		Issuer: s.Dao.GlobalDao,
@@ -112,6 +149,18 @@ func (s *KeeperTestSuite) TestRemove() {
 	// check kyc
 	_, f = s.Keeper().GetKYC(s.Ctx, did)
 	s.Require().False(f)
+
+	// 5. Verify user is removed from group!
+	joined, found = s.App.GroupKeeper.GetMemberJoined(s.Ctx, kycAccount.String())
+	s.Require().True(found)
+	s.Require().Equal(uint64(0), joined.GroupId)
+
+	hasMember := s.App.GroupKeeper.HasGroupMember(s.Ctx, 1, kycAccount.String())
+	s.Require().False(hasMember)
+
+	count, found := s.App.GroupKeeper.GetGroupMemberCount(s.Ctx, 1)
+	s.Require().True(found)
+	s.Require().Equal(uint64(0), count)
 }
 
 func (s *KeeperTestSuite) TestUpdate() {

--- a/x/megroup/keeper/keeper.go
+++ b/x/megroup/keeper/keeper.go
@@ -64,6 +64,7 @@ func NewKeeper(
 		kycKeeper:     kycKeeper,
 	}
 	keeperVal.kycKeeper.RegisterEventHandler(kycTypes.EventTypeUpdate, 0, types.ModuleName, keeperVal.KycStatusChanged)
+	keeperVal.kycKeeper.RegisterEventHandler(kycTypes.EventTypeRemove, 0, types.ModuleName, keeperVal.KycStatusChanged)
 	return keeperVal
 }
 
@@ -72,8 +73,26 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 }
 
 func (k Keeper) KycStatusChanged(goCtx context.Context, msgType string, data interface{}) error {
-	//if eventType
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	if msgType == kycTypes.EventTypeRemove {
+		if val, ok := data.(sdk.Event); !ok {
+			return fmt.Errorf("data's type is not sdk.Event.but msgType is remove")
+		} else {
+			attrAddress, found := val.GetAttribute(kycTypes.AttributeKeyAddress)
+			if !found {
+				return fmt.Errorf("can not found AttributeKeyAddress.but EventType is remove")
+			}
+			attrRegion, found := val.GetAttribute(kycTypes.AttributeKeyRegionId)
+			if !found {
+				return fmt.Errorf("can not found AttributeKeyRegionId.but EventType is remove")
+			}
+			if err := k.procKycRegionChange(ctx, attrAddress.Value, attrRegion.Value, ""); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	if kycTypes.EventTypeUpdate != msgType {
 		return nil
 	}
@@ -105,7 +124,6 @@ func (k Keeper) KycStatusChanged(goCtx context.Context, msgType string, data int
 	}
 
 	return nil
-
 }
 
 func (k Keeper) procKycRegionChange(sdkCtx sdk.Context, address, preRegionID, nowRegionID string) error {


### PR DESCRIPTION
Addresses Issue #667

## Problem

Removing a user's KYC record does not emit the expected KYC removal event, so downstream modules such as `megroup` may not update their membership state.

When `kyc.Remove` deletes the KYC record, it does not emit a removal event or notify downstream listeners. Therefore, users remain in regional groups even after their KYC is removed, leaving group membership out of sync.

## Solution

1. Updated `x/kyc/keeper/msg_server.go::Remove` to:
   - Emit `types.EventTypeRemove` with the address, region, and level.
   - Invoke the event handlers registered for `types.EventTypeRemove` via `m.handlerReg.HandleEvent`.
2. Updated `x/megroup/keeper/keeper.go::NewKeeper` to register `keeperVal.KycStatusChanged` for `kycTypes.EventTypeRemove`.
3. Updated `KycStatusChanged` in `x/megroup/keeper/keeper.go` to handle `EventTypeRemove` events, checking that the event attributes exist and invoking `procKycRegionChange(ctx, address, regionId, "")` to transition the user out of their previous group.
4. Added a test in `x/kyc/keeper/msg_server_test.go` (`TestRemove`) that verifies a user is automatically removed from their megroup group upon KYC removal.
