### PR TITLE
fix(gravity): decrement supply on added bridge fee

### DIFF
--- a/x/gravity/keeper/batch_fee.go
+++ b/x/gravity/keeper/batch_fee.go
@@ -96,6 +96,9 @@ func (k Keeper) AddUnbatchedTxBridgeFee(ctx sdk.Context, txId uint64, sender sdk
 	if tx.Fee.Contract != bridgeToken.ContractAddress {
 		return errorsmod.Wrap(types.ErrInvalid, "token not equal tx fee token")
 	}
+	if addBridgeFee.Amount.GT(bridgeToken.Supply) {
+		return errorsmod.Wrapf(types.ErrInvalid, "bridge fee %s exceeds bridge token supply %s", addBridgeFee.Amount, bridgeToken.Supply)
+	}
 
 	// If it is an external blockchain asset we burn it send coins to module in prep for burn
 	{
@@ -117,6 +120,8 @@ func (k Keeper) AddUnbatchedTxBridgeFee(ctx sdk.Context, txId uint64, sender sdk
 	if err := k.AddUnbatchedTx(ctx, tx); err != nil {
 		return err
 	}
+	bridgeToken.Supply = bridgeToken.Supply.Sub(addBridgeFee.Amount)
+	k.SetBridgeToken(ctx, bridgeToken)
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		types.EventTypeIncreaseBridgeFee,

--- a/x/gravity/keeper/outgoing_tx_pool_test.go
+++ b/x/gravity/keeper/outgoing_tx_pool_test.go
@@ -39,3 +39,33 @@ func (s *KeeperTestSuite) TestKeeper_OutgoingAncCancel() {
 	s.Equal(s.App.BankKeeper.GetAllBalances(s.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 	s.Equal(sendAmount, s.App.BankKeeper.GetSupply(s.Ctx, denom))
 }
+
+func (s *KeeperTestSuite) TestAddUnbatchedTxBridgeFeeDecrementsBridgeTokenSupply() {
+	sender := helpers.GenerateAddress().Bytes()
+	receiver := helpers.GenerateAddress().Hex()
+	denom := "supplydrift"
+
+	initialSupply := sdk.NewCoin(denom, sdkmath.NewInt(1000))
+	s.NewBridgeToken(sender, initialSupply)
+
+	amount := sdk.NewCoin(denom, sdkmath.NewInt(300))
+	fee := sdk.NewCoin(denom, sdkmath.NewInt(100))
+	txID, err := s.Keeper().AddToOutgoingPool(s.Ctx, sender, receiver, amount, fee)
+	s.Require().NoError(err)
+
+	bridgeToken, err := s.Keeper().GetBridgeTokenByDenom(s.Ctx, denom)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewInt(600), bridgeToken.Supply)
+
+	addedFee := sdk.NewCoin(denom, sdkmath.NewInt(200))
+	err = s.Keeper().AddUnbatchedTxBridgeFee(s.Ctx, txID, sender, addedFee)
+	s.Require().NoError(err)
+
+	bridgeToken, err = s.Keeper().GetBridgeTokenByDenom(s.Ctx, denom)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewInt(400), bridgeToken.Supply)
+
+	tx, err := s.Keeper().GetUnbatchedTxById(s.Ctx, txID)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewInt(300), tx.Fee.Amount)
+}


### PR DESCRIPTION
## Summary
- Decrement BridgeToken.Supply when AddUnbatchedTxBridgeFee burns additional bridge-fee vouchers.
- Reject added fees that exceed the tracked bridge-token supply instead of allowing negative accounting.
- Add regression coverage for AddToOutgoingPool followed by AddUnbatchedTxBridgeFee.

## Issue
Fixes #162

## Tests
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestAddUnbatchedTxBridgeFeeDecrementsBridgeTokenSupply' -count=1 -v
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(Keeper_OutgoingAncCancel|AddUnbatchedTxBridgeFeeDecrementsBridgeTokenSupply)' -count=1 -v
- git diff --check

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099