### PR TITLE
fix(wstaking): call SetInviterReward after sending invite reward to prevent duplicate payments (#605)

### DIFF
--- a/x/wstaking/keeper/invite_reward.go
+++ b/x/wstaking/keeper/invite_reward.go
@@ -38,6 +38,7 @@ func (k Keeper) SendInviteReward(ctx sdk.Context, inviter, invitee, regionId str
 			sdk.NewAttribute(types.AttributeKeyKycInviterReward, types.InviteReward.String()),
 		),
 	)
+	k.SetInviterReward(ctx, invitee)
 	return nil
 }
 

--- a/x/wstaking/keeper/kyc_reward_test.go
+++ b/x/wstaking/keeper/kyc_reward_test.go
@@ -312,3 +312,41 @@ func (s *KeeperTestSuite) TestRemoveKycReward_WithFixedDeposit() {
 	err = s.Keeper().RemoveKycReward(s.Ctx, userAccount, s.usaValidator.Description.RegionID)
 	s.Require().ErrorContains(err, types.ErrRemoveKyc.Error())
 }
+
+func (s *KeeperTestSuite) TestSendInviteReward_NoDuplicate() {
+	s.SetupTest()
+
+	newRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            "USA",
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	inviter, _ := s.NewAccount()
+	invitee, _ := s.NewAccount()
+
+	// First invite reward should succeed
+	err = s.Keeper().SendInviteReward(s.Ctx, inviter.String(), invitee.String(), s.usaValidator.Description.RegionID)
+	s.Require().NoError(err)
+
+	// Inviter should have received the reward
+	balance := s.App.BankKeeper.GetBalance(s.Ctx, inviter, params.BaseDenom)
+	s.Require().Equal(types.InviteReward.String(), balance.Amount.String())
+
+	// Invitee should now be marked as rewarded
+	s.Require().True(s.Keeper().HasInviterReward(s.Ctx, invitee.String()))
+
+	// Second invite reward for the same invitee should be a no-op
+	err = s.Keeper().SendInviteReward(s.Ctx, inviter.String(), invitee.String(), s.usaValidator.Description.RegionID)
+	s.Require().NoError(err)
+
+	// Inviter balance should NOT have changed (no duplicate payment)
+	balanceAfter := s.App.BankKeeper.GetBalance(s.Ctx, inviter, params.BaseDenom)
+	s.Require().Equal(balance.Amount.String(), balanceAfter.Amount.String())
+}


### PR DESCRIPTION
Addresses Issue #605

## Problem

`SendInviteReward` sends invite rewards from the region treasury to the inviter, but never calls `SetInviterReward(ctx, invitee)` after a successful payment. The `SetInviterReward` function exists in the codebase but has zero call sites (dead code). This means `HasInviterReward` always returns `false`, allowing the same invitee to trigger unlimited invite rewards per re-approval — enabling infinite treasury drain.

## Solution

Added `k.SetInviterReward(ctx, invitee)` after the reward event emission in `SendInviteReward` (`x/wstaking/keeper/invite_reward.go`), so duplicate invite reward payments are blocked on subsequent calls.

## Test

Added `TestSendInviteReward_NoDuplicate` in `x/wstaking/keeper/kyc_reward_test.go` that verifies:
1. First `SendInviteReward` call succeeds and transfers coins.
2. `HasInviterReward` returns `true` for the invitee after the call.
3. Second `SendInviteReward` call for the same invitee is a no-op (balance unchanged).