### PR TITLE
fix(rollapp): gate packet-forward transfers

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -507,7 +507,11 @@ func (a *AppKeepers) InitKeepers(
 
 	a.PacketForwardMiddlewareKeeper = packetforwardkeeper.NewKeeper(
 		appCodec, a.keys[packetforwardtypes.StoreKey],
-		a.TransferKeeper,
+		transfergenesis.NewTransferEnabledTransferKeeper(
+			a.TransferKeeper,
+			a.RollappKeeper.GetRollapp,
+			a.IBCKeeper.ChannelKeeper,
+		),
 		a.IBCKeeper.ChannelKeeper,
 		a.DistrKeeper,
 		a.BankKeeper,

--- a/x/rollapp/transfergenesis/transfer_keeper.go
+++ b/x/rollapp/transfergenesis/transfer_keeper.go
@@ -1,0 +1,68 @@
+package transfergenesis
+
+import (
+	"context"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	transferTypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	"github.com/openmetaearth/me-hub/utils/gerrc"
+)
+
+type PacketForwardTransferKeeper interface {
+	Transfer(ctx context.Context, msg *transferTypes.MsgTransfer) (*transferTypes.MsgTransferResponse, error)
+	DenomPathFromHash(ctx sdk.Context, denom string) (string, error)
+	GetTotalEscrowForDenom(ctx sdk.Context, denom string) sdk.Coin
+	SetTotalEscrowForDenom(ctx sdk.Context, coin sdk.Coin)
+}
+
+type transferEnabledTransferKeeper struct {
+	next                  PacketForwardTransferKeeper
+	getRollapp            GetRollapp
+	getChannelClientState ChannelKeeper
+}
+
+func NewTransferEnabledTransferKeeper(
+	next PacketForwardTransferKeeper,
+	getRollapp GetRollapp,
+	getChannelClientState ChannelKeeper,
+) PacketForwardTransferKeeper {
+	return transferEnabledTransferKeeper{
+		next:                  next,
+		getRollapp:            getRollapp,
+		getChannelClientState: getChannelClientState,
+	}
+}
+
+func (k transferEnabledTransferKeeper) Transfer(
+	goCtx context.Context,
+	msg *transferTypes.MsgTransfer,
+) (*transferTypes.MsgTransferResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	gate := TransferEnabledDecorator{
+		getRollapp:            k.getRollapp,
+		getChannelClientState: k.getChannelClientState,
+	}
+
+	enabled, err := gate.transfersEnabled(ctx, msg)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "transfer genesis: transfers enabled")
+	}
+	if !enabled {
+		return nil, errorsmod.Wrap(gerrc.ErrFailedPrecondition, "transfers to/from rollapp are disabled")
+	}
+
+	return k.next.Transfer(goCtx, msg)
+}
+
+func (k transferEnabledTransferKeeper) DenomPathFromHash(ctx sdk.Context, denom string) (string, error) {
+	return k.next.DenomPathFromHash(ctx, denom)
+}
+
+func (k transferEnabledTransferKeeper) GetTotalEscrowForDenom(ctx sdk.Context, denom string) sdk.Coin {
+	return k.next.GetTotalEscrowForDenom(ctx, denom)
+}
+
+func (k transferEnabledTransferKeeper) SetTotalEscrowForDenom(ctx sdk.Context, coin sdk.Coin) {
+	k.next.SetTotalEscrowForDenom(ctx, coin)
+}

--- a/x/rollapp/transfergenesis/transfer_keeper_test.go
+++ b/x/rollapp/transfergenesis/transfer_keeper_test.go
@@ -1,0 +1,108 @@
+package transfergenesis
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
+	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/utils/gerrc"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransferEnabledTransferKeeperRejectsDisabledRollappTransfer(t *testing.T) {
+	const rollappID = "rollapp_100-1"
+	next := &recordingPacketForwardTransferKeeper{}
+	keeper := NewTransferEnabledTransferKeeper(
+		next,
+		staticRollappGetter(rollappID, false),
+		staticChannelKeeper{chainID: rollappID},
+	)
+
+	_, err := keeper.Transfer(sdk.WrapSDKContext(sdk.Context{}), testMsgTransfer())
+
+	require.ErrorIs(t, err, gerrc.ErrFailedPrecondition)
+	require.False(t, next.called)
+}
+
+func TestTransferEnabledTransferKeeperAllowsEnabledRollappTransfer(t *testing.T) {
+	const rollappID = "rollapp_100-1"
+	next := &recordingPacketForwardTransferKeeper{}
+	keeper := NewTransferEnabledTransferKeeper(
+		next,
+		staticRollappGetter(rollappID, true),
+		staticChannelKeeper{chainID: rollappID},
+	)
+
+	_, err := keeper.Transfer(sdk.WrapSDKContext(sdk.Context{}), testMsgTransfer())
+
+	require.NoError(t, err)
+	require.True(t, next.called)
+}
+
+func testMsgTransfer() *types.MsgTransfer {
+	return types.NewMsgTransfer(
+		types.PortID,
+		"channel-0",
+		sdk.NewCoin(params.BaseDenom, sdk.NewInt(1)),
+		"me1l2lt9e4w6qj0ra6jq3dn4csx3z2tyjwk6zu5ac",
+		"rollapp1l2lt9e4w6qj0ra6jq3dn4csx3z2tyjwk7t4za7",
+		clienttypes.Height{},
+		0,
+		"",
+	)
+}
+
+func staticRollappGetter(rollappID string, transfersEnabled bool) GetRollapp {
+	return func(ctx sdk.Context, id string) (rollapptypes.Rollapp, bool) {
+		if id != rollappID {
+			return rollapptypes.Rollapp{}, false
+		}
+		return rollapptypes.Rollapp{
+			RollappId: rollappID,
+			GenesisState: rollapptypes.RollappGenesisState{
+				TransfersEnabled: transfersEnabled,
+			},
+		}, true
+	}
+}
+
+type staticChannelKeeper struct {
+	chainID string
+}
+
+func (k staticChannelKeeper) GetChannelClientState(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+) (string, exported.ClientState, error) {
+	return "07-tendermint-0", &ibctmtypes.ClientState{ChainId: k.chainID}, nil
+}
+
+type recordingPacketForwardTransferKeeper struct {
+	called bool
+}
+
+func (k *recordingPacketForwardTransferKeeper) Transfer(
+	ctx context.Context,
+	msg *types.MsgTransfer,
+) (*types.MsgTransferResponse, error) {
+	k.called = true
+	return &types.MsgTransferResponse{Sequence: 1}, nil
+}
+
+func (k *recordingPacketForwardTransferKeeper) DenomPathFromHash(ctx sdk.Context, denom string) (string, error) {
+	return denom, nil
+}
+
+func (k *recordingPacketForwardTransferKeeper) GetTotalEscrowForDenom(ctx sdk.Context, denom string) sdk.Coin {
+	return sdk.NewCoin(denom, sdk.ZeroInt())
+}
+
+func (k *recordingPacketForwardTransferKeeper) SetTotalEscrowForDenom(ctx sdk.Context, coin sdk.Coin) {
+}


### PR DESCRIPTION
## Summary
- wrap the transfer keeper passed to packet-forward middleware with the Rollapp transfer-genesis gate
- apply the same TransfersEnabled policy to internal PFM MsgTransfer calls that ante already applies to user txs
- add unit coverage proving disabled Rollapp forwards are rejected before calling Transfer, while enabled Rollapps still pass through

Fixes #211.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./x/rollapp/transfergenesis -run 'TestTransferEnabledTransferKeeper' -count=1 -v\n- go test ./x/rollapp/transfergenesis ./app/keepers -count=1\n- git diff --check