### PR TITLE
fix(megroup): validate join group before free gas

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -95,6 +95,7 @@ func (suite *AnteTestSuite) TestCosmosAnteHandlerEip712() {
 	suite.mockDaoKeeper.EXPECT().GetGlobalDao(gomock.Any()).Return(devOperator.Address)
 	suite.mockDaoKeeper.EXPECT().GetMeidDao(gomock.Any()).Return(devOperator.Address)
 	suite.mockDaoKeeper.EXPECT().GetGlobalDaoFeePoolAddr(gomock.Any()).Return(devOperator.GetAddress())
+	suite.mockDaoKeeper.EXPECT().IsDao(gomock.Any(), addr.Address).Return(false)
 	suite.mockDaoKeeper.EXPECT().CheckFreeGasAccount(gomock.Any(), addr.Address).Return(false)
 
 	amt := sdk.NewInt(100)

--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -143,7 +143,12 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	if !freeGas && len(feeTx.GetMsgs()) > 0 {
 		allJoinGroup := true
 		for _, msg := range feeTx.GetMsgs() {
-			if _, ok := msg.(*megrouptypes.MsgJoinGroup); !ok {
+			joinGroupMsg, ok := msg.(*megrouptypes.MsgJoinGroup)
+			if !ok {
+				allJoinGroup = false
+				break
+			}
+			if err := joinGroupMsg.ValidateBasic(); err != nil {
 				allJoinGroup = false
 				break
 			}

--- a/app/ante/fee_deduct_test.go
+++ b/app/ante/fee_deduct_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/openmetaearth/me-hub/app/ante"
 	"github.com/openmetaearth/me-hub/app/params"
+	megrouptypes "github.com/openmetaearth/me-hub/x/megroup/types"
 	"regexp"
 	"strconv"
 	"testing"
@@ -32,6 +33,36 @@ func NewAccountWithEthPrivKey() (*authtypes.BaseAccount, *ethsecp256k1.PrivKey) 
 	return acc, senderPrivKey
 }
 
+type feeTxForFreeGasTest struct {
+	msgs     []sdk.Msg
+	feePayer sdk.AccAddress
+	fees     sdk.Coins
+}
+
+func (tx feeTxForFreeGasTest) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx feeTxForFreeGasTest) ValidateBasic() error {
+	return nil
+}
+
+func (tx feeTxForFreeGasTest) GetGas() uint64 {
+	return 0
+}
+
+func (tx feeTxForFreeGasTest) GetFee() sdk.Coins {
+	return tx.fees
+}
+
+func (tx feeTxForFreeGasTest) FeePayer() sdk.AccAddress {
+	return tx.feePayer
+}
+
+func (tx feeTxForFreeGasTest) FeeGranter() sdk.AccAddress {
+	return nil
+}
+
 func TestMockBankKeeper(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -46,6 +77,58 @@ func TestMockBankKeeper(t *testing.T) {
 
 	balances := mockBankKeeper.GetAllBalances(ctx, addr)
 	require.Equal(t, expectedBalances, balances)
+}
+
+func TestInvalidJoinGroupDoesNotGetFreeGas(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := sdk.Context{}
+	mockBankKeeper := mock.NewMockBankKeeper(ctrl)
+	mockAccountKeeper := authantetestutil.NewMockAccountKeeper(ctrl)
+	mockFeegrantKeeper := authantetestutil.NewMockFeegrantKeeper(ctrl)
+	mockStakingKeeper := mock.NewMockStakingKeeper(ctrl)
+	mockKycKeeper := mock.NewMockKycKeeper(ctrl)
+	mockDaoKeeper := mock.NewMockDaoKeeper(ctrl)
+	mockWasmKeeper := mock.NewMockWasmKeeper(ctrl)
+
+	feeCheckerCalled := false
+	decorator := ante.NewDeductFeeDecorator(
+		mockAccountKeeper,
+		mockBankKeeper,
+		mockFeegrantKeeper,
+		mockDaoKeeper,
+		mockStakingKeeper,
+		mockKycKeeper,
+		func(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+			feeCheckerCalled = true
+			return nil, 0, sdkerrors.Wrap(sdkerrors.ErrInsufficientFee, "invalid join group should pay fees")
+		},
+		mockWasmKeeper,
+	)
+
+	feePayer := NewAccount()
+	msg := &megrouptypes.MsgJoinGroup{
+		Creator:          feePayer.Address,
+		GroupId:          0,
+		ApplicantAddress: "",
+	}
+
+	mockDaoKeeper.EXPECT().IsDao(gomock.Any(), feePayer.Address).Return(false)
+	mockDaoKeeper.EXPECT().CheckFreeGasAccount(gomock.Any(), feePayer.Address).Return(false)
+
+	nextCalled := false
+	_, err := decorator.AnteHandle(ctx, feeTxForFreeGasTest{
+		msgs:     []sdk.Msg{msg},
+		feePayer: feePayer.GetAddress(),
+	}, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		nextCalled = true
+		return ctx, nil
+	})
+
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
+	require.True(t, feeCheckerCalled)
+	require.False(t, nextCalled)
 }
 
 func TestCheckFunds(t *testing.T) {

--- a/app/ante/mock/expected_keepers_mocks.go
+++ b/app/ante/mock/expected_keepers_mocks.go
@@ -52,6 +52,20 @@ func (mr *MockDaoKeeperMockRecorder) CheckFreeGasAccount(ctx, address interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckFreeGasAccount", reflect.TypeOf((*MockDaoKeeper)(nil).CheckFreeGasAccount), ctx, address)
 }
 
+// IsDao mocks base method.
+func (m *MockDaoKeeper) IsDao(ctx types0.Context, address string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDao", ctx, address)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDao indicates an expected call of IsDao.
+func (mr *MockDaoKeeperMockRecorder) IsDao(ctx, address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDao", reflect.TypeOf((*MockDaoKeeper)(nil).IsDao), ctx, address)
+}
+
 // GetAirdropAddress mocks base method.
 func (m *MockDaoKeeper) GetAirdropAddress(ctx types0.Context) string {
 	m.ctrl.T.Helper()

--- a/x/megroup/types/message_join_group.go
+++ b/x/megroup/types/message_join_group.go
@@ -43,6 +43,12 @@ func (msg *MsgJoinGroup) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	if msg.GroupId == 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "group_id cannot be 0")
+	}
+	if _, err = sdk.AccAddressFromBech32(msg.ApplicantAddress); err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid applicant address (%s)", err)
+	}
 	return nil
 }
 

--- a/x/megroup/types/message_join_group_test.go
+++ b/x/megroup/types/message_join_group_test.go
@@ -20,10 +20,30 @@ func TestMsgJoinGroup_ValidateBasic(t *testing.T) {
 				Creator: "invalid_address",
 			},
 			err: sdkerrors.ErrInvalidAddress,
-		}, {
+		},
+		{
+			name: "missing group id",
+			msg: MsgJoinGroup{
+				Creator:          sample.AccAddress(),
+				ApplicantAddress: sample.AccAddress(),
+			},
+			err: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid applicant address",
+			msg: MsgJoinGroup{
+				Creator:          sample.AccAddress(),
+				GroupId:          1,
+				ApplicantAddress: "invalid_address",
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		},
+		{
 			name: "valid address",
 			msg: MsgJoinGroup{
-				Creator: sample.AccAddress(),
+				Creator:          sample.AccAddress(),
+				GroupId:          1,
+				ApplicantAddress: sample.AccAddress(),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #208.

## Problem
The custom fee decorator grants free gas to transactions containing only `MsgJoinGroup`. `MsgJoinGroup.ValidateBasic` only checked `Creator`, so messages with `group_id=0` or an empty/invalid `applicant_address` could skip the fee checker and fail later in the message server.

## Fix
- Validate `MsgJoinGroup.GroupId` and `ApplicantAddress` in `ValidateBasic`.
- Only apply the JoinGroup free-gas path when every `MsgJoinGroup` in the tx passes `ValidateBasic`.
- Refresh the ante DaoKeeper mock with `IsDao` so `app/ante` tests compile against the current interface.

## Tests
- `go test ./app/ante -run TestInvalidJoinGroupDoesNotGetFreeGas -count=1 -v`
- `go test ./app/ante -count=1`
- `go test ./x/megroup/types -run TestMsgJoinGroup_ValidateBasic -count=1 -v`
- `git diff --check`

Note: `go test ./x/megroup/types -count=1` currently fails on pre-existing issue #200 (`MsgCreateGroup` nil `GroupInfo` panic), which is separate from this patch.

Bounty payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`