### PR TITLE
fix(wstaking): normalize validator region updates

### DIFF
--- a/x/wstaking/keeper/msg_server_validator_edit.go
+++ b/x/wstaking/keeper/msg_server_validator_edit.go
@@ -41,19 +41,25 @@ func (k MsgServer) UpdateValidator(goCtx context.Context, msg *types.MsgUpdateVa
 		if _, err := utils.CheckRegionName(strings.ToUpper(msg.Description.RegionID)); err != nil {
 			return nil, types.ErrRegionName
 		}
+		newRegionId := strings.ToLower(msg.Description.RegionID)
 		// remove duplication
 		validators := k.GetAllValidators(ctx)
 		for _, v := range validators {
-			if v.Description.RegionID == msg.Description.RegionID {
+			if v.OperatorAddress != validator.OperatorAddress && strings.ToLower(v.Description.RegionID) == newRegionId {
 				return nil, types.ErrValidatorRegionDuplication
 			}
 		}
-		k.UnBondRegion(ctx, oldRegionId)
-		description.RegionID = msg.Description.RegionID
+		description.RegionID = newRegionId
 		validator.Description = description
-		region, f := k.GetRegion(ctx, msg.Description.RegionID)
-		if f && region.OperatorAddress == "" {
-			k.BondRegion(ctx, validator, validator.Tokens, true)
+		if newRegionId != oldRegionId {
+			region, f := k.GetRegion(ctx, newRegionId)
+			if !f {
+				return nil, types.ErrRegionNotExist
+			}
+			k.UnBondRegion(ctx, oldRegionId)
+			if region.OperatorAddress == "" {
+				k.BondRegion(ctx, validator, validator.Tokens, true)
+			}
 		}
 	}
 

--- a/x/wstaking/keeper/msg_server_validator_edit_test.go
+++ b/x/wstaking/keeper/msg_server_validator_edit_test.go
@@ -1,0 +1,44 @@
+package keeper_test
+
+import (
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestUpdateValidatorKeepsRegionBoundForCaseOnlyRegionID() {
+	s.SetupTest()
+
+	regionID := s.usaValidator.Description.RegionID
+	_, err := s.msgServer.NewRegion(s.Ctx, &types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            strings.ToUpper(regionID),
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	})
+	s.Require().NoError(err)
+
+	regionBefore, found := s.Keeper().GetRegion(s.Ctx, regionID)
+	s.Require().True(found)
+	s.Require().Equal(s.usaValidator.OperatorAddress, regionBefore.OperatorAddress)
+
+	description := s.usaValidator.Description
+	description.RegionID = strings.ToUpper(regionID)
+	_, err = s.msgServer.UpdateValidator(s.Ctx, &types.MsgUpdateValidator{
+		Description:     description,
+		StakerAddress:   s.Dao.GlobalDao,
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	})
+	s.Require().NoError(err)
+
+	regionAfter, found := s.Keeper().GetRegion(s.Ctx, regionID)
+	s.Require().True(found)
+	s.Require().Equal(regionBefore.OperatorAddress, regionAfter.OperatorAddress)
+	s.Require().Equal(regionBefore.RegionShare.String(), regionAfter.RegionShare.String())
+
+	valAddr, err := sdk.ValAddressFromBech32(s.usaValidator.OperatorAddress)
+	s.Require().NoError(err)
+	validatorAfter, found := s.Keeper().GetValidator(s.Ctx, valAddr)
+	s.Require().True(found)
+	s.Require().Equal(regionID, validatorAfter.Description.RegionID)
+}


### PR DESCRIPTION
## Summary
- normalize UpdateValidator RegionID to lowercase before duplicate checks and store access
- skip unbond/rebond for case-only region updates, preserving the canonical region binding
- validate the new canonical region exists before unbonding the old region
- add regression coverage for `usa -> USA` keeping the region operator and share intact

Fixes #350.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestUpdateValidatorKeepsRegionBoundForCaseOnlyRegionID' -count=1 -v\n- git diff --check\n\n## Known baseline\n- go test ./x/wstaking/keeper -count=1 still fails on existing unrelated tests: TestDelegate/un_did_delegate, KYC reward balance expectations, region DAO permission expectations, stake/unstake balance expectations, and WithdrawFromRegion/Dao_Permission.