### PR TITLE
fix(eibc): validate and propagate expected fee in FulfillOrder and UpdateDemandOrder (#581)

### DIFF
--- a/x/eibc/keeper/msg_server.go
+++ b/x/eibc/keeper/msg_server.go
@@ -39,7 +39,10 @@ func (m msgServer) FulfillOrder(goCtx context.Context, msg *types.MsgFulfillOrde
 	}
 
 	// Check that the fulfiller expected fee is equal to the demand order fee
-	expectedFee, _ := sdk.NewIntFromString(msg.ExpectedFee)
+	expectedFee, ok := sdk.NewIntFromString(msg.ExpectedFee)
+	if !ok {
+		return nil, errorsmod.Wrapf(types.ErrInvalidExpectedFee, "invalid expected fee: %s", msg.ExpectedFee)
+	}
 	orderFee := demandOrder.GetFeeAmount()
 	if !orderFee.Equal(expectedFee) {
 		return nil, types.ErrExpectedFeeNotMet
@@ -107,8 +110,14 @@ func (m msgServer) UpdateDemandOrder(goCtx context.Context, msg *types.MsgUpdate
 	}
 
 	// calculate the new price: transferTotal - newFee - bridgingFee
-	newFeeInt, _ := sdk.NewIntFromString(msg.NewFee)
-	transferTotal, _ := sdk.NewIntFromString(data.Amount)
+	newFeeInt, ok := sdk.NewIntFromString(msg.NewFee)
+	if !ok {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid new fee: %s", msg.NewFee)
+	}
+	transferTotal, ok := sdk.NewIntFromString(data.Amount)
+	if !ok {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid transfer amount: %s", data.Amount)
+	}
 	newPrice, err := types.CalcPriceWithBridgingFee(transferTotal, newFeeInt, bridgingFeeMultiplier)
 	if err != nil {
 		return nil, err

--- a/x/eibc/types/errors.go
+++ b/x/eibc/types/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrFeeTooHigh                   = errorsmod.Register(ModuleName, 11, "Fee must be less than or equal to the total amount")
 	ErrExpectedFeeNotMet            = errorsmod.Register(ModuleName, 12, "Expected fee not met")
 	ErrNegativeFee                  = errorsmod.Register(ModuleName, 13, "Fee must be greater than or equal to 0")
+	ErrInvalidExpectedFee           = errorsmod.Register(ModuleName, 14, "Invalid expected fee")
 	ErrMultipleDenoms               = errorsmod.Register(ModuleName, 15, "Multiple denoms not allowed")
 	ErrEmptyPrice                   = errorsmod.Register(ModuleName, 16, "Price must be greater than 0")
 )


### PR DESCRIPTION
Addresses Issue #581

## Problem

In `FulfillOrder` (`x/eibc/keeper/msg_server.go:42`), `sdk.NewIntFromString(msg.ExpectedFee)` discards the boolean success indicator with `_`. If `ExpectedFee` is a malformed string, `expectedFee` silently becomes zero. If the order fee is also zero, the comparison passes and the fulfiller pays no fee. Same pattern exists in `UpdateDemandOrder` for `NewFee` and `Amount`.

## Solution

1. **FulfillOrder**: Check the boolean return from `sdk.NewIntFromString(msg.ExpectedFee)` and return `ErrInvalidExpectedFee` on parse failure.
2. **UpdateDemandOrder**: Check boolean returns from `sdk.NewIntFromString(msg.NewFee)` and `sdk.NewIntFromString(data.Amount)`, returning `sdkerrors.ErrInvalidRequest` on parse failure.
3. **New Error**: Added `ErrInvalidExpectedFee` sentinel error (code 14) in `x/eibc/types/errors.go`.