### PR TITLE
fix(wdistri): avoid int64 reward overflow

### DIFF
--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -101,7 +101,7 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		// calculate every region coins: RegionShare * totalMintCoins / totalRegionShare
 		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(totalMintCoin.AmountOf(params.BaseDenom).ToLegacyDec()).Quo(totalRegionShareDec)
 		regionAmount := amount.TruncateInt()
-		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
+		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, regionAmount))
 		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()), regionCoins)
 		if err != nil {
 			return err

--- a/x/wdistri/keeper/keeper_test.go
+++ b/x/wdistri/keeper/keeper_test.go
@@ -237,6 +237,25 @@ func (suite *KeeperTestSuite) TestEndBlocker() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestAllocateBlockRewardDoesNotOverflowLargeRegionAmount() {
+	ctx := suite.HelperNewContextWith(types.OneDayTotalBlocks)
+	addrs := suite.mockGetRegionI(ctx, 1)
+	largeAmount, ok := sdk.NewIntFromString("10000000000000000000")
+	suite.Require().True(ok)
+	suite.SetMockGetBalance(ctx, largeAmount)
+
+	suite.bankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(
+			ctx,
+			suite.App.DistrKeeper.GetTreasuryModuleAccount(),
+			sdk.MustAccAddressFromBech32(addrs[0]),
+			sdk.NewCoins(sdk.NewCoin(params.BaseDenom, largeAmount)),
+		).Return(nil)
+
+	err := suite.App.DistrKeeper.AllocateBlockReward(ctx)
+	suite.Require().NoError(err)
+}
+
 func (suite *KeeperTestSuite) mockGetRegionI(ctx sdk.Context, regionShare ...int) []string {
 	var addrs []string
 	if len(regionShare) == 0 {


### PR DESCRIPTION
Fixes #86.

## Problem
`AllocateBlockReward` truncated each computed region reward through `regionAmount.Int64()` and then rebuilt it with `sdk.NewInt(...)`. For reward amounts above `int64` range, this can silently overflow and corrupt or panic reward distribution.

## Fix
- Pass `regionAmount` directly to `sdk.NewCoin`; it is already an SDK integer.
- Add a regression test with a `10^19 umec` reward amount to prove large rewards are preserved without the `int64` bottleneck.

## Tests
- `go test ./x/wdistri/keeper -run 'TestKeeperTestSuite/TestAllocateBlockRewardDoesNotOverflowLargeRegionAmount' -count=1 -v`\n- `go test ./x/wdistri/keeper -count=1 -v`\n- `git diff --check`\n\nBounty payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`