### PR TITLE
fix: enqueue replaced proposer for unbonding and clean up queue on force unbond (#717)

### DIFF
--- a/x/sequencer/keeper/replace_proposer.go
+++ b/x/sequencer/keeper/replace_proposer.go
@@ -117,10 +117,14 @@ func (k Keeper) ProcSequencerByPendingStates(ctx sdk.Context, rollappId, creator
 				oldSequencer.RollappId, rollappId)
 		}
 		if oldSequencer.IsProposer() || oldSequencer.Status == types.Bonded {
+			oldStatus := oldSequencer.Status
 			oldSequencer.Proposer = false
 			oldSequencer.Status = types.Unbonding
 			oldSequencer.UnbondingHeight = ctx.BlockHeight()
-			k.UpdateSequencer(ctx, oldSequencer, types.Bonded)
+			oldSequencer.UnbondTime = ctx.BlockHeader().Time.Add(k.UnbondingTime(ctx))
+			k.UpdateSequencer(ctx, oldSequencer, oldStatus)
+			k.setUnbondingSequencerQueue(ctx, oldSequencer)
+
 			newSequencer, found := k.GetSequencer(ctx, val.ReplaceProposer.NewProposer)
 			if !found {
 				return fmt.Errorf("can not found new sequencer: %s", val.ReplaceProposer.NewProposer)

--- a/x/sequencer/keeper/replace_proposer_test.go
+++ b/x/sequencer/keeper/replace_proposer_test.go
@@ -1,0 +1,132 @@
+package keeper_test
+
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/openmetaearth/me-hub/x/sequencer/types"
+)
+
+func (suite *SequencerTestSuite) TestReplaceProposerUnbondingFlow() {
+	suite.SetupTest()
+	rollappId := suite.CreateDefaultRollapp()
+
+	// 1. Create old proposer and new proposer sequencers
+	oldProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	newProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	// Verify old proposer is indeed the proposer and status is Bonded
+	oldProposer, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, oldProposerAddr)
+	suite.Require().True(found)
+	suite.Require().Equal(types.Bonded, oldProposer.Status)
+	suite.Require().True(oldProposer.Proposer)
+
+	newProposer, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, newProposerAddr)
+	suite.Require().True(found)
+	suite.Require().Equal(types.Bonded, newProposer.Status)
+	suite.Require().False(newProposer.Proposer)
+
+	// 2. Set replace proposer request
+	replaceMsg := &types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: oldProposerAddr,
+		NewProposer: newProposerAddr,
+		BlockHeight: 100,
+	}
+	err := suite.App.SequencerKeeper.SetReplaceProposer(suite.Ctx, replaceMsg)
+	suite.Require().NoError(err)
+
+	// 3. ProcSequencerByPendingStates at height lower than replacement height
+	stateInfoLow := &rollapptypes.StateInfo{
+		StartHeight: 1,
+		NumBlocks:   50,
+	}
+	err = suite.App.SequencerKeeper.ProcSequencerByPendingStates(suite.Ctx, rollappId, oldProposerAddr, stateInfoLow)
+	suite.Require().NoError(err)
+
+	// Old proposer should still be bonded and proposer
+	oldProposer, _ = suite.App.SequencerKeeper.GetSequencer(suite.Ctx, oldProposerAddr)
+	suite.Require().Equal(types.Bonded, oldProposer.Status)
+	suite.Require().True(oldProposer.Proposer)
+
+	// 4. ProcSequencerByPendingStates at/above replacement height
+	stateInfoHigh := &rollapptypes.StateInfo{
+		StartHeight: 51,
+		NumBlocks:   50, // 51 + 50 - 1 = 100
+	}
+	suite.Ctx = suite.Ctx.WithBlockTime(time.Now())
+	err = suite.App.SequencerKeeper.ProcSequencerByPendingStates(suite.Ctx, rollappId, oldProposerAddr, stateInfoHigh)
+	suite.Require().NoError(err)
+
+	// 5. Verify status transitions
+	oldProposer, _ = suite.App.SequencerKeeper.GetSequencer(suite.Ctx, oldProposerAddr)
+	suite.Require().Equal(types.Unbonding, oldProposer.Status)
+	suite.Require().False(oldProposer.Proposer)
+	suite.Require().False(oldProposer.UnbondTime.IsZero())
+
+	newProposer, _ = suite.App.SequencerKeeper.GetSequencer(suite.Ctx, newProposerAddr)
+	suite.Require().Equal(types.Bonded, newProposer.Status)
+	suite.Require().True(newProposer.Proposer)
+
+	// Check if old sequencer is in the unbonding queue
+	unbondingSeqs := suite.App.SequencerKeeper.GetMatureUnbondingSequencers(suite.Ctx, oldProposer.UnbondTime.Add(1*time.Second))
+	suite.Require().Len(unbondingSeqs, 1)
+	suite.Require().Equal(oldProposerAddr, unbondingSeqs[0].SequencerAddress)
+
+	// 6. Test maturation path (UnbondAllMatureSequencers)
+	suite.App.SequencerKeeper.UnbondAllMatureSequencers(suite.Ctx, oldProposer.UnbondTime.Add(1*time.Second))
+	oldProposer, _ = suite.App.SequencerKeeper.GetSequencer(suite.Ctx, oldProposerAddr)
+	suite.Require().Equal(types.Unbonded, oldProposer.Status)
+
+	// Verify it was removed from the queue
+	unbondingSeqsAfter := suite.App.SequencerKeeper.GetMatureUnbondingSequencers(suite.Ctx, oldProposer.UnbondTime.Add(1*time.Second))
+	suite.Require().Len(unbondingSeqsAfter, 0)
+}
+
+func (suite *SequencerTestSuite) TestReplaceProposerForceRemoveQueueCleanup() {
+	suite.SetupTest()
+	rollappId := suite.CreateDefaultRollapp()
+
+	// 1. Create old proposer and new proposer sequencers
+	oldProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	newProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	// 2. Set replace proposer request
+	replaceMsg := &types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: oldProposerAddr,
+		NewProposer: newProposerAddr,
+		BlockHeight: 100,
+	}
+	err := suite.App.SequencerKeeper.SetReplaceProposer(suite.Ctx, replaceMsg)
+	suite.Require().NoError(err)
+
+	// 3. ProcSequencerByPendingStates to transition old proposer to Unbonding and enqueue it
+	stateInfo := &rollapptypes.StateInfo{
+		StartHeight: 1,
+		NumBlocks:   100,
+	}
+	suite.Ctx = suite.Ctx.WithBlockTime(time.Now())
+	err = suite.App.SequencerKeeper.ProcSequencerByPendingStates(suite.Ctx, rollappId, oldProposerAddr, stateInfo)
+	suite.Require().NoError(err)
+
+	oldProposer, _ := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, oldProposerAddr)
+	suite.Require().Equal(types.Unbonding, oldProposer.Status)
+
+	// Verify old proposer is in the unbonding queue
+	unbondingSeqs := suite.App.SequencerKeeper.GetMatureUnbondingSequencers(suite.Ctx, oldProposer.UnbondTime.Add(1*time.Second))
+	suite.Require().Len(unbondingSeqs, 1)
+
+	// 4. Trigger force remove unbonding sequencer (dispute period ended / state finalized)
+	err = suite.App.SequencerKeeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, stateInfo)
+	suite.Require().NoError(err)
+
+	// 5. Verify sequencer is deleted from store
+	_, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, oldProposerAddr)
+	suite.Require().False(found)
+
+	// 6. Verify sequencer is removed from the unbonding queue as well!
+	unbondingSeqsAfter := suite.App.SequencerKeeper.GetMatureUnbondingSequencers(suite.Ctx, oldProposer.UnbondTime.Add(1*time.Second))
+	suite.Require().Len(unbondingSeqsAfter, 0)
+}

