### PR TITLE
fix(gravity): re-enable relayer slashing in EndBlocker (#580)

### DIFF
--- a/x/gravity/keeper/abci.go
+++ b/x/gravity/keeper/abci.go
@@ -13,7 +13,7 @@ import (
 func (k Keeper) EndBlocker(ctx sdk.Context) {
 	k.cleanupTimedOutBatches(ctx)
 	signedWindow := k.GetSignedWindow(ctx)
-	//k.slashing(ctx, signedWindow)
+	k.slashing(ctx, signedWindow)
 	k.createRelayerSetChangeRequest(ctx)
 	k.pruneRelayerSet(ctx, signedWindow)
 }


### PR DESCRIPTION
Addresses Issue #580

## Problem

The call to `k.slashing(ctx, signedWindow)` in the gravity module's `EndBlocker` (`x/gravity/keeper/abci.go:16`) is commented out. The slashing function is fully implemented (lines 57-69) and includes both relayer set slashing and batch slashing, but since it is never called, relayers face zero consequences for failing to sign relayer set changes or batch requests. This removes the economic incentive for relayers to participate in consensus.

## Solution

Uncommented the `k.slashing(ctx, signedWindow)` call on line 16 of `x/gravity/keeper/abci.go` to re-enable relayer slashing enforcement.