### PR TITLE
fix(wstaking): preserve signing info on key rotation

### DIFF
--- a/x/wstaking/keeper/replace_consensus_pubkey_test.go
+++ b/x/wstaking/keeper/replace_consensus_pubkey_test.go
@@ -1,0 +1,58 @@
+package keeper_test
+
+import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestReplaceConsensusPubKeyPreservesDowntimeSigningInfo() {
+	validator := s.experienceValidator
+	oldConsAddr, err := validator.GetConsAddr()
+	s.Require().NoError(err)
+
+	oldSigningInfo := slashingtypes.NewValidatorSigningInfo(
+		oldConsAddr,
+		1,
+		99,
+		time.Unix(123, 0).UTC(),
+		false,
+		50,
+	)
+	s.App.SlashingKeeper.SetValidatorSigningInfo(s.Ctx, oldConsAddr, oldSigningInfo)
+	s.App.SlashingKeeper.SetValidatorMissedBlockBitArray(s.Ctx, oldConsAddr, 3, true)
+	s.App.SlashingKeeper.SetValidatorMissedBlockBitArray(s.Ctx, oldConsAddr, 17, true)
+
+	newPubKey := ed25519.GenPrivKey().PubKey().(*ed25519.PubKey)
+	newPubKeyData, err := newPubKey.Marshal()
+	s.Require().NoError(err)
+	updateHeight := int64(111)
+
+	s.Ctx = s.Ctx.WithBlockHeight(updateHeight)
+	err = s.Keeper().SetReplacePubKeyInfo(s.Ctx, &types.UpdatePubKeyInfo{
+		OperatorAddress: validator.OperatorAddress,
+		OldConsAddress:  oldConsAddr.Bytes(),
+		PubKey:          newPubKeyData,
+		UpdateAtHeight:  updateHeight,
+	})
+	s.Require().NoError(err)
+
+	replacePubKey, err := s.Keeper().UpdateValidatorPubKey(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().NotNil(replacePubKey)
+
+	newConsAddr := sdk.GetConsAddress(newPubKey)
+	newSigningInfo, found := s.App.SlashingKeeper.GetValidatorSigningInfo(s.Ctx, newConsAddr)
+	s.Require().True(found)
+	s.Require().Equal(newConsAddr.String(), newSigningInfo.Address)
+	s.Require().Equal(oldSigningInfo.StartHeight, newSigningInfo.StartHeight)
+	s.Require().Equal(oldSigningInfo.IndexOffset, newSigningInfo.IndexOffset)
+	s.Require().Equal(oldSigningInfo.JailedUntil, newSigningInfo.JailedUntil)
+	s.Require().Equal(oldSigningInfo.Tombstoned, newSigningInfo.Tombstoned)
+	s.Require().Equal(oldSigningInfo.MissedBlocksCounter, newSigningInfo.MissedBlocksCounter)
+	s.Require().True(s.App.SlashingKeeper.GetValidatorMissedBlockBitArray(s.Ctx, newConsAddr, 3))
+	s.Require().True(s.App.SlashingKeeper.GetValidatorMissedBlockBitArray(s.Ctx, newConsAddr, 17))
+}

--- a/x/wstaking/keeper/update_pub_key.go
+++ b/x/wstaking/keeper/update_pub_key.go
@@ -74,17 +74,23 @@ func (k Keeper) UpdateValidatorPubKey(ctx sdk.Context) (*types.ReplaceNodePubKey
 				k.Logger(ctx).Info("AfterValidatorCreated hook ", "err", err.Error())
 				return nil, sdkerrors.Wrapf(types.ErrInterProc, "AfterValidatorCreated hook error: %v", err)
 			}
-			//directly set new signing info for new cons addr
+			oldConsAddr := sdk.ConsAddress(updateInfo.OldConsAddress)
 			newConsAddr := sdk.GetConsAddress(pk)
-			newSigningInfo := slashingtypes.NewValidatorSigningInfo(
-				newConsAddr,
-				ctx.BlockHeight(),
-				0,
-				time.Unix(0, 0),
-				false,
-				0,
-			)
-			k.slashingKeeper.SetValidatorSigningInfo(ctx, newConsAddr, newSigningInfo)
+			if oldSigningInfo, found := k.slashingKeeper.GetValidatorSigningInfo(ctx, oldConsAddr); found {
+				oldSigningInfo.Address = newConsAddr.String()
+				k.slashingKeeper.SetValidatorSigningInfo(ctx, newConsAddr, oldSigningInfo)
+				k.copyValidatorMissedBlockBitArray(ctx, oldConsAddr, newConsAddr)
+			} else {
+				newSigningInfo := slashingtypes.NewValidatorSigningInfo(
+					newConsAddr,
+					ctx.BlockHeight(),
+					0,
+					time.Unix(0, 0),
+					false,
+					0,
+				)
+				k.slashingKeeper.SetValidatorSigningInfo(ctx, newConsAddr, newSigningInfo)
+			}
 
 			ctx.EventManager().EmitEvent(
 				sdk.NewEvent(types.EventTypeStartReplacePubKey,
@@ -121,6 +127,13 @@ func (k Keeper) UpdateValidatorPubKey(ctx sdk.Context) (*types.ReplaceNodePubKey
 				ctx.BlockHeight(), updateInfo.UpdateAtHeight)
 		}
 	}
+}
+
+func (k Keeper) copyValidatorMissedBlockBitArray(ctx sdk.Context, oldConsAddr, newConsAddr sdk.ConsAddress) {
+	k.slashingKeeper.IterateValidatorMissedBlockBitArray(ctx, oldConsAddr, func(index int64, missed bool) (stop bool) {
+		k.slashingKeeper.SetValidatorMissedBlockBitArray(ctx, newConsAddr, index, missed)
+		return false
+	})
 }
 
 func (k Keeper) SetReplacePubKeyInfo(ctx sdk.Context, data *types.UpdatePubKeyInfo) error {


### PR DESCRIPTION
Fixes #367.

## Summary
- migrates existing slashing `ValidatorSigningInfo` from the old consensus address to the new consensus address during `ReplaceConsensusPubKey`
- preserves `StartHeight`, `IndexOffset`, `JailedUntil`, `Tombstoned`, and `MissedBlocksCounter` instead of resetting downtime history
- copies the stored missed-block bit array to the new consensus address
- keeps the previous fresh-signing-info fallback for validators that genuinely have no old signing info

## Tests
- go test ./x/wstaking/keeper -run TestKeeperTestSuite/TestReplaceConsensusPubKeyPreservesDowntimeSigningInfo -count=1 -v
- git diff --check

## Known baseline
- go test ./x/wstaking/keeper -count=1 currently fails on existing tests unrelated to this patch, including TestDelegate/un_did_delegate, several KYC reward expectation tests, region DAO permission tests, TestStake/No_error, TestTransferKycRegion, TestUnStake/No_error, and TestWithdrawFromRegion/Dao_Permission.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099