--- a/x/sequencer/keeper/unbond.go
+++ b/x/sequencer/keeper/unbond.go
@@ -162,6 +162,7 @@ func (k Keeper) forceRemoveUnbondingSequencer(ctx sdk.Context, seqAddr string, r
 
 	seqByRollappKey := types.SequencerByRollappByStatusKey(seq.RollappId, seq.SequencerAddress, types.Unbonding)
 	store.Delete(seqByRollappKey)
+	k.removeUnbondingSequencer(ctx, seq)
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventDirectRemoveSequencer,


### PR DESCRIPTION
Addresses Issue #717

## Problem

When a rollapp's proposer is replaced via `ProcSequencerByPendingStates`, the old sequencer transitions to `Unbonding` status, but:
1. `UnbondTime` is never set.
2. `setUnbondingSequencerQueue` is never called.
3. The previous status is hardcoded to `types.Bonded` when calling `UpdateSequencer`.

This causes the old sequencer's bonded tokens to be permanently locked in the module account if the rollapp halts, fraud is submitted, or finalization never fires (since tokens are normally returned only during the `AfterStateFinalized` hook).

Furthermore, if the sequencer is added to the unbonding queue, but `forceRemoveUnbondingSequencer` (finalization path) runs, the sequencer is deleted from the store, but it remains in the unbonding queue. When the mature time is reached, `UnbondAllMatureSequencers` will repeatedly fail with `types.ErrUnknownSequencer` and log errors on every single block because the queue entry is never cleaned up.

## Solution

1. Updated `ProcSequencerByPendingStates` in `x/sequencer/keeper/replace_proposer.go` to:
   - Set the `UnbondTime` on the old sequencer (block header time + unbonding time).
   - Enqueue the old sequencer in the unbonding queue via `k.setUnbondingSequencerQueue`.
   - Update the sequencer using its actual previous status (`oldStatus`) instead of hardcoding `types.Bonded`.
2. Updated `forceRemoveUnbondingSequencer` in `x/sequencer/keeper/unbond.go` to call `k.removeUnbondingSequencer(ctx, seq)`, cleaning up the unbonding queue and preventing orphaned queue entries.
3. Added comprehensive unit tests in `x/sequencer/keeper/replace_proposer_test.go` (`TestReplaceProposerUnbondingFlow` and `TestReplaceProposerForceRemoveQueueCleanup`) to verify that:
   - Replaced proposers are correctly set to `Unbonding`, enqueued, and matured/refunded.
   - Force removing a replaced sequencer correctly deletes the sequencer and cleans up the unbonding queue.
