### PR TITLE
fix(wbank): validate fee receivers before transfer

### DIFF
--- a/x/wbank/keeper/keeper.go
+++ b/x/wbank/keeper/keeper.go
@@ -92,27 +92,32 @@ func (k BaseKeeperWrapper) UnstakeCoinsFromModuleToModule(
 }
 
 func (k BaseKeeperWrapper) FeeToReceivers(ctx sdk.Context, inputs []banktypes.Input, outputs []banktypes.Output, receiverTypes []types.FeeReceiverType) error {
+	if len(inputs) == 0 {
+		return errors.New("inputs error")
+	}
+
+	if len(receiverTypes) != len(outputs) {
+		return sdkerrors.Wrapf(
+			sdkerrors.ErrInvalidRequest,
+			"fee receiver types and outputs are not equal: got %d receiver types for %d outputs",
+			len(receiverTypes),
+			len(outputs),
+		)
+	}
+
 	err := k.InputOutputCoins(ctx, inputs, outputs)
 	if err != nil {
 		return sdkerrors.Wrap(err, "failed to process input-output coins")
 	}
 
-	if len(receiverTypes) != len(outputs) {
-		return sdkerrors.Wrap(err, "fee receiver types and outputs are not equal")
-	}
-
 	attributes := []sdk.Attribute{}
-	if len(inputs) > 0 {
-		attributes = append(attributes, sdk.NewAttribute(sdk.AttributeKeySender, inputs[0].Address))
-		for index, output := range outputs {
-			attributes = append(attributes, sdk.NewAttribute(fmt.Sprintf("%s", receiverTypes[index]), output.Address))
-			attributes = append(attributes, sdk.NewAttribute(fmt.Sprintf("%s_amount", receiverTypes[index]), output.Coins.String()))
-		}
-		event := sdk.NewEvent(types.EventTypeFeeToReceivers, attributes...)
-		ctx.EventManager().EmitEvent(event)
-	} else {
-		return errors.New("inputs error")
+	attributes = append(attributes, sdk.NewAttribute(sdk.AttributeKeySender, inputs[0].Address))
+	for index, output := range outputs {
+		attributes = append(attributes, sdk.NewAttribute(fmt.Sprintf("%s", receiverTypes[index]), output.Address))
+		attributes = append(attributes, sdk.NewAttribute(fmt.Sprintf("%s_amount", receiverTypes[index]), output.Coins.String()))
 	}
+	event := sdk.NewEvent(types.EventTypeFeeToReceivers, attributes...)
+	ctx.EventManager().EmitEvent(event)
 	return nil
 }
 

--- a/x/wbank/keeper/keeper_test.go
+++ b/x/wbank/keeper/keeper_test.go
@@ -1,0 +1,37 @@
+package keeper_test
+
+import (
+	"testing"
+
+	cometbftproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankutil "github.com/cosmos/cosmos-sdk/x/bank/testutil"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	"github.com/openmetaearth/me-hub/app/params"
+	wbanktypes "github.com/openmetaearth/me-hub/x/wbank/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeeToReceiversRejectsMismatchedReceiverTypesBeforeTransfer(t *testing.T) {
+	app := apptesting.Setup(t, false)
+	ctx := app.BaseApp.NewContext(false, cometbftproto.Header{}).WithChainID(apptesting.TestChainID)
+
+	sender := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+	receiver := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+	fee := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(100)))
+
+	require.NoError(t, bankutil.FundAccount(app.BankKeeper, ctx, sender, fee))
+
+	err := app.BankKeeper.FeeToReceivers(
+		ctx,
+		[]banktypes.Input{{Address: sender.String(), Coins: fee}},
+		[]banktypes.Output{{Address: receiver.String(), Coins: fee}},
+		[]wbanktypes.FeeReceiverType{},
+	)
+
+	require.Error(t, err)
+	require.Equal(t, fee, app.BankKeeper.GetAllBalances(ctx, sender))
+	require.True(t, app.BankKeeper.GetAllBalances(ctx, receiver).IsZero())
+}


### PR DESCRIPTION
## Summary
- Validate FeeToReceivers inputs and receiver metadata before calling InputOutputCoins.
- Return a real invalid-request error when receiverTypes and outputs lengths differ.
- Add regression coverage proving balances remain unchanged when metadata validation fails.

## Issue
Fixes #382

## Tests
- go test ./x/wbank/keeper -run TestFeeToReceiversRejectsMismatchedReceiverTypesBeforeTransfer -count=1 -v
- go test ./x/wbank/keeper -count=1
- git diff --check

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099