### PR TITLE
fix(gravity): preserve slash counter on delegate

### DIFF
--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -131,7 +131,6 @@ func (s MsgServer) AddDelegate(c context.Context, msg *types.MsgAddDelegate) (*t
 		relayer.StartHeight = ctx.BlockHeight()
 	}
 
-	relayer.SlashTimes = 0
 	s.SetRelayer(ctx, relayerAddress, relayer)
 	s.SetLastTotalPower(ctx)
 

--- a/x/gravity/keeper/msg_server_test.go
+++ b/x/gravity/keeper/msg_server_test.go
@@ -133,6 +133,7 @@ func (s *KeeperTestSuite) TestMsgAddDelegate() {
 		err                  string
 		preRun               func(msg *types.MsgAddDelegate)
 		expectDelegateAmount func(msg *types.MsgAddDelegate) sdk.Int
+		expectSlashTimes     int64
 	}{
 		{
 			name: "error - sender not relayer",
@@ -213,6 +214,7 @@ func (s *KeeperTestSuite) TestMsgAddDelegate() {
 			expectDelegateAmount: func(msg *types.MsgAddDelegate) sdk.Int {
 				return initDelegateAmount
 			},
+			expectSlashTimes: 1,
 		},
 		{
 			name: "pass - add more slash amount",
@@ -231,6 +233,25 @@ func (s *KeeperTestSuite) TestMsgAddDelegate() {
 			expectDelegateAmount: func(msg *types.MsgAddDelegate) sdk.Int {
 				return initDelegateAmount.Add(sdk.NewInt(1000))
 			},
+			expectSlashTimes: 1,
+		},
+		{
+			name: "pass - online relayer preserves slash times",
+			preRun: func(msg *types.MsgAddDelegate) {
+				relayerAddress := sdk.MustAccAddressFromBech32(msg.RelayerAddress)
+				relayer, _ := s.Keeper().GetRelayer(s.Ctx, relayerAddress)
+				relayer.SlashTimes = 1
+				s.Keeper().SetRelayer(s.Ctx, relayerAddress, relayer)
+
+				slashFraction := s.Keeper().GetSlashFraction(s.Ctx)
+				slashAmount := sdk.NewDecFromInt(initDelegateAmount).Mul(slashFraction).MulInt64(relayer.SlashTimes).TruncateInt()
+				msg.Amount.Amount = slashAmount.Add(sdk.NewInt(1000))
+			},
+			pass: true,
+			expectDelegateAmount: func(msg *types.MsgAddDelegate) sdk.Int {
+				return initDelegateAmount.Add(sdk.NewInt(1000))
+			},
+			expectSlashTimes: 1,
 		},
 	}
 	for _, testCase := range testCases {
@@ -267,7 +288,7 @@ func (s *KeeperTestSuite) TestMsgAddDelegate() {
 			s.Require().NotNil(relayer)
 			s.Require().EqualValues(msg.RelayerAddress, relayer.RelayerAddress)
 			s.Require().True(relayer.Online)
-			s.Require().EqualValues(0, relayer.SlashTimes)
+			s.Require().EqualValues(testCase.expectSlashTimes, relayer.SlashTimes)
 
 			// check power
 			totalPower := s.Keeper().GetLastTotalPower(s.Ctx)


### PR DESCRIPTION
Fixes #64.

## Problem
`AddDelegate` unconditionally reset `Relayer.SlashTimes` after a relayer added stake. That let a relayer clear the repeated-slash counter through a delegate top-up instead of only having the counter advance through slashing logic.

## Fix
- Preserve `Relayer.SlashTimes` in `AddDelegate`.
- Keep the existing slash-amount payment behavior and online recovery behavior unchanged.
- Extend `TestMsgAddDelegate` to assert that slash times survive both offline recovery and an online delegate top-up.

## Tests
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestMsgAddDelegate' -count=1 -v`\n- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestSlashRelayer' -count=1 -v`\n- `git diff --check`\n\nNote: `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestRelayerSetSlash' -count=1 -v` currently fails on clean `origin/main` at `abci_test.go:506`, which is separate from this patch.\n\nBounty payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`