### PR TITLE
fix(wgov): delete votes after tally iteration

### DIFF
--- a/x/wgov/keeper/tally.go
+++ b/x/wgov/keeper/tally.go
@@ -18,6 +18,11 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 
 	totalVotingPower := math.LegacyZeroDec()
 	currValidators := make(map[string]v1.ValidatorGovInfo)
+	type voteDeletion struct {
+		proposalID uint64
+		voter      sdk.AccAddress
+	}
+	votesToDelete := make([]voteDeletion, 0)
 
 	// fetch all the bonded validators, insert them into currValidators
 	keeper.stakingKeeper.IterateBondedValidatorsByPower(ctx, func(index int64, validator stakingtypes.ValidatorI) (stop bool) {
@@ -66,9 +71,16 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 		//	return false
 		//})
 
-		keeper.DeleteVote(ctx, vote.ProposalId, voter)
+		votesToDelete = append(votesToDelete, voteDeletion{
+			proposalID: vote.ProposalId,
+			voter:      voter,
+		})
 		return false
 	})
+
+	for _, vote := range votesToDelete {
+		keeper.DeleteVote(ctx, vote.proposalID, vote.voter)
+	}
 
 	// iterate over the validators again to tally their voting power
 	for _, val := range currValidators {

--- a/x/wgov/keeper/tally_test.go
+++ b/x/wgov/keeper/tally_test.go
@@ -1,0 +1,53 @@
+package keeper
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTallyDoesNotDeleteVotesDuringIteration(t *testing.T) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "tally.go", nil, 0)
+	require.NoError(t, err)
+
+	foundIterateVotes := false
+	foundDeleteInIterator := false
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !isKeeperCall(call.Fun, "IterateVotes") || len(call.Args) < 3 {
+			return true
+		}
+
+		callback, ok := call.Args[2].(*ast.FuncLit)
+		require.True(t, ok)
+		foundIterateVotes = true
+
+		ast.Inspect(callback.Body, func(callbackNode ast.Node) bool {
+			callbackCall, ok := callbackNode.(*ast.CallExpr)
+			if ok && isKeeperCall(callbackCall.Fun, "DeleteVote") {
+				foundDeleteInIterator = true
+			}
+			return true
+		})
+
+		return true
+	})
+
+	require.True(t, foundIterateVotes)
+	require.False(t, foundDeleteInIterator)
+}
+
+func isKeeperCall(expr ast.Expr, method string) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != method {
+		return false
+	}
+
+	ident, ok := selector.X.(*ast.Ident)
+	return ok && ident.Name == "keeper"
+}


### PR DESCRIPTION
Fixes #63.

## Problem
`Tally` deleted votes from the KV store inside the `IterateVotes` callback. Mutating the vote prefix while iterating it makes tally behavior fragile and can skip entries depending on iterator/store behavior.

## Fix
- Collect votes that should be removed while tallying.
- Delete the collected votes only after `IterateVotes` has completed.
- Add a focused regression test that asserts `DeleteVote` is no longer called from inside the `IterateVotes` callback.

## Tests
- `go test ./x/wgov/keeper -count=1 -v`
- `git diff --check`

Bounty payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`