### PR TITLE
fix(sequencer): auto-cancel stale ReplaceProposer request when old sequencer is not found (#569)

### DIFF
--- a/x/sequencer/keeper/replace_proposer.go
+++ b/x/sequencer/keeper/replace_proposer.go
@@ -110,7 +110,12 @@ func (k Keeper) ProcSequencerByPendingStates(ctx sdk.Context, rollappId, creator
 		//delete the replaced sequencer address record and set the new sequencer as proposer
 		oldSequencer, found := k.GetSequencer(ctx, val.ReplaceProposer.OldProposer)
 		if !found {
-			return fmt.Errorf("can not found old sequencer: %s", val.ReplaceProposer.OldProposer)
+			// Old sequencer no longer exists (unbonded, slashed, etc.)
+			// Auto-cancel the stale replace proposer request to prevent permanent DoS
+			k.Logger(ctx).Error("auto-cancelling stale ReplaceProposer request: old sequencer not found",
+				"rollapp", rollappId, "old_proposer", val.ReplaceProposer.OldProposer)
+			k.DeleteReplaceProposer(ctx, rollappId)
+			return nil
 		}
 		if oldSequencer.RollappId != rollappId {
 			return fmt.Errorf("old sequencer's rollapp(%s) dismatch to processing rollapp(%s)",


### PR DESCRIPTION
Addresses Issue #569

## Problem

When a `ReplaceProposer` pending request references an old proposer that has already unbonded or been slashed, `ProcSequencerByPendingStates` returns `fmt.Errorf` but never cleans up the stale request. Since `SetReplaceProposer` rejects new requests when one already exists (`ErrExistingReplaceProposer`), the rollapp's proposer replacement governance is permanently broken.

## Solution

Updated `ProcSequencerByPendingStates` in `x/sequencer/keeper/replace_proposer.go` to auto-cancel the stale request when the old sequencer is not found:
- Log a warning about the stale request
- Call `k.DeleteReplaceProposer(ctx, rollappId)` to clean up
- Return `nil` instead of an error (so EndBlocker does not panic)

This allows future `ReplaceProposer` submissions to proceed normally.