### PR TITLE
fix(wdistri): remove Int64 overflow in AllocateBlockReward (#565)

### DIFF
--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -101,7 +101,7 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		// calculate every region coins: RegionShare * totalMintCoins / totalRegionShare
 		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(totalMintCoin.AmountOf(params.BaseDenom).ToLegacyDec()).Quo(totalRegionShareDec)
 		regionAmount := amount.TruncateInt()
-		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
+		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, regionAmount))
 		treasuryAddr, addrErr := sdk.AccAddressFromBech32(region.GetRegionTreasureAddr())
 		if addrErr != nil {
 			ctx.Logger().Error("invalid region treasure address, skipping reward", "regionId", region.GetRegionId(), "addr", region.GetRegionTreasureAddr(), "err", addrErr)


### PR DESCRIPTION
Addresses Issue #565

## Problem

In `AllocateBlockReward` (`x/wdistri/keeper/keeper.go:104`), `regionAmount` (a `math.Int`) is converted via `.Int64()` then wrapped back with `sdk.NewInt()`. If `regionAmount` exceeds `math.MaxInt64` (which is possible with large total mint supplies), `.Int64()` panics at runtime, crashing the node during `EndBlocker`.

## Solution

Replaced `sdk.NewInt(regionAmount.Int64())` with just `regionAmount` since it is already a `math.Int` — the `.Int64()` round-trip was redundant and dangerous.