### PR TITLE
fix(upgrades): preserve module version map migrations

### DIFF
--- a/app/upgrades/upgrade_handler_test.go
+++ b/app/upgrades/upgrade_handler_test.go
@@ -1,0 +1,52 @@
+package upgrades
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+func TestUpgradeHandlersDoNotOverwriteFromVersionMap(t *testing.T) {
+	t.Parallel()
+
+	files := []string{
+		filepath.Join("v2_0_13", "upgrade.go"),
+		filepath.Join("v2_0_14", "upgrade.go"),
+		filepath.Join("v2.0.14.patch.2", "upgrade.go"),
+	}
+
+	for _, file := range files {
+		file := file
+		t.Run(file, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			parsed, err := parser.ParseFile(fset, file, nil, 0)
+			if err != nil {
+				t.Fatalf("parse upgrade handler: %v", err)
+			}
+
+			ast.Inspect(parsed, func(node ast.Node) bool {
+				assign, ok := node.(*ast.AssignStmt)
+				if !ok {
+					return true
+				}
+
+				for _, lhs := range assign.Lhs {
+					index, ok := lhs.(*ast.IndexExpr)
+					if !ok {
+						continue
+					}
+					ident, ok := index.X.(*ast.Ident)
+					if ok && ident.Name == "fromVM" {
+						t.Fatalf("upgrade handler must not overwrite fromVM at %s", fset.Position(lhs.Pos()))
+					}
+				}
+
+				return true
+			})
+		})
+	}
+}

--- a/app/upgrades/v2.0.14.patch.2/upgrade.go
+++ b/app/upgrades/v2.0.14.patch.2/upgrade.go
@@ -20,13 +20,6 @@ func CreateUpgradeHandler(
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 		logger.Info("upgrade starting...")
 
-		// Initialize consensus versions for all modules
-		for n, m := range mm.Modules {
-			if mod, ok := m.(module.HasConsensusVersion); ok {
-				fromVM[n] = mod.ConsensusVersion()
-			}
-		}
-
 		evmParams := keepers.EvmKeeper.GetParams(ctx)
 		evmParams.EvmDenom = "umec"
 		if err := keepers.EvmKeeper.SetParams(ctx, evmParams); err != nil {

--- a/app/upgrades/v2_0_13/upgrade.go
+++ b/app/upgrades/v2_0_13/upgrade.go
@@ -30,13 +30,6 @@ func CreateUpgradeHandler(
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 		logger.Info("upgrade starting...")
 
-		// Initialize consensus versions for all modules
-		for n, m := range mm.Modules {
-			if mod, ok := m.(module.HasConsensusVersion); ok {
-				fromVM[n] = mod.ConsensusVersion()
-			}
-		}
-
 		params := keepers.GovKeeper.GetParams(ctx)
 		maxDepositPeriod := 30 * time.Minute
 		params.MaxDepositPeriod = &maxDepositPeriod

--- a/app/upgrades/v2_0_14/upgrade.go
+++ b/app/upgrades/v2_0_14/upgrade.go
@@ -20,13 +20,6 @@ func CreateUpgradeHandler(
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 		logger.Info("upgrade starting...")
 
-		// Initialize consensus versions for all modules
-		for n, m := range mm.Modules {
-			if mod, ok := m.(module.HasConsensusVersion); ok {
-				fromVM[n] = mod.ConsensusVersion()
-			}
-		}
-
 		logger.Info("upgrade finished successfully.")
 		return mm.RunMigrations(ctx, configurator, fromVM)
 	}


### PR DESCRIPTION
## Summary
- Stop upgrade handlers from overwriting every fromVM entry with the current consensus version before RunMigrations.
- Preserve the SDK migration runner semantics: existing modules can run migrations and missing modules can be initialized according to the real version map.
- Apply the same safety fix to the v2.0.13, v2.0.14, and v2.0.14.patch.2 handlers because they share the same migration-skipping pattern.
- Add a regression test that fails if upgrade handlers reintroduce fromVM[...] assignment.

Fixes #690.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./app/upgrades -run TestUpgradeHandlersDoNotOverwriteFromVersionMap -count=1 -v
- go test ./app/upgrades/v2_0_13 ./app/upgrades/v2_0_14 ./app/upgrades/v2.0.14.patch.2 -count=1
- go test ./app/upgrades/... -count=1
- git diff --check