### PR TITLE
fix(gravity): count batch fees in pending supply

### DIFF
--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -155,3 +155,39 @@ func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {
 	)
 	suite.Equal(len(batchs), index)
 }
+
+func (suite *KeeperTestSuite) TestOutgoingBatchFeesReserveSupplyForFutureTransfers() {
+	sender := helpers.GenerateAddress().Bytes()
+	denom := "batchreserve"
+	bridgeToken := suite.NewBridgeToken(sender, sdk.NewCoin(denom, sdkmath.NewInt(1000)))
+
+	_, err := suite.Keeper().AddToOutgoingPool(
+		suite.Ctx,
+		sender,
+		helpers.GenerateAddress().Hex(),
+		sdk.NewCoin(denom, sdkmath.NewInt(1)),
+		sdk.NewCoin(denom, sdkmath.NewInt(499)),
+	)
+	suite.Require().NoError(err)
+
+	suite.Keeper().SetLastObservedBlockHeight(suite.Ctx, 1, 1)
+	_, err = suite.Keeper().BuildOutgoingTxBatch(
+		suite.Ctx,
+		bridgeToken.ContractAddress,
+		helpers.GenerateAddress().Hex(),
+		types.OutgoingTxBatchSize,
+		sdkmath.ZeroInt(),
+		sdkmath.ZeroInt(),
+	)
+	suite.Require().NoError(err)
+
+	_, err = suite.Keeper().AddToOutgoingPool(
+		suite.Ctx,
+		sender,
+		helpers.GenerateAddress().Hex(),
+		sdk.NewCoin(denom, sdkmath.NewInt(498)),
+		sdk.NewCoin(denom, sdkmath.NewInt(1)),
+	)
+	suite.Require().Error(err)
+	suite.Require().Equal(sdkmath.NewInt(500), suite.App.BankKeeper.GetAllBalances(suite.Ctx, sender).AmountOf(denom))
+}

--- a/x/gravity/keeper/outgoing_tx_pool.go
+++ b/x/gravity/keeper/outgoing_tx_pool.go
@@ -261,7 +261,8 @@ func (k Keeper) GetOutgoingPendingTxTotal(ctx sdk.Context, chainName string, bri
 	// Add all batched transactions
 	k.IterateOutgoingTxBatches(ctx, func(batch *types.OutgoingTxBatch) bool {
 		if batch.TokenContract == bridgeToken.ContractAddress {
-			totalPending = totalPending.Add(types.GetMintAmount(batch.TotalAmount(), chainName, bridgeToken))
+			batchPending := batch.TotalAmount().Add(types.OutgoingTransferTxs(batch.Transactions).TotalFee())
+			totalPending = totalPending.Add(types.GetMintAmount(batchPending, chainName, bridgeToken))
 		}
 		return false
 	})


### PR DESCRIPTION
Fixes #185.

## Problem
`GetOutgoingPendingTxTotal` counted unbatched transfer amount + fee, but counted only `batch.TotalAmount()` for already batched outgoing transfers. That left batched fees outside pending supply accounting and allowed future transfers to over-reserve bridge token supply.

## Fix
Count each outgoing batch as `TotalAmount() + TotalFee()` before converting through `GetMintAmount`.

## Tests
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestOutgoingBatchFeesReserveSupplyForFutureTransfers' -count=1 -v`\n- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(OutgoingBatchFeesReserveSupplyForFutureTransfers|Keeper_IterateBatch|Keeper_DeleteBatchConfirm)' -count=1 -v`\n- `git diff --check`\n\nNote: `go test ./x/gravity/keeper -count=1` currently fails on pre-existing unrelated tests: `TestGrav004_FailedAttestationMustNotLockNonce`, `TestMsgBondedRelayer`, and `TestRelayerSetSlash`.\n\nBounty payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`