### PR TITLE
fix(wstaking): check region interest treasury reserve

### DIFF
--- a/x/wstaking/keeper/delegate_interest.go
+++ b/x/wstaking/keeper/delegate_interest.go
@@ -1,0 +1,51 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (k Keeper) validateDelegateInterestPayout(ctx sdk.Context, region types.Region, rewards sdk.Dec) (sdk.AccAddress, sdk.Coin, error) {
+	regionTreasureAddr, err := sdk.AccAddressFromBech32(region.RegionTreasureAddr)
+	if err != nil {
+		return nil, sdk.Coin{}, err
+	}
+
+	if !region.DelegateInterest.GTE(rewards) {
+		return nil, sdk.Coin{}, types.ErrPayInterest.Wrapf(
+			"region(%s) total interest not enough. need pay %s, only have %s",
+			region.RegionId,
+			rewards.String(),
+			region.DelegateInterest.String(),
+		)
+	}
+
+	rewardCoin := sdk.NewCoin(params.BaseDenom, rewards.TruncateInt())
+	treasuryBalance := k.bankKeeper.GetBalance(ctx, regionTreasureAddr, params.BaseDenom)
+	if rewardCoin.Amount.IsPositive() {
+		if treasuryBalance.IsLT(rewardCoin) {
+			return nil, sdk.Coin{}, types.ErrPayInterest.Wrapf(
+				"region(%s) treasury balance not enough. need pay %s, only have %s",
+				region.RegionId,
+				rewardCoin.String(),
+				treasuryBalance.String(),
+			)
+		}
+	}
+
+	remainingInterest := region.DelegateInterest.Sub(rewards)
+	projectedTreasuryBalance := treasuryBalance.Amount.Sub(rewardCoin.Amount)
+	if projectedTreasuryBalance.LT(remainingInterest.RoundInt()) {
+		return nil, sdk.Coin{}, types.ErrPayInterest.Wrapf(
+			"region(%s) treasury reserve not enough after payout. need reserve %s%s, projected balance %s%s",
+			region.RegionId,
+			remainingInterest.RoundInt().String(),
+			params.BaseDenom,
+			projectedTreasuryBalance.String(),
+			params.BaseDenom,
+		)
+	}
+
+	return regionTreasureAddr, rewardCoin, nil
+}

--- a/x/wstaking/keeper/delegation.go
+++ b/x/wstaking/keeper/delegation.go
@@ -201,19 +201,17 @@ func (k Keeper) internalWithdrawDelegationRewards(ctx sdk.Context, delAddr sdk.A
 	if err != nil {
 		return nil, types.ErrCalculateInterest.Wrap(err.Error())
 	}
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
-	} else {
-		return nil, types.ErrCalculateInterest.Wrap(fmt.Sprintf("distribution reward.region(%s) total interest not enough.need pay %s,only have %s",
-			region.RegionId, rewards.String(), region.DelegateInterest.String()))
+	regionTreasureAddr, coin, err := k.validateDelegateInterestPayout(ctx, region, rewards)
+	if err != nil {
+		return nil, err
 	}
+	region.DelegateInterest = region.DelegateInterest.Sub(rewards)
 	// truncate reward dec coins, return remainder to community pool
 	//finalRewards, remainder := rewards.TruncateDecimal()
-	coin := sdk.NewCoin(params.BaseDenom, rewards.TruncateInt())
 	coins := sdk.NewCoins(coin)
 	// add coins to user account
 	if !coin.Amount.IsZero() {
-		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, sdk.MustAccAddressFromBech32(region.RegionTreasureAddr), del.GetDelegatorAddr(), coins, fmt.Sprintf("WithdrawDelegationRewards_%s", region.RegionId))
+		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, regionTreasureAddr, del.GetDelegatorAddr(), coins, fmt.Sprintf("WithdrawDelegationRewards_%s", region.RegionId))
 		if err != nil {
 			return nil, err
 		}

--- a/x/wstaking/keeper/msg_server_delegate.go
+++ b/x/wstaking/keeper/msg_server_delegate.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -57,22 +56,18 @@ func (k MsgServer) Delegate(goCtx context.Context, msg *stakingtypes.MsgDelegate
 	delegation, isOK := k.GetDelegation(ctx, delegatorAddress, validator.GetOperator())
 	rewards := sdk.ZeroDec()
 	var regionTreasureAddr sdk.AccAddress
+	var rewardCoin sdk.Coin
 	if isOK {
 		rewards, err = k.CalculateInterest(ctx, delegation.Amount.Add(delegation.UnMeidAmount).Add(delegation.Unmovable), delegation.StartHeight)
 		if err != nil {
 			return nil, types.ErrCalculateInterest.Wrap(err.Error())
 		}
-		regionTreasureAddr, err = sdk.AccAddressFromBech32(region.RegionTreasureAddr)
+		regionTreasureAddr, rewardCoin, err = k.validateDelegateInterestPayout(ctx, region, rewards)
 		if err != nil {
 			return nil, err
 		}
-		if region.DelegateInterest.GTE(rewards) {
-			region.DelegateInterest = region.DelegateInterest.Sub(rewards)
-		} else {
-			return nil, errors.New(fmt.Sprintf("region(%s) total interest not enough.need pay %s,only have %s",
-				region.RegionId, rewards.String(), region.DelegateInterest.String()))
-		}
-		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, regionTreasureAddr, delegatorAddress, sdk.NewCoins(sdk.NewCoin(params.BaseDenom, rewards.TruncateInt())),
+		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
+		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, regionTreasureAddr, delegatorAddress, sdk.NewCoins(rewardCoin),
 			fmt.Sprintf("Delegate_SendRewards_%s", region.RegionId),
 		)
 		if err != nil {

--- a/x/wstaking/keeper/msg_server_delegate_test.go
+++ b/x/wstaking/keeper/msg_server_delegate_test.go
@@ -161,3 +161,146 @@ func (s *KeeperTestSuite) TestUnDelegate() {
 		})
 	}
 }
+
+func (s *KeeperTestSuite) TestDelegateRejectsInterestPayoutWhenRegionTreasuryUnderfunded() {
+	s.SetupTest()
+
+	delegator := s.Dao.AirdropAddress
+	amount := sdk.NewCoin(params.BaseDenom, sdk.NewInt(1000000))
+	_, err := s.msgServer.Delegate(s.Ctx, &stakingtypes.MsgDelegate{
+		DelegatorAddress: delegator,
+		ValidatorAddress: "",
+		Amount:           amount,
+	})
+	s.Require().NoError(err)
+
+	region, delegation := s.prepareUnderfundedDelegateInterest(delegator, 100)
+
+	_, err = s.msgServer.Delegate(s.Ctx, &stakingtypes.MsgDelegate{
+		DelegatorAddress: delegator,
+		ValidatorAddress: "",
+		Amount:           amount,
+	})
+	s.Require().ErrorIs(err, types.ErrPayInterest)
+
+	regionAfter, found := s.Keeper().GetRegion(s.Ctx, region.RegionId)
+	s.Require().True(found)
+	s.Require().True(regionAfter.DelegateInterest.Equal(region.DelegateInterest))
+	s.Require().Equal(region.DelegateAmount.String(), regionAfter.DelegateAmount.String())
+
+	delegationAfter, found := s.Keeper().GetDelegation(s.Ctx, sdk.MustAccAddressFromBech32(delegator), sdk.ValAddress{})
+	s.Require().True(found)
+	s.Require().Equal(delegation.Amount.String(), delegationAfter.Amount.String())
+}
+
+func (s *KeeperTestSuite) TestUndelegateRejectsInterestPayoutWhenRegionTreasuryUnderfunded() {
+	s.SetupTest()
+
+	delegator := s.Dao.AirdropAddress
+	amount := sdk.NewCoin(params.BaseDenom, sdk.NewInt(1000000))
+	_, err := s.msgServer.Delegate(s.Ctx, &stakingtypes.MsgDelegate{
+		DelegatorAddress: delegator,
+		ValidatorAddress: "",
+		Amount:           amount,
+	})
+	s.Require().NoError(err)
+
+	region, delegation := s.prepareUnderfundedDelegateInterest(delegator, 100)
+
+	_, err = s.msgServer.Undelegate(s.Ctx, &stakingtypes.MsgUndelegate{
+		DelegatorAddress: delegator,
+		ValidatorAddress: "",
+		Amount:           amount,
+	})
+	s.Require().ErrorIs(err, types.ErrPayInterest)
+
+	regionAfter, found := s.Keeper().GetRegion(s.Ctx, region.RegionId)
+	s.Require().True(found)
+	s.Require().True(regionAfter.DelegateInterest.Equal(region.DelegateInterest))
+	s.Require().Equal(region.DelegateAmount.String(), regionAfter.DelegateAmount.String())
+
+	delegationAfter, found := s.Keeper().GetDelegation(s.Ctx, sdk.MustAccAddressFromBech32(delegator), sdk.ValAddress{})
+	s.Require().True(found)
+	s.Require().Equal(delegation.Amount.String(), delegationAfter.Amount.String())
+}
+
+func (s *KeeperTestSuite) TestUndelegateRejectsInterestPayoutWhenRegionReserveUnderfunded() {
+	s.SetupTest()
+
+	delegator := s.Dao.AirdropAddress
+	amount := sdk.NewCoin(params.BaseDenom, sdk.NewInt(1000000))
+	_, err := s.msgServer.Delegate(s.Ctx, &stakingtypes.MsgDelegate{
+		DelegatorAddress: delegator,
+		ValidatorAddress: "",
+		Amount:           amount,
+	})
+	s.Require().NoError(err)
+
+	region, delegation := s.prepareUnderfundedDelegateInterest(delegator, 100)
+
+	rewards, err := s.Keeper().CalculateInterest(
+		s.Ctx,
+		delegation.Amount.Add(delegation.UnMeidAmount).Add(delegation.Unmovable),
+		delegation.StartHeight,
+	)
+	s.Require().NoError(err)
+	rewardCoin := sdk.NewCoin(params.BaseDenom, rewards.TruncateInt())
+	s.Require().True(rewardCoin.Amount.IsPositive())
+
+	region.DelegateInterest = rewards.Add(sdk.NewDec(100))
+	s.Keeper().SetRegion(s.Ctx, region)
+
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(
+		s.Ctx,
+		mintypes.ModuleName,
+		sdk.MustAccAddressFromBech32(region.RegionTreasureAddr),
+		sdk.NewCoins(rewardCoin),
+	)
+	s.Require().NoError(err)
+
+	_, err = s.msgServer.Undelegate(s.Ctx, &stakingtypes.MsgUndelegate{
+		DelegatorAddress: delegator,
+		ValidatorAddress: "",
+		Amount:           amount,
+	})
+	s.Require().ErrorIs(err, types.ErrPayInterest)
+
+	regionAfter, found := s.Keeper().GetRegion(s.Ctx, region.RegionId)
+	s.Require().True(found)
+	s.Require().True(regionAfter.DelegateInterest.Equal(region.DelegateInterest))
+	s.Require().Equal(region.DelegateAmount.String(), regionAfter.DelegateAmount.String())
+}
+
+func (s *KeeperTestSuite) prepareUnderfundedDelegateInterest(delegator string, blockHeight int64) (types.Region, stakingtypes.Delegation) {
+	delegatorAddr := sdk.MustAccAddressFromBech32(delegator)
+	delegation, found := s.Keeper().GetDelegation(s.Ctx, delegatorAddr, sdk.ValAddress{})
+	s.Require().True(found)
+
+	s.Ctx = s.Ctx.WithBlockHeight(blockHeight)
+	rewards, err := s.Keeper().CalculateInterest(
+		s.Ctx,
+		delegation.Amount.Add(delegation.UnMeidAmount).Add(delegation.Unmovable),
+		delegation.StartHeight,
+	)
+	s.Require().NoError(err)
+	s.Require().True(rewards.TruncateInt().IsPositive())
+
+	region, found := s.Keeper().GetRegion(s.Ctx, s.experienceValidator.Description.RegionID)
+	s.Require().True(found)
+	region.DelegateInterest = rewards
+	s.Keeper().SetRegion(s.Ctx, region)
+
+	treasuryAddr := sdk.MustAccAddressFromBech32(region.RegionTreasureAddr)
+	treasuryBalance := s.App.BankKeeper.GetBalance(s.Ctx, treasuryAddr, params.BaseDenom)
+	if treasuryBalance.Amount.IsPositive() {
+		err = s.App.BankKeeper.SendCoins(
+			s.Ctx,
+			treasuryAddr,
+			sdk.MustAccAddressFromBech32(s.Dao.GlobalDao),
+			sdk.NewCoins(treasuryBalance),
+		)
+		s.Require().NoError(err)
+	}
+
+	return region, delegation
+}

--- a/x/wstaking/keeper/msg_server_undelegate.go
+++ b/x/wstaking/keeper/msg_server_undelegate.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -66,12 +65,12 @@ func (k MsgServer) Undelegate(goCtx context.Context, msg *stakingtypes.MsgUndele
 	if err != nil {
 		return nil, types.ErrCalculateInterest.Wrap(err.Error())
 	}
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
-	} else {
-		return nil, errors.New(fmt.Sprintf("undelegate err,region(%s) total interest not enough.need pay %s,only have %s",
-			region.RegionId, rewards.String(), region.DelegateInterest.String()))
+	rewardCoin := sdk.Coin{}
+	regionTreasureAddr, rewardCoin, err = k.validateDelegateInterestPayout(ctx, region, rewards)
+	if err != nil {
+		return nil, err
 	}
+	region.DelegateInterest = region.DelegateInterest.Sub(rewards)
 
 	isMeid := true
 	if strings.ToLower(val.Description.RegionID) == strings.ToLower(types.ExperienceRegionName) {
@@ -87,7 +86,7 @@ func (k MsgServer) Undelegate(goCtx context.Context, msg *stakingtypes.MsgUndele
 	val.DelegationAmount = val.DelegationAmount.Sub(returnAmount)
 	k.SetValidator(ctx, val)
 	//send delegation rewards
-	err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, regionTreasureAddr, delegatorAddress, sdk.NewCoins(sdk.NewCoin(params.BaseDenom, rewards.TruncateInt())),
+	err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, regionTreasureAddr, delegatorAddress, sdk.NewCoins(rewardCoin),
 		fmt.Sprintf("Undelegate_SendRewards_%s", region.RegionId),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add a shared delegate-interest payout preflight for Delegate, Undelegate, and direct reward withdrawals
- require the region treasury to cover the current payout and the remaining DelegateInterest reserve after payout
- add regression coverage for underfunded treasury and underfunded reserve cases

Fixes #79.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/Test(DelegateRejectsInterestPayoutWhenRegionTreasuryUnderfunded|UndelegateRejectsInterestPayoutWhenRegionTreasuryUnderfunded|UndelegateRejectsInterestPayoutWhenRegionReserveUnderfunded)' -count=1 -v\n- git diff --check\n\n## Known baseline\n- go test ./x/wstaking/keeper -count=1 still fails on existing unrelated tests: TestDelegate/un_did_delegate, KYC reward balance expectations, region DAO permission expectations, stake/unstake balance expectations, and WithdrawFromRegion/Dao_Permission.