### PR TITLE
fix(wstaking): clamp DelegateInterest to zero instead of silently skipping subtraction (#607)

### DIFF
--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -117,9 +117,7 @@ func (k Keeper) RemoveKycReward(ctx sdk.Context, account sdk.AccAddress, regionI
 		return fmt.Errorf("settle interest error: %v", err)
 	}
 
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
-	}
+	region.DelegateInterest = sdk.MaxDec(sdk.ZeroDec(), region.DelegateInterest.Sub(rewards))
 
 	if delegation.Unmovable.LTE(sdk.ZeroInt()) {
 		return types.ErrDidExists
@@ -192,9 +190,7 @@ func (k Keeper) sendKycRewards(ctx sdk.Context, delAddr sdk.AccAddress, validato
 				return err
 			}
 		}
-		if experienceRegion.DelegateInterest.GTE(interest) {
-			experienceRegion.DelegateInterest = experienceRegion.DelegateInterest.Sub(interest)
-		}
+		experienceRegion.DelegateInterest = sdk.MaxDec(sdk.ZeroDec(), experienceRegion.DelegateInterest.Sub(interest))
 		experienceRegion.DelegateAmount = experienceRegion.DelegateAmount.Sub(delegation.UnMeidAmount)
 		k.SetRegion(ctx, experienceRegion)
 
@@ -425,9 +421,7 @@ func (k Keeper) transferUnRegisterMeid(ctx sdk.Context, delAddr sdk.AccAddress, 
 		return amount, err
 	}
 
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
-	}
+	region.DelegateInterest = sdk.MaxDec(sdk.ZeroDec(), region.DelegateInterest.Sub(rewards))
 
 	if delegation.Unmovable.LTE(sdk.ZeroInt()) {
 		return amount, errors.New("UnRegisterMeid err: delegation UnMovable <= 0")


### PR DESCRIPTION
Addresses Issue #607

## Problem

In `x/wstaking/keeper/kyc_reward.go`, three locations silently skip the `DelegateInterest` subtraction when `DelegateInterest < rewards`:

```go
if region.DelegateInterest.GTE(rewards) {
    region.DelegateInterest = region.DelegateInterest.Sub(rewards)
}
// else: subtraction silently skipped — accounting drift
```

This means the treasury pays out rewards but the `DelegateInterest` tracker is never decremented when it falls below the reward amount. Over time, this creates an ever-growing accounting gap between actual treasury payouts and the tracked interest balance.

## Solution

Replaced all 3 instances with `sdk.MaxDec(sdk.ZeroDec(), region.DelegateInterest.Sub(rewards))` to always subtract and clamp to zero. This ensures accounting stays consistent without blocking the operation.

### Changed locations
- Line 120 (`RemoveKycReward`)
- Line 195 (`sendKycRewards` — experience region interest)
- Line 428 (`transferUnRegisterMeid`)