### PR TITLE
fix(gravity): reject BSC USDT/USDC dust deposits

### DIFF
--- a/x/gravity/keeper/attestation_handler.go
+++ b/x/gravity/keeper/attestation_handler.go
@@ -26,6 +26,9 @@ func (k Keeper) AttestationHandler(ctx sdk.Context, externalClaim types.External
 			return errorsmod.Wrap(types.ErrInvalid, "receiver address")
 		}
 
+		if err := types.ValidateMintAmount(claim.Amount, claim.ChainName, bridgeToken); err != nil {
+			return err
+		}
 		mintAmount := types.GetMintCoin(claim.Amount, claim.ChainName, bridgeToken)
 		if err := k.bankKeeper.MintCoins(ctx, k.moduleName, sdk.NewCoins(mintAmount)); err != nil {
 			return errorsmod.Wrapf(err, "mint vouchers coins")

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -195,6 +195,43 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 	}
 }
 
+func (s *KeeperTestSuite) TestSendToMeClaimRejectsBscUsdtDustBeforeMint() {
+	k := s.Keeper()
+	tokenContract := "0x0000000000000000000000000000000000000203"
+	receiver := s.relayerAddrs[0]
+	bridgeToken := &types.BridgeToken{
+		ContractAddress: tokenContract,
+		Denom:           "uusdt",
+		Name:            "Tether USD",
+		Symbol:          "USDT",
+		Decimal:         18,
+		Supply:          sdkmath.ZeroInt(),
+	}
+	k.SetBridgeToken(s.Ctx, bridgeToken)
+
+	dustClaim := &types.MsgSendToMeClaim{
+		EventNonce:     1,
+		BlockHeight:    1,
+		TokenContract:  tokenContract,
+		Amount:         sdkmath.NewInt(999_999_999_999),
+		Sender:         "0x0000000000000000000000000000000000000204",
+		Receiver:       receiver.String(),
+		RelayerAddress: s.relayerAddrs[1].String(),
+		ChainName:      s.chainName,
+	}
+
+	err := k.AttestationHandler(s.Ctx, dustClaim)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, types.ErrInvalid)
+
+	balance := s.App.BankKeeper.GetBalance(s.Ctx, receiver, bridgeToken.Denom)
+	s.Require().True(balance.Amount.IsZero(), "dust claim must not mint vouchers")
+
+	storedToken, err := k.GetBridgeTokenByContract(s.Ctx, tokenContract)
+	s.Require().NoError(err)
+	s.Require().True(storedToken.Supply.IsZero(), "dust claim must not increase bridge token supply")
+}
+
 // ---------------------------------------------------------------------------
 // Helper: bond relayers, confirm and observe the initial relayer set.
 // Mirrors the opening of TestRequestBatchBaseFee in msg_server_test.go, but

--- a/x/gravity/types/convert.go
+++ b/x/gravity/types/convert.go
@@ -3,6 +3,7 @@ package types
 import (
 	"strings"
 
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -25,17 +26,55 @@ func GetMintCoin(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk
 }
 
 func GetMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
-	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
-		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
-		amount = amount.Quo(convert)
+	if requiresBscUsdtUsdcDownConversion(chainName, bridgeToken) {
+		amount = amount.Quo(bscUsdtUsdcConversionFactor(chainName, bridgeToken))
 	}
 	return amount
 }
 
 func GetExternalUnlockAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
-	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
-		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
-		amount = amount.Mul(convert)
+	if requiresBscUsdtUsdcDownConversion(chainName, bridgeToken) {
+		amount = amount.Mul(bscUsdtUsdcConversionFactor(chainName, bridgeToken))
 	}
 	return amount
+}
+
+func requiresBscUsdtUsdcDownConversion(chainName string, bridgeToken *BridgeToken) bool {
+	return bridgeToken != nil && CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6
+}
+
+func bscUsdtUsdcConversionFactor(chainName string, bridgeToken *BridgeToken) sdk.Int {
+	if !requiresBscUsdtUsdcDownConversion(chainName, bridgeToken) {
+		return sdk.OneInt()
+	}
+	return sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
+}
+
+// ValidateMintAmount rejects BSC USDT/USDC deposits that would lose precision during 6-decimal minting.
+func ValidateMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) error {
+	if !requiresBscUsdtUsdcDownConversion(chainName, bridgeToken) {
+		return nil
+	}
+
+	convert := bscUsdtUsdcConversionFactor(chainName, bridgeToken)
+	if amount.IsNil() || !amount.IsPositive() {
+		return errorsmod.Wrap(ErrInvalid, "converted BSC USDT/USDC deposit amount must be positive")
+	}
+	if amount.LT(convert) {
+		return errorsmod.Wrapf(
+			ErrInvalid,
+			"converted BSC USDT/USDC deposit amount %s rounds down to zero with factor %s",
+			amount.String(),
+			convert.String(),
+		)
+	}
+	if !amount.Mod(convert).IsZero() {
+		return errorsmod.Wrapf(
+			ErrInvalid,
+			"converted BSC USDT/USDC deposit amount %s is not divisible by factor %s",
+			amount.String(),
+			convert.String(),
+		)
+	}
+	return nil
 }

--- a/x/gravity/types/convert_test.go
+++ b/x/gravity/types/convert_test.go
@@ -89,3 +89,53 @@ func TestGetExternalUnlockAmount(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateMintAmountRejectsBscUsdtUsdcDustAndRemainders(t *testing.T) {
+	bridgeToken := &BridgeToken{
+		Symbol:  "USDT",
+		Decimal: 18,
+	}
+
+	tests := []struct {
+		name      string
+		amount    sdk.Int
+		chainName string
+		wantErr   bool
+	}{
+		{
+			name:      "rejects dust that would mint zero vouchers",
+			amount:    sdkmath.NewInt(999_999_999_999),
+			chainName: "bsc",
+			wantErr:   true,
+		},
+		{
+			name:      "rejects non-divisible amount that would lose remainder",
+			amount:    sdkmath.NewInt(1_000_000_000_123),
+			chainName: "bsc",
+			wantErr:   true,
+		},
+		{
+			name:      "accepts exact conversion factor",
+			amount:    sdkmath.NewInt(1_000_000_000_000),
+			chainName: "bsc",
+			wantErr:   false,
+		},
+		{
+			name:      "does not reject other chains",
+			amount:    sdkmath.NewInt(123),
+			chainName: "eth",
+			wantErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMintAmount(tc.amount, tc.chainName, bridgeToken)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #203.

## Summary
- adds a state-aware mint amount validation for BSC USDT/USDC tokens with decimals greater than 6
- rejects external deposit amounts that would round down to zero vouchers
- rejects non-divisible external deposit amounts that would silently lose precision
- calls the validation before voucher minting and supply accounting

## Tests
- go test ./x/gravity/types -run TestValidateMintAmountRejectsBscUsdtUsdcDustAndRemainders -count=1 -v
- go test ./x/gravity/keeper -run TestGravityKeeperTestSuite/TestSendToMeClaimRejectsBscUsdtDustBeforeMint -count=1 -v
- git diff --check

## Known baseline
- go test ./x/gravity/types ./x/gravity/keeper -count=1 currently fails on existing keeper tests unrelated to this patch: TestGrav004_FailedAttestationMustNotLockNonce, TestMsgBondedRelayer expected error strings, and TestRelayerSetSlash.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099
