### PR TITLE
fix(sequencer): paginate rollapp sequencer queries

### DIFF
--- a/proto/metaearth/sequencer/query.proto
+++ b/proto/metaearth/sequencer/query.proto
@@ -80,19 +80,23 @@ message QuerySequencersResponse {
 
 message QueryGetSequencersByRollappRequest {
   string rollappId = 1;
+  cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
 message QueryGetSequencersByRollappResponse {
   repeated Sequencer sequencers = 1 [(gogoproto.nullable) = false];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
 message QueryGetSequencersByRollappByStatusRequest {
   string rollappId = 1;
   OperatingStatus status = 2;
+  cosmos.base.query.v1beta1.PageRequest pagination = 3;
 }
 
 message QueryGetSequencersByRollappByStatusResponse {
   repeated Sequencer sequencers = 1 [(gogoproto.nullable) = false];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
 message QueryGetUnConfirmSequencersAddrByRollappRequest {

--- a/x/sequencer/client/cli/query_sequencers_by_rollapp.go
+++ b/x/sequencer/client/cli/query_sequencers_by_rollapp.go
@@ -18,12 +18,18 @@ func CmdShowSequencersByRollapp() *cobra.Command {
 				return err
 			}
 
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
 			queryClient := types.NewQueryClient(clientCtx)
 
 			argRollappId := args[0]
 
 			params := &types.QueryGetSequencersByRollappRequest{
-				RollappId: argRollappId,
+				RollappId:  argRollappId,
+				Pagination: pageReq,
 			}
 
 			res, err := queryClient.SequencersByRollapp(cmd.Context(), params)
@@ -35,6 +41,7 @@ func CmdShowSequencersByRollapp() *cobra.Command {
 		},
 	}
 
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd

--- a/x/sequencer/keeper/grpc_query_sequencers_by_rollapp.go
+++ b/x/sequencer/keeper/grpc_query_sequencers_by_rollapp.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,9 +22,23 @@ func (k Keeper) SequencersByRollapp(c context.Context, req *types.QueryGetSequen
 		return nil, types.ErrUnknownRollappID
 	}
 
-	sequencers := k.GetSequencersByRollapp(ctx, req.RollappId)
+	var sequencers []types.Sequencer
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.SequencersByRollappKey(req.RollappId))
+	pageRes, err := query.Paginate(store, req.Pagination, func(key []byte, value []byte) error {
+		var sequencer types.Sequencer
+		if err := k.cdc.Unmarshal(value, &sequencer); err != nil {
+			return err
+		}
+		sequencers = append(sequencers, sequencer)
+		return nil
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	return &types.QueryGetSequencersByRollappResponse{
 		Sequencers: sequencers,
+		Pagination: pageRes,
 	}, nil
 }
 
@@ -36,14 +52,23 @@ func (k Keeper) SequencersByRollappByStatus(c context.Context, req *types.QueryG
 		return nil, types.ErrUnknownRollappID
 	}
 
-	sequencers := k.GetSequencersByRollappByStatus(
-		ctx,
-		req.RollappId,
-		req.Status,
-	)
+	var sequencers []types.Sequencer
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.SequencersByRollappByStatusKey(req.RollappId, req.Status))
+	pageRes, err := query.Paginate(store, req.Pagination, func(key []byte, value []byte) error {
+		var sequencer types.Sequencer
+		if err := k.cdc.Unmarshal(value, &sequencer); err != nil {
+			return err
+		}
+		sequencers = append(sequencers, sequencer)
+		return nil
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 
 	return &types.QueryGetSequencersByRollappByStatusResponse{
 		Sequencers: sequencers,
+		Pagination: pageRes,
 	}, nil
 }
 

--- a/x/sequencer/keeper/grpc_query_sequencers_by_rollapp_test.go
+++ b/x/sequencer/keeper/grpc_query_sequencers_by_rollapp_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,24 +21,16 @@ func (suite *SequencerTestSuite) TestSequencersByRollappQuery3() {
 	rollappId2 := suite.CreateDefaultRollapp()
 
 	// create 2 sequencer
-	addr1_1 := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
-	addr2_1 := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
-	seq1, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr1_1)
-	require.True(suite.T(), found)
-	seq2, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr2_1)
-	require.True(suite.T(), found)
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId)
 	seq1Response := types.QueryGetSequencersByRollappResponse{
-		Sequencers: []types.Sequencer{seq1, seq2},
+		Sequencers: suite.App.SequencerKeeper.GetSequencersByRollapp(suite.Ctx, rollappId),
 	}
 
-	addr1_2 := suite.CreateDefaultSequencer(suite.Ctx, rollappId2)
-	addr2_2 := suite.CreateDefaultSequencer(suite.Ctx, rollappId2)
-	seq3, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr1_2)
-	require.True(suite.T(), found)
-	seq4, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr2_2)
-	require.True(suite.T(), found)
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId2)
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId2)
 	seq2Response := types.QueryGetSequencersByRollappResponse{
-		Sequencers: []types.Sequencer{seq3, seq4},
+		Sequencers: suite.App.SequencerKeeper.GetSequencersByRollapp(suite.Ctx, rollappId2),
 	}
 
 	for _, tc := range []struct {
@@ -79,12 +72,36 @@ func (suite *SequencerTestSuite) TestSequencersByRollappQuery3() {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t,
-					nullify.Fill(tc.response),
-					nullify.Fill(response),
+					nullify.Fill(tc.response.Sequencers),
+					nullify.Fill(response.Sequencers),
 				)
+				require.NotNil(t, response.Pagination)
+				require.Equal(t, uint64(len(tc.response.Sequencers)), response.Pagination.Total)
 			}
 		})
 	}
+}
+
+func (suite *SequencerTestSuite) TestSequencersByRollappQueryPagination() {
+	suite.SetupTest()
+
+	rollappId := suite.CreateDefaultRollapp()
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	response, err := suite.App.SequencerKeeper.SequencersByRollapp(suite.Ctx, &types.QueryGetSequencersByRollappRequest{
+		RollappId: rollappId,
+		Pagination: &query.PageRequest{
+			Limit:      1,
+			CountTotal: true,
+		},
+	})
+	require.NoError(suite.T(), err)
+	require.Len(suite.T(), response.Sequencers, 1)
+	require.NotNil(suite.T(), response.Pagination)
+	require.Equal(suite.T(), uint64(3), response.Pagination.Total)
+	require.NotEmpty(suite.T(), response.Pagination.NextKey)
 }
 
 func (suite *SequencerTestSuite) TestSequencersByRollappByStatusQuery() {
@@ -172,4 +189,27 @@ func (suite *SequencerTestSuite) TestSequencersByRollappByStatusQuery() {
 			}
 		})
 	}
+}
+
+func (suite *SequencerTestSuite) TestSequencersByRollappByStatusQueryPagination() {
+	suite.SetupTest()
+
+	rollappId := suite.CreateDefaultRollapp()
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	response, err := suite.App.SequencerKeeper.SequencersByRollappByStatus(suite.Ctx, &types.QueryGetSequencersByRollappByStatusRequest{
+		RollappId: rollappId,
+		Status:    types.Bonded,
+		Pagination: &query.PageRequest{
+			Limit:      2,
+			CountTotal: true,
+		},
+	})
+	require.NoError(suite.T(), err)
+	require.Len(suite.T(), response.Sequencers, 2)
+	require.NotNil(suite.T(), response.Pagination)
+	require.Equal(suite.T(), uint64(3), response.Pagination.Total)
+	require.NotEmpty(suite.T(), response.Pagination.NextKey)
 }

--- a/x/sequencer/types/query.pb.go
+++ b/x/sequencer/types/query.pb.go
@@ -298,7 +298,8 @@ func (m *QuerySequencersResponse) GetPagination() *query.PageResponse {
 }
 
 type QueryGetSequencersByRollappRequest struct {
-	RollappId string `protobuf:"bytes,1,opt,name=rollappId,proto3" json:"rollappId,omitempty"`
+	RollappId  string             `protobuf:"bytes,1,opt,name=rollappId,proto3" json:"rollappId,omitempty"`
+	Pagination *query.PageRequest `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
 
 func (m *QueryGetSequencersByRollappRequest) Reset()         { *m = QueryGetSequencersByRollappRequest{} }
@@ -341,8 +342,16 @@ func (m *QueryGetSequencersByRollappRequest) GetRollappId() string {
 	return ""
 }
 
+func (m *QueryGetSequencersByRollappRequest) GetPagination() *query.PageRequest {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
 type QueryGetSequencersByRollappResponse struct {
-	Sequencers []Sequencer `protobuf:"bytes,1,rep,name=sequencers,proto3" json:"sequencers"`
+	Sequencers []Sequencer         `protobuf:"bytes,1,rep,name=sequencers,proto3" json:"sequencers"`
+	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
 
 func (m *QueryGetSequencersByRollappResponse) Reset()         { *m = QueryGetSequencersByRollappResponse{} }
@@ -385,9 +394,17 @@ func (m *QueryGetSequencersByRollappResponse) GetSequencers() []Sequencer {
 	return nil
 }
 
+func (m *QueryGetSequencersByRollappResponse) GetPagination() *query.PageResponse {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
 type QueryGetSequencersByRollappByStatusRequest struct {
-	RollappId string          `protobuf:"bytes,1,opt,name=rollappId,proto3" json:"rollappId,omitempty"`
-	Status    OperatingStatus `protobuf:"varint,2,opt,name=status,proto3,enum=metaearth.sequencer.OperatingStatus" json:"status,omitempty"`
+	RollappId  string             `protobuf:"bytes,1,opt,name=rollappId,proto3" json:"rollappId,omitempty"`
+	Status     OperatingStatus    `protobuf:"varint,2,opt,name=status,proto3,enum=metaearth.sequencer.OperatingStatus" json:"status,omitempty"`
+	Pagination *query.PageRequest `protobuf:"bytes,3,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
 
 func (m *QueryGetSequencersByRollappByStatusRequest) Reset() {
@@ -441,8 +458,16 @@ func (m *QueryGetSequencersByRollappByStatusRequest) GetStatus() OperatingStatus
 	return Unbonded
 }
 
+func (m *QueryGetSequencersByRollappByStatusRequest) GetPagination() *query.PageRequest {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
 type QueryGetSequencersByRollappByStatusResponse struct {
-	Sequencers []Sequencer `protobuf:"bytes,1,rep,name=sequencers,proto3" json:"sequencers"`
+	Sequencers []Sequencer         `protobuf:"bytes,1,rep,name=sequencers,proto3" json:"sequencers"`
+	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
 
 func (m *QueryGetSequencersByRollappByStatusResponse) Reset() {
@@ -485,6 +510,13 @@ var xxx_messageInfo_QueryGetSequencersByRollappByStatusResponse proto.InternalMe
 func (m *QueryGetSequencersByRollappByStatusResponse) GetSequencers() []Sequencer {
 	if m != nil {
 		return m.Sequencers
+	}
+	return nil
+}
+
+func (m *QueryGetSequencersByRollappByStatusResponse) GetPagination() *query.PageResponse {
+	if m != nil {
+		return m.Pagination
 	}
 	return nil
 }
@@ -1308,6 +1340,18 @@ func (m *QueryGetSequencersByRollappRequest) MarshalToSizedBuffer(dAtA []byte) (
 	_ = i
 	var l int
 	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.RollappId) > 0 {
 		i -= len(m.RollappId)
 		copy(dAtA[i:], m.RollappId)
@@ -1338,6 +1382,18 @@ func (m *QueryGetSequencersByRollappResponse) MarshalToSizedBuffer(dAtA []byte) 
 	_ = i
 	var l int
 	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.Sequencers) > 0 {
 		for iNdEx := len(m.Sequencers) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -1375,6 +1431,18 @@ func (m *QueryGetSequencersByRollappByStatusRequest) MarshalToSizedBuffer(dAtA [
 	_ = i
 	var l int
 	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
 	if m.Status != 0 {
 		i = encodeVarintQuery(dAtA, i, uint64(m.Status))
 		i--
@@ -1410,6 +1478,18 @@ func (m *QueryGetSequencersByRollappByStatusResponse) MarshalToSizedBuffer(dAtA 
 	_ = i
 	var l int
 	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.Sequencers) > 0 {
 		for iNdEx := len(m.Sequencers) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -1665,6 +1745,10 @@ func (m *QueryGetSequencersByRollappRequest) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovQuery(uint64(l))
 	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
 	return n
 }
 
@@ -1679,6 +1763,10 @@ func (m *QueryGetSequencersByRollappResponse) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
 }
@@ -1696,6 +1784,10 @@ func (m *QueryGetSequencersByRollappByStatusRequest) Size() (n int) {
 	if m.Status != 0 {
 		n += 1 + sovQuery(uint64(m.Status))
 	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
 	return n
 }
 
@@ -1710,6 +1802,10 @@ func (m *QueryGetSequencersByRollappByStatusResponse) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
 }
@@ -2342,6 +2438,42 @@ func (m *QueryGetSequencersByRollappRequest) Unmarshal(dAtA []byte) error {
 			}
 			m.RollappId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageRequest{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipQuery(dAtA[iNdEx:])
@@ -2423,6 +2555,42 @@ func (m *QueryGetSequencersByRollappResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Sequencers = append(m.Sequencers, Sequencer{})
 			if err := m.Sequencers[len(m.Sequencers)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageResponse{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -2527,6 +2695,42 @@ func (m *QueryGetSequencersByRollappByStatusRequest) Unmarshal(dAtA []byte) erro
 					break
 				}
 			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageRequest{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipQuery(dAtA[iNdEx:])
@@ -2608,6 +2812,42 @@ func (m *QueryGetSequencersByRollappByStatusResponse) Unmarshal(dAtA []byte) err
 			}
 			m.Sequencers = append(m.Sequencers, Sequencer{})
 			if err := m.Sequencers[len(m.Sequencers)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageResponse{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/sequencer/types/query.pb.gw.go
+++ b/x/sequencer/types/query.pb.gw.go
@@ -106,7 +106,9 @@ func local_request_Query_Sequencer_0(ctx context.Context, marshaler runtime.Mars
 }
 
 var (
-	filter_Query_Sequencers_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+	filter_Query_Sequencers_0                  = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+	filter_Query_SequencersByRollapp_0         = &utilities.DoubleArray{Encoding: map[string]int{"rollappId": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+	filter_Query_SequencersByRollappByStatus_0 = &utilities.DoubleArray{Encoding: map[string]int{"rollappId": 0, "status": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
 )
 
 func request_Query_Sequencers_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -163,6 +165,13 @@ func request_Query_SequencersByRollapp_0(ctx context.Context, marshaler runtime.
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rollappId", err)
 	}
 
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_SequencersByRollapp_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
 	msg, err := client.SequencersByRollapp(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -188,6 +197,13 @@ func local_request_Query_SequencersByRollapp_0(ctx context.Context, marshaler ru
 
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rollappId", err)
+	}
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_SequencersByRollapp_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	msg, err := server.SequencersByRollapp(ctx, &protoReq)
@@ -231,6 +247,13 @@ func request_Query_SequencersByRollappByStatus_0(ctx context.Context, marshaler 
 
 	protoReq.Status = OperatingStatus(e)
 
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_SequencersByRollappByStatus_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
 	msg, err := client.SequencersByRollappByStatus(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -271,6 +294,13 @@ func local_request_Query_SequencersByRollappByStatus_0(ctx context.Context, mars
 	}
 
 	protoReq.Status = OperatingStatus(e)
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_SequencersByRollappByStatus_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
 
 	msg, err := server.SequencersByRollappByStatus(ctx, &protoReq)
 	return msg, metadata, err


### PR DESCRIPTION
## Summary
- Add PageRequest/PageResponse fields to SequencersByRollapp and SequencersByRollappByStatus query messages.
- Use prefix-store query.Paginate in both gRPC handlers so large rollapp sequencer sets can be requested in bounded pages.
- Parse REST query parameters for pagination and pass CLI pagination flags for show-sequencers-by-rollapp.
- Add focused regression tests for limited rollapp sequencer responses.

Fixes #229.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./x/sequencer/keeper -run 'TestSequencerKeeperTestSuite/TestSequencersByRollapp(Query3|QueryPagination|ByStatusQuery|ByStatusQueryPagination)' -count=1 -v
- go test ./x/sequencer/types ./x/sequencer/client/cli -count=1
- git diff --check

## Known baseline failures
- go test ./x/sequencer/keeper ./x/sequencer/types ./x/sequencer/client/cli -count=1 still fails on existing unrelated keeper tests:
  - TestMinBond: expected empty Coins vs nil Coins
  - TestRotatingSequencerByBond
  - TestTokensRefundOnUnbond

## Proto generation note
- make proto-gen / narrow buf generate is currently blocked by the remote buf registry returning: "Failure: the server hosted at that remote is unavailable."
- The generated Go files were updated manually and verified by the focused compile/tests above.