### PR TITLE
fix: require active DID for KYC benefits

### DIFF
--- a/app/ante/expected_keepers.go
+++ b/app/ante/expected_keepers.go
@@ -28,6 +28,7 @@ type StakingKeeper interface {
 
 type KycKeeper interface {
 	GetDID(ctx sdk.Context, addr sdk.AccAddress) (string, bool)
+	GetDidInfo(ctx sdk.Context, did string) (info didtypes.DidInfo, found bool)
 	GetKYC(ctx sdk.Context, did string) (kyc didtypes.Credential, found bool)
 }
 

--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -227,7 +227,10 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 			kyc, isKyc := didtypes.Credential{}, false
 			did, hasDid := dfd.kycKeeper.GetDID(ctx, deductFeesFrom)
 			if hasDid {
-				kyc, isKyc = dfd.kycKeeper.GetKYC(ctx, did)
+				didInfo, hasDidInfo := dfd.kycKeeper.GetDidInfo(ctx, did)
+				if hasDidInfo && didInfo.Status == didtypes.DID_STATUS_ACTIVE {
+					kyc, isKyc = dfd.kycKeeper.GetKYC(ctx, did)
+				}
 			}
 			if isKyc {
 				fee20Address, err = dfd.stakingKeeper.GetValOwnerAddress(ctx, string(kyc.Data))

--- a/app/ante/mock/expected_keepers_mocks.go
+++ b/app/ante/mock/expected_keepers_mocks.go
@@ -264,6 +264,21 @@ func (mr *MockKycKeeperMockRecorder) GetDID(ctx, addr interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDID", reflect.TypeOf((*MockKycKeeper)(nil).GetDID), ctx, addr)
 }
 
+// GetDidInfo mocks base method.
+func (m *MockKycKeeper) GetDidInfo(ctx types0.Context, did string) (types2.DidInfo, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDidInfo", ctx, did)
+	ret0, _ := ret[0].(types2.DidInfo)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetDidInfo indicates an expected call of GetDidInfo.
+func (mr *MockKycKeeperMockRecorder) GetDidInfo(ctx, did interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDidInfo", reflect.TypeOf((*MockKycKeeper)(nil).GetDidInfo), ctx, did)
+}
+
 // GetKYC mocks base method.
 func (m *MockKycKeeper) GetKYC(ctx types0.Context, did string) (types2.Credential, bool) {
 	m.ctrl.T.Helper()

--- a/x/kyc/keeper/grpc_query.go
+++ b/x/kyc/keeper/grpc_query.go
@@ -74,6 +74,9 @@ func (k Keeper) DIDs(goCtx context.Context, req *types.QueryDIDs) (*types.QueryD
 		if !found {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("kyc exist, but did %s is not found", kyc.Did))
 		}
+		if info.Status != didtypes.DID_STATUS_ACTIVE {
+			continue
+		}
 
 		infos = append(infos, info)
 	}
@@ -87,8 +90,12 @@ func (k Keeper) KYC(goCtx context.Context, req *types.QueryKYC) (*types.QueryKYC
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if !k.HasDidInfo(ctx, req.Did) {
+	didInfo, found := k.GetDidInfo(ctx, req.Did)
+	if !found {
 		return nil, status.Error(codes.Internal, "DID not found")
+	}
+	if didInfo.Status != didtypes.DID_STATUS_ACTIVE {
+		return nil, status.Error(codes.Internal, "DID not active")
 	}
 	kyc, found := k.GetKYC(ctx, req.Did)
 	if !found {
@@ -109,7 +116,15 @@ func (k Keeper) KYCs(goCtx context.Context, req *types.QueryKYCs) (*types.QueryK
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return &types.QueryKYCsResponse{KYCs: KYCs, Pagination: pageRes}, nil
+	var activeKYCs []didtypes.Credential
+	for _, kyc := range KYCs {
+		didInfo, found := k.GetDidInfo(ctx, kyc.Did)
+		if found && didInfo.Status == didtypes.DID_STATUS_ACTIVE {
+			activeKYCs = append(activeKYCs, kyc)
+		}
+	}
+
+	return &types.QueryKYCsResponse{KYCs: activeKYCs, Pagination: pageRes}, nil
 }
 
 func (k Keeper) SBT(goCtx context.Context, req *types.QuerySBT) (*types.QuerySBTResponse, error) {

--- a/x/kyc/keeper/grpc_query_test.go
+++ b/x/kyc/keeper/grpc_query_test.go
@@ -142,6 +142,48 @@ func (s *KeeperTestSuite) TestKYC() {
 	s.Require().Equal(res.Kyc.Data, []byte(strings.ToLower(wstakingtypes.MeEarthRegionName)))
 }
 
+func (s *KeeperTestSuite) TestInactiveDIDDoesNotReturnKYC() {
+	s.SetupTest()
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	did := "1111111111111111"
+	kycAccount, newUserPubkey := s.NewAccount()
+	inviter, _ := s.NewAccount()
+	msg := &types.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: strings.ToLower(wstakingtypes.MeEarthRegionName),
+		Address:  kycAccount.String(),
+		Pubkey:   newUserPubkey,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "aaaa",
+		Inviter:  inviter.String(),
+		Level:    didtypes.KYC_LEVEL_TWO,
+	}
+	_, err := s.msgServer.Approve(s.Ctx, msg)
+	s.Require().NoError(err)
+
+	didInfo, found := s.Keeper().GetDidInfo(s.Ctx, did)
+	s.Require().True(found)
+	didInfo.Status = didtypes.DID_STATUS_INACTIVE
+	didInfo.KycLevel = didtypes.KYC_LEVEL_NONE
+	s.Keeper().SetDidInfo(s.Ctx, did, didInfo)
+
+	_, err = s.queryClient.KYC(s.Ctx, &types.QueryKYC{Did: did})
+	s.Require().Error(err)
+
+	dids, err := s.queryClient.DIDs(s.Ctx, &types.QueryDIDs{RegionId: strings.ToLower(wstakingtypes.MeEarthRegionName)})
+	s.Require().NoError(err)
+	s.Require().Empty(dids.Infos)
+
+	kycs, err := s.queryClient.KYCs(s.Ctx, &types.QueryKYCs{RegionId: strings.ToLower(wstakingtypes.MeEarthRegionName)})
+	s.Require().NoError(err)
+	s.Require().Empty(kycs.KYCs)
+}
+
 func (s *KeeperTestSuite) TestKYCs() {
 	s.SetupTest()
 

--- a/x/wstaking/keeper/kyc_region.go
+++ b/x/wstaking/keeper/kyc_region.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/openmetaearth/me-hub/app/params"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/wstaking/types"
 	"strings"
 )
@@ -16,11 +17,11 @@ func (k Keeper) GetRegionIdByAccount(ctx sdk.Context, address sdk.AccAddress) st
 	if !ok {
 		return regionId
 	}
-	kycData, ok := k.kycKeeper.GetKYC(ctx, did)
+	kycRegionId, ok := k.getActiveKycRegionId(ctx, did)
 	if !ok {
 		return regionId
 	}
-	return string(kycData.Data)
+	return kycRegionId
 }
 
 func (k Keeper) MustGetKycRegionIdByAccount(ctx sdk.Context, account string) (string, error) {
@@ -28,11 +29,23 @@ func (k Keeper) MustGetKycRegionIdByAccount(ctx sdk.Context, account string) (st
 	if !ok {
 		return "", sdkerrors.Wrapf(types.ErrDidNotExists, "did with account %s not exist", account)
 	}
-	kycData, ok := k.kycKeeper.GetKYC(ctx, did)
+	kycRegionId, ok := k.getActiveKycRegionId(ctx, did)
 	if !ok {
-		return "", sdkerrors.Wrapf(types.ErrKycNotExists, "kyc with account %s not exist", account)
+		return "", sdkerrors.Wrapf(types.ErrKycNotExists, "active kyc with account %s not exist", account)
 	}
-	return string(kycData.Data), nil
+	return kycRegionId, nil
+}
+
+func (k Keeper) getActiveKycRegionId(ctx sdk.Context, did string) (string, bool) {
+	didInfo, found := k.didKeeper.GetDidInfo(ctx, did)
+	if !found || didInfo.Status != didtypes.DID_STATUS_ACTIVE {
+		return "", false
+	}
+	kycData, found := k.kycKeeper.GetKYC(ctx, did)
+	if !found {
+		return "", false
+	}
+	return string(kycData.Data), true
 }
 
 func (k Keeper) TransferKycRegion(ctx sdk.Context, address sdk.AccAddress, creator, fromRegionId, toRegionId string) error {

--- a/x/wstaking/keeper/kyc_region_test.go
+++ b/x/wstaking/keeper/kyc_region_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	"github.com/openmetaearth/me-hub/app/params"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
 	wmintTypes "github.com/openmetaearth/me-hub/x/wmint/types"
@@ -67,4 +68,35 @@ func (s *KeeperTestSuite) TestTransferKycRegion() {
 	s.Require().Equal(delegation.Unmovable.String(), types.Bonus.String())
 	s.Require().Equal(delegation.ValidatorAddress, s.usaValidator.OperatorAddress)
 	s.Require().EqualValues(delegation.StartHeight, wmintTypes.OneDayTotalBlocks+1)
+}
+
+func (s *KeeperTestSuite) TestGetRegionIdByAccountRequiresActiveDID() {
+	s.SetupTest()
+
+	account := s.TestAccs[0]
+	did := "1111111111111111"
+	didInfo := didtypes.DidInfo{
+		Did:      did,
+		Address:  account.String(),
+		RegionId: types.MeEarthRegionId,
+		KycLevel: didtypes.KYC_LEVEL_TWO,
+		Status:   didtypes.DID_STATUS_ACTIVE,
+	}
+	kyc := didtypes.Credential{Did: did, Data: []byte(types.MeEarthRegionId)}
+
+	s.App.KycKeeper.SetDID(s.Ctx, account, did)
+	s.App.KycKeeper.SetDidInfo(s.Ctx, did, didInfo)
+	s.App.KycKeeper.SetKYC(s.Ctx, did, kyc)
+
+	s.Require().Equal(types.MeEarthRegionId, s.Keeper().GetRegionIdByAccount(s.Ctx, account))
+	regionId, err := s.Keeper().MustGetKycRegionIdByAccount(s.Ctx, account.String())
+	s.Require().NoError(err)
+	s.Require().Equal(types.MeEarthRegionId, regionId)
+
+	didInfo.Status = didtypes.DID_STATUS_INACTIVE
+	s.App.KycKeeper.SetDidInfo(s.Ctx, did, didInfo)
+
+	s.Require().Equal(strings.ToLower(types.ExperienceRegionName), s.Keeper().GetRegionIdByAccount(s.Ctx, account))
+	_, err = s.Keeper().MustGetKycRegionIdByAccount(s.Ctx, account.String())
+	s.Require().Error(err)
 }


### PR DESCRIPTION
## Summary
- require the DID backing a KYC credential to remain `DID_STATUS_ACTIVE` before KYC queries return it
- make `wstaking` fall back to the experience region, or reject mandatory KYC region lookups, when a DID is inactive even if the KYC credential still exists
- avoid routing fee shares through a stale KYC region for inactive DIDs
- add regressions covering inactive DID + persisted KYC state

## Root cause
DID status can be changed independently from the persisted KYC credential. Several KYC-gated paths looked only for the DID-to-account mapping and the KYC credential, so an inactive DID could continue to expose KYC records and drive staking/fee region selection.

The current `Credential`/`DidInfo` schema does not expose an on-chain expiry timestamp, so this patch enforces the available on-chain validity signal: the DID must still be active anywhere KYC benefits are consumed.

## Verification
- `git diff --check`
- `go test ./x/kyc/keeper` reached compile/link, then failed locally on Windows because the project-specific CosmWasm library is unavailable: `ld: cannot find -lwasmvm`
- `go test ./x/wstaking/keeper` reached compile/link, then failed locally on Windows for the same `-lwasmvm` linker dependency
- `go test ./x/did/types` passes

Existing unrelated local failures remain in `x/kyc/types` genesis validation tests and `x/wstaking/types` IBC transfer validation tests.

Addresses #773