### PR TITLE
fix(ibctesting): check rollapp packet commitments

### DIFF
--- a/ibctesting/eibc_test.go
+++ b/ibctesting/eibc_test.go
@@ -3,6 +3,7 @@ package ibctesting_test
 import (
 	"encoding/json"
 	"errors"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -367,10 +368,27 @@ func (s *eibcSuite) TestEIBCDemandOrderFulfillment() {
 }
 
 func (s *eibcSuite) rollappHasPacketCommitment(packet channeltypes.Packet) bool {
-	// TODO: this should be used to check that a commitment does (or doesn't) exist, when it should
-	// TODO: this is important to check that things actually work as expected and dont just look ok on the outside
-	// TODO: finish implementing, true is a temporary placeholder
-	return true
+	rollappIBCKeeper := s.rollappChain().App.GetIBCKeeper()
+	return rollappIBCKeeper.ChannelKeeper.HasPacketCommitment(
+		s.rollappCtx(),
+		packet.GetSourcePort(),
+		packet.GetSourceChannel(),
+		packet.GetSequence(),
+	)
+}
+
+func TestRollappHasPacketCommitmentQueriesIBCStore(t *testing.T) {
+	source, err := os.ReadFile("eibc_test.go")
+	if err != nil {
+		t.Fatalf("read eibc test source: %v", err)
+	}
+	body := string(source)
+	if !strings.Contains(body, "ChannelKeeper.HasPacketCommitment") {
+		t.Fatal("rollappHasPacketCommitment must query the IBC channel keeper")
+	}
+	if strings.Contains(body, "return true\n}") {
+		t.Fatal("rollappHasPacketCommitment must not return a hardcoded true value")
+	}
 }
 
 // TestTimeoutEIBCDemandOrderFulfillment: when a packet hub->rollapp times out, or gets an error ack, than eIBC can be used to recover quickly.


### PR DESCRIPTION
## Summary
- Replace the hardcoded `rollappHasPacketCommitment` test helper with a real `ChannelKeeper.HasPacketCommitment` lookup on the RollApp chain.
- Check source port, source channel, and packet sequence from the packet under test.
- Add a lightweight regression test that prevents the helper from becoming a hardcoded `return true` placeholder again.

Fixes #677.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./ibctesting -run TestRollappHasPacketCommitmentQueriesIBCStore -count=1 -v
- go test ./ibctesting -run '^$' -count=1
- git diff --check

## Known baseline failures
- go test ./ibctesting -count=1 currently fails before packet-commitment assertions because the test app genesis setup panics on stale fields such as `regions`, `stakes`, `fixedDepositList`, and `unbonding_stakes` in `types.GenesisState`.