### PR TITLE
fix(gravity): validate relayer query addresses

### DIFF
--- a/x/gravity/keeper/grpc_query.go
+++ b/x/gravity/keeper/grpc_query.go
@@ -82,7 +82,11 @@ func (k QueryServer) RelayerSetConfirm(c context.Context, req *types.QueryRelaye
 		return nil, status.Error(codes.InvalidArgument, "nonce")
 	}
 	ctx := sdk.UnwrapSDKContext(c)
-	return &types.QueryRelayerSetConfirmResponse{Confirm: k.GetRelayerSetConfirm(ctx, req.Nonce, sdk.MustAccAddressFromBech32(req.RelayerAddress))}, nil
+	relayerAddress, err := parseQueryRelayerAddress(req.RelayerAddress)
+	if err != nil {
+		return nil, err
+	}
+	return &types.QueryRelayerSetConfirmResponse{Confirm: k.GetRelayerSetConfirm(ctx, req.Nonce, relayerAddress)}, nil
 }
 
 func (k QueryServer) RelayerSetConfirmsByNonce(c context.Context, req *types.QueryRelayerSetConfirmsByNonceRequest) (*types.QueryRelayerSetConfirmsByNonceResponse, error) {
@@ -117,7 +121,11 @@ func (k QueryServer) LastRelayerSetRequests(c context.Context, req *types.QueryL
 
 func (k QueryServer) LastPendingRelayerSetRequestByAddr(c context.Context, req *types.QueryLastPendingRelayerSetRequestByAddrRequest) (*types.QueryLastPendingRelayerSetRequestByAddrResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	relayer, ok := k.GetRelayer(ctx, sdk.MustAccAddressFromBech32(req.RelayerAddress))
+	relayerAddress, err := parseQueryRelayerAddress(req.RelayerAddress)
+	if err != nil {
+		return nil, err
+	}
+	relayer, ok := k.GetRelayer(ctx, relayerAddress)
 	if !ok {
 		return nil, types.ErrNotFoundRelayer
 	}
@@ -140,8 +148,11 @@ func (k QueryServer) LastPendingRelayerSetRequestByAddr(c context.Context, req *
 
 func (k QueryServer) LastPendingBatchRequestByAddr(c context.Context, req *types.QueryLastPendingBatchRequestByAddrRequest) (*types.QueryLastPendingBatchRequestByAddrResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	RelayerAddress := sdk.MustAccAddressFromBech32(req.RelayerAddress)
-	relayer, ok := k.GetRelayer(ctx, RelayerAddress)
+	relayerAddress, err := parseQueryRelayerAddress(req.RelayerAddress)
+	if err != nil {
+		return nil, err
+	}
+	relayer, ok := k.GetRelayer(ctx, relayerAddress)
 	if !ok {
 		return nil, types.ErrNotFoundRelayer
 	}
@@ -151,7 +162,7 @@ func (k QueryServer) LastPendingBatchRequestByAddr(c context.Context, req *types
 		if relayer.StartHeight > int64(batch.Block) {
 			return false
 		}
-		foundConfirm := k.GetBatchConfirm(ctx, batch.TokenContract, batch.BatchNonce, RelayerAddress) != nil
+		foundConfirm := k.GetBatchConfirm(ctx, batch.TokenContract, batch.BatchNonce, relayerAddress) != nil
 		if !foundConfirm {
 			pendingBatchReq = batch
 			return true
@@ -163,13 +174,21 @@ func (k QueryServer) LastPendingBatchRequestByAddr(c context.Context, req *types
 
 func (k QueryServer) LastEventNonceByAddr(c context.Context, req *types.QueryLastEventNonceByAddrRequest) (*types.QueryLastEventNonceByAddrResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	lastEventNonce := k.GetLastEventNonceByRelayer(ctx, sdk.MustAccAddressFromBech32(req.RelayerAddress))
+	relayerAddress, err := parseQueryRelayerAddress(req.RelayerAddress)
+	if err != nil {
+		return nil, err
+	}
+	lastEventNonce := k.GetLastEventNonceByRelayer(ctx, relayerAddress)
 	return &types.QueryLastEventNonceByAddrResponse{EventNonce: lastEventNonce}, nil
 }
 
 func (k QueryServer) LastEventBlockHeightByAddr(c context.Context, req *types.QueryLastEventBlockHeightByAddrRequest) (*types.QueryLastEventBlockHeightByAddrResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	lastEventBlockHeight := k.GetLastEventBlockHeightByRelayer(ctx, sdk.MustAccAddressFromBech32(req.RelayerAddress))
+	relayerAddress, err := parseQueryRelayerAddress(req.RelayerAddress)
+	if err != nil {
+		return nil, err
+	}
+	lastEventBlockHeight := k.GetLastEventBlockHeightByRelayer(ctx, relayerAddress)
 	return &types.QueryLastEventBlockHeightByAddrResponse{BlockHeight: lastEventBlockHeight}, nil
 }
 
@@ -223,13 +242,24 @@ func (k QueryServer) BatchConfirm(c context.Context, req *types.QueryBatchConfir
 		return nil, status.Error(codes.InvalidArgument, "nonce")
 	}
 	ctx := sdk.UnwrapSDKContext(c)
-	RelayerAddress := sdk.MustAccAddressFromBech32(req.RelayerAddress)
-	_, ok := k.GetRelayer(ctx, RelayerAddress)
+	relayerAddress, err := parseQueryRelayerAddress(req.RelayerAddress)
+	if err != nil {
+		return nil, err
+	}
+	_, ok := k.GetRelayer(ctx, relayerAddress)
 	if !ok {
 		return nil, types.ErrNotFoundRelayer
 	}
-	confirm := k.GetBatchConfirm(ctx, req.TokenContract, req.Nonce, RelayerAddress)
+	confirm := k.GetBatchConfirm(ctx, req.TokenContract, req.Nonce, relayerAddress)
 	return &types.QueryBatchConfirmResponse{Confirm: confirm}, nil
+}
+
+func parseQueryRelayerAddress(relayerAddress string) (sdk.AccAddress, error) {
+	address, err := sdk.AccAddressFromBech32(relayerAddress)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "relayer address")
+	}
+	return address, nil
 }
 
 func (k QueryServer) BatchConfirms(c context.Context, req *types.QueryBatchConfirmsRequest) (*types.QueryBatchConfirmsResponse, error) {

--- a/x/gravity/keeper/grpc_query_test.go
+++ b/x/gravity/keeper/grpc_query_test.go
@@ -2,11 +2,14 @@ package keeper_test
 
 import (
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/openmetaearth/me-hub/testutil/helpers"
 	"github.com/openmetaearth/me-hub/x/gravity/keeper"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *KeeperTestSuite) TestQueryUnbatchedTxs() {
@@ -73,4 +76,85 @@ func (s *KeeperTestSuite) TestQueryUnbatchedTxs() {
 	s.Require().Len(res.Txs, numTxs-pageLimit)
 	s.Require().NotNil(res.Pagination)
 	s.Require().Nil(res.Pagination.NextKey)
+}
+
+func (s *KeeperTestSuite) TestQueriesRejectInvalidRelayerAddressWithoutPanic() {
+	queryServer := keeper.NewQueryServerImpl(s.Keeper())
+	invalidRelayer := "not-a-bech32-address"
+	tokenContract := helpers.GenHexAddress().String()
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "RelayerSetConfirm",
+			call: func() error {
+				_, err := queryServer.RelayerSetConfirm(s.Ctx, &types.QueryRelayerSetConfirmRequest{
+					Nonce:          1,
+					RelayerAddress: invalidRelayer,
+				})
+				return err
+			},
+		},
+		{
+			name: "LastPendingRelayerSetRequestByAddr",
+			call: func() error {
+				_, err := queryServer.LastPendingRelayerSetRequestByAddr(s.Ctx, &types.QueryLastPendingRelayerSetRequestByAddrRequest{
+					RelayerAddress: invalidRelayer,
+				})
+				return err
+			},
+		},
+		{
+			name: "LastPendingBatchRequestByAddr",
+			call: func() error {
+				_, err := queryServer.LastPendingBatchRequestByAddr(s.Ctx, &types.QueryLastPendingBatchRequestByAddrRequest{
+					RelayerAddress: invalidRelayer,
+				})
+				return err
+			},
+		},
+		{
+			name: "LastEventNonceByAddr",
+			call: func() error {
+				_, err := queryServer.LastEventNonceByAddr(s.Ctx, &types.QueryLastEventNonceByAddrRequest{
+					RelayerAddress: invalidRelayer,
+				})
+				return err
+			},
+		},
+		{
+			name: "LastEventBlockHeightByAddr",
+			call: func() error {
+				_, err := queryServer.LastEventBlockHeightByAddr(s.Ctx, &types.QueryLastEventBlockHeightByAddrRequest{
+					RelayerAddress: invalidRelayer,
+				})
+				return err
+			},
+		},
+		{
+			name: "BatchConfirm",
+			call: func() error {
+				_, err := queryServer.BatchConfirm(s.Ctx, &types.QueryBatchConfirmRequest{
+					ChainName:      s.chainName,
+					TokenContract:  tokenContract,
+					Nonce:          1,
+					RelayerAddress: invalidRelayer,
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			var err error
+			s.Require().NotPanics(func() {
+				err = tc.call()
+			})
+			s.Require().Error(err)
+			s.Require().Equal(codes.InvalidArgument, status.Code(err))
+		})
+	}
 }


### PR DESCRIPTION
Fixes #177.

## Summary
- replaces public Gravity query `MustAccAddressFromBech32` parsing for relayer request fields with checked parsing
- returns gRPC `InvalidArgument` for malformed relayer addresses instead of panicking
- covers all affected query handlers listed in the bounty report

## Tests
- go test ./x/gravity/keeper -run TestGravityKeeperTestSuite/TestQueriesRejectInvalidRelayerAddressWithoutPanic -count=1 -v
- git diff --check
- rg -n "MustAccAddressFromBech32\(req\.RelayerAddress\)" x/gravity/keeper/grpc_query.go || true

## Known baseline
- go test ./x/gravity/keeper -count=1 currently fails on existing tests unrelated to this patch: TestGrav004_FailedAttestationMustNotLockNonce, TestMsgBondedRelayer expected error strings, and TestRelayerSetSlash.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099
