### PR TITLE
fix(wgov): restore stake-weighted voting power and delegator vote counting

### DIFF
--- a/x/wgov/keeper/tally.go
+++ b/x/wgov/keeper/tally.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 
 // Tally iterates over the votes and updates the tally of a proposal based on the voting power of the
@@ -43,28 +44,28 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 		}
 
 		// iterate over all delegations from voter, deduct from any delegated-to validators
-		//keeper.stakingKeeper.IterateStakes(ctx, voter, func(index int64, stake wstakingtypes.Stake) (stop bool) {
-		//	valAddrStr := stake.GetValidatorAddr().String()
-		//
-		//	if val, ok := currValidators[valAddrStr]; ok {
-		//		// There is no need to handle the special case that validator address equal to voter address.
-		//		// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
-		//		val.DelegatorDeductions = val.DelegatorDeductions.Add(stake.GetShares())
-		//		currValidators[valAddrStr] = val
-		//
-		//		// delegation shares * bonded / total shares
-		//		votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
-		//
-		//		for _, option := range vote.Options {
-		//			weight, _ := sdk.NewDecFromStr(option.Weight)
-		//			subPower := votingPower.Mul(weight)
-		//			results[option.Option] = results[option.Option].Add(subPower)
-		//		}
-		//		totalVotingPower = totalVotingPower.Add(votingPower)
-		//	}
-		//
-		//	return false
-		//})
+		keeper.stakingKeeper.IterateStakes(ctx, voter, func(index int64, stake wstakingtypes.Stake) (stop bool) {
+			valAddrStr := stake.GetValidatorAddr().String()
+
+			if val, ok := currValidators[valAddrStr]; ok {
+				// There is no need to handle the special case that validator address equal to voter address.
+				// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
+				val.DelegatorDeductions = val.DelegatorDeductions.Add(stake.GetShares())
+				currValidators[valAddrStr] = val
+
+				// delegation shares * bonded / total shares
+				votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+
+				for _, option := range vote.Options {
+					weight, _ := sdk.NewDecFromStr(option.Weight)
+					subPower := votingPower.Mul(weight)
+					results[option.Option] = results[option.Option].Add(subPower)
+				}
+				totalVotingPower = totalVotingPower.Add(votingPower)
+			}
+
+			return false
+		})
 
 		keeper.DeleteVote(ctx, vote.ProposalId, voter)
 		return false
@@ -76,9 +77,8 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 			continue
 		}
 
-		//sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
-		//votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
-		votingPower := sdk.NewDec(1)
+		sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
+		votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
 
 		for _, option := range val.Vote {
 			weight, _ := sdk.NewDecFromStr(option.Weight)
@@ -91,16 +91,13 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 	params := keeper.GetParams(ctx)
 	tallyResults = v1.NewTallyResultFromMap(results)
 
-	// TODO: Upgrade the spec to cover all of these cases & remove pseudocode.
 	// If there is no staked coins, the proposal fails
-	//if keeper.stakingKeeper.TotalBondedStakePool(ctx).IsZero() {
-	//	return false, false, tallyResults
-	//}
-	totalValidatorNumber := len(currValidators)
+	if keeper.stakingKeeper.TotalBondedStakePool(ctx).IsZero() {
+		return false, false, tallyResults
+	}
 
 	// If there is not enough quorum of votes, the proposal fails
-	//percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(keeper.stakingKeeper.TotalBondedStakePool(ctx)))
-	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(sdk.NewInt(int64(totalValidatorNumber))))
+	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(keeper.stakingKeeper.TotalBondedStakePool(ctx)))
 	quorum, _ := sdk.NewDecFromStr(params.Quorum)
 	if percentVoting.LT(quorum) {
 		return false, params.BurnVoteQuorum, tallyResults


### PR DESCRIPTION
## What

Fixes #792 — three governance bypass issues in `x/wgov/keeper/tally.go`:

1. **Restored delegator vote counting** — `IterateStakes` loop was fully commented out, delegator votes deleted without counting
2. **Restored stake-weighted validator voting power** — was hardcoded to `sdk.NewDec(1)`, now uses `sharesAfterDeductions * BondedTokens / DelegatorShares`
3. **Restored stake-based quorum** — was `totalVotingPower / validatorCount`, now `totalVotingPower / TotalBondedStakePool`

## Why

Without this fix, governance proposals can pass with a minority of stake. Two validators with 1 token each can outvote a validator with 1 billion tokens. Delegators have zero governance influence.

## How

Restored the original Cosmos SDK governance tally logic adapted for wstaking's `IterateStakes` interface. Added `wstakingtypes` import.