### PR TITLE
fix(kyc): avoid phantom protocol regions

### DIFF
--- a/x/kyc/keeper/grpc_query_test.go
+++ b/x/kyc/keeper/grpc_query_test.go
@@ -34,6 +34,17 @@ func (s *KeeperTestSuite) TestProtocol() {
 	s.Require().Equal(len(res.Protocol.Regions), 0)
 }
 
+func (s *KeeperTestSuite) TestGetAllRegionsDoesNotIncludePhantomRegions() {
+	s.SetupTest()
+
+	regions := s.Keeper().GetAllRegions(s.Ctx)
+	s.Require().Len(regions, 3)
+	for _, region := range regions {
+		s.Require().NotEmpty(region.Id)
+		s.Require().NotEmpty(region.Name)
+	}
+}
+
 func (s *KeeperTestSuite) TestDID() {
 	s.SetupTest()
 

--- a/x/kyc/keeper/protocol.go
+++ b/x/kyc/keeper/protocol.go
@@ -25,7 +25,7 @@ func (k *Keeper) GetRegion(ctx sdk.Context, regionId string) (reg types.Region, 
 
 func (k *Keeper) GetAllRegions(ctx sdk.Context) (regs []types.Region) {
 	raws := k.stkKeeper.GetAllRegion(ctx)
-	regions := make([]types.Region, len(raws))
+	regions := make([]types.Region, 0, len(raws))
 	for _, rew := range raws {
 		regions = append(regions, types.Region{Id: rew.RegionId, Name: rew.Name})
 	}


### PR DESCRIPTION
Fixes #239.

## Problem
`GetAllRegions` allocated the destination slice with `len(raws)` and then appended every converted region. That returned `len(raws)` zero-value phantom regions followed by the real regions.

## Fix
- Allocate the region list with zero length and `len(raws)` capacity.
- Add a regression test proving the KYC protocol region list contains only real, non-empty regions.

## Tests
- `go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestGetAllRegionsDoesNotIncludePhantomRegions' -count=1 -v`\n- `git diff --check`\n\nNote: `go test ./x/kyc/keeper -count=1 -v` and `go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestProtocol' -count=1 -v` currently fail on clean `origin/main` in existing KYC query tests; those failures are separate from this patch.\n\nBounty payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`