### PR TITLE
fix(gravity): make CancelOutgoingTxBatch atomic to prevent partial state corruption (#584)

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -189,14 +189,18 @@ func (k Keeper) CancelOutgoingTxBatch(ctx sdk.Context, contractAddress string, b
 	if batch == nil {
 		return types.ErrUnknown
 	}
+
+	cacheCtx, writeCache := ctx.CacheContext()
 	for _, tx := range batch.Transactions {
-		if err := k.AddUnbatchedTx(ctx, tx); err != nil {
+		if err := k.AddUnbatchedTx(cacheCtx, tx); err != nil {
 			return errorsmod.Wrapf(err, "unable to add batched transaction back into pool %v", tx)
 		}
 	}
 
 	// Delete batch since it is finished
-	k.DeleteBatch(ctx, batch)
+	k.DeleteBatch(cacheCtx, batch)
+
+	writeCache()
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		types.EventTypeOutgoingBatchCanceled,

--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -155,3 +155,62 @@ func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {
 	)
 	suite.Equal(len(batchs), index)
 }
+
+func (suite *KeeperTestSuite) TestCancelOutgoingTxBatchAtomicity() {
+	tokenContract := helpers.GenerateAddress().Hex()
+
+	tx1 := &types.OutgoingTransferTx{
+		Id:          1,
+		Sender:      sdk.AccAddress(helpers.GenerateAddress().Bytes()).String(),
+		DestAddress: helpers.GenerateAddress().Hex(),
+		Token: types.ERC20Token{
+			Contract: tokenContract,
+			Amount:   sdkmath.NewInt(100),
+		},
+		Fee: types.ERC20Token{
+			Contract: tokenContract,
+			Amount:   sdkmath.NewInt(10),
+		},
+	}
+	tx2 := &types.OutgoingTransferTx{
+		Id:          2,
+		Sender:      sdk.AccAddress(helpers.GenerateAddress().Bytes()).String(),
+		DestAddress: helpers.GenerateAddress().Hex(),
+		Token: types.ERC20Token{
+			Contract: tokenContract,
+			Amount:   sdkmath.NewInt(200),
+		},
+		Fee: types.ERC20Token{
+			Contract: tokenContract,
+			Amount:   sdkmath.NewInt(20),
+		},
+	}
+
+	batch := &types.OutgoingTxBatch{
+		BatchNonce:    1,
+		BatchTimeout:  0,
+		Transactions:  []*types.OutgoingTransferTx{tx1, tx2},
+		TokenContract: tokenContract,
+		Block:         100,
+		FeeReceive:    helpers.GenerateAddress().Hex(),
+	}
+
+	suite.NoError(suite.Keeper().StoreBatch(suite.Ctx, batch))
+
+	// Pre-seed the second transaction (tx2) in the pool.
+	// This will cause AddUnbatchedTx for tx2 to fail with duplicate transaction error.
+	suite.NoError(suite.Keeper().AddUnbatchedTx(suite.Ctx, tx2))
+
+	// Call CancelOutgoingTxBatch, which should fail due to the duplicate tx2.
+	err := suite.Keeper().CancelOutgoingTxBatch(suite.Ctx, tokenContract, batch.BatchNonce)
+	suite.Error(err)
+
+	// Since it failed, check that the state is clean (rolled back) and NOT partially applied:
+	// 1. tx1 should NOT be in the pool.
+	_, err1 := suite.Keeper().GetUnbatchedTxByFeeAndId(suite.Ctx, tx1.Fee, tx1.Id)
+	suite.Error(err1)
+
+	// 2. The batch should still exist in store.
+	batchInStore := suite.Keeper().GetOutgoingTxBatch(suite.Ctx, tokenContract, batch.BatchNonce)
+	suite.NotNil(batchInStore)
+}


### PR DESCRIPTION
Addresses Issue #584

## Problem

In `x/gravity/keeper/batch.go:CancelOutgoingTxBatch`, the function iterates through the batch's transactions and adds them back to the unbatched pool:
```go
for _, tx := range batch.Transactions {
    if err := k.AddUnbatchedTx(ctx, tx); err != nil {
        return errorsmod.Wrapf(err, "unable to add batched transaction back into pool %v", tx)
    }
}
```
If any transaction fail to be added back (e.g. because a duplicate transaction already exists in the pool index), `CancelOutgoingTxBatch` aborts and returns an error immediately. However, any transactions processed prior to the failure are already written to the KVStore because it executes on the parent block context. This leaves the system in a corrupted partial state where some transactions are both in the unbatched pool and in the batch, leading to potential duplicate processing and double spends.

## Solution

Wrap the `AddUnbatchedTx` loop and `DeleteBatch` in a transaction `CacheContext`. The cache is only written (`writeCache()`) to the parent context if all transactions are successfully added back to the pool and the batch is successfully deleted. This ensures all-or-nothing atomicity for the batch cancellation.

We also added a unit test `TestCancelOutgoingTxBatchAtomicity` to verify the state rollback when an error is encountered.
