### PR TITLE
fix(kyc): avoid empty protocol regions

### DIFF
--- a/x/kyc/keeper/grpc_query_test.go
+++ b/x/kyc/keeper/grpc_query_test.go
@@ -34,6 +34,19 @@ func (s *KeeperTestSuite) TestProtocol() {
 	s.Require().Equal(len(res.Protocol.Regions), 0)
 }
 
+func (s *KeeperTestSuite) TestGetAllRegionsDoesNotReturnEmptyPlaceholders() {
+	s.SetupTest()
+
+	rawRegions := s.App.StakingKeeper.GetAllRegion(s.Ctx)
+	regions := s.Keeper().GetAllRegions(s.Ctx)
+
+	s.Require().Len(regions, len(rawRegions))
+	for _, region := range regions {
+		s.Require().NotEmpty(region.Id)
+		s.Require().NotEmpty(region.Name)
+	}
+}
+
 func (s *KeeperTestSuite) TestDID() {
 	s.SetupTest()
 

--- a/x/kyc/keeper/protocol.go
+++ b/x/kyc/keeper/protocol.go
@@ -25,7 +25,7 @@ func (k *Keeper) GetRegion(ctx sdk.Context, regionId string) (reg types.Region, 
 
 func (k *Keeper) GetAllRegions(ctx sdk.Context) (regs []types.Region) {
 	raws := k.stkKeeper.GetAllRegion(ctx)
-	regions := make([]types.Region, len(raws))
+	regions := make([]types.Region, 0, len(raws))
 	for _, rew := range raws {
 		regions = append(regions, types.Region{Id: rew.RegionId, Name: rew.Name})
 	}


### PR DESCRIPTION
## Summary
- Fix GetAllRegions to allocate a zero-length result slice with capacity instead of preallocating populated zero-value entries.
- Keep protocol region responses to exactly the real configured staking regions.
- Add a regression test that fails if empty placeholder regions are returned.

Fixes #671.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestGetAllRegionsDoesNotReturnEmptyPlaceholders' -count=1 -v
- go test ./x/kyc/keeper -run '^$' -count=1
- git diff --check

## Known baseline failures
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestProtocol' -count=1 -v currently fails on an existing issuer count expectation: expected 1, actual 0.
- go test ./x/kyc/types -count=1 currently fails on existing genesis validation expectations unrelated to this patch.