### PR TITLE
fix(delayedack): cap FinalizeRollappPackets batch to 1000

### DIFF
--- a/x/delayedack/keeper/finalize.go
+++ b/x/delayedack/keeper/finalize.go
@@ -15,6 +15,14 @@ import (
 	"github.com/openmetaearth/me-hub/x/delayedack/types"
 )
 
+const (
+	// finalizePacketsBatchSize caps the number of rollapp packets finalized
+	// per AfterStateFinalized call to prevent unbounded EndBlock gas usage
+	// when many packets accumulate during a long state-update window.
+	// Matches the epoch deletion batch size for consistency.
+	finalizePacketsBatchSize = 1000
+)
+
 // FinalizeRollappPackets finalizes the packets for the given rollapp until the given height which is
 // the end height of the latest finalized state
 func (k Keeper) FinalizeRollappPackets(ctx sdk.Context, ibc porttypes.IBCModule, rollappID string, stateEndHeight uint64) error {
@@ -23,6 +31,16 @@ func (k Keeper) FinalizeRollappPackets(ctx sdk.Context, ibc porttypes.IBCModule,
 		return nil
 	}
 	logger := ctx.Logger().With("module", "DelayedAckMiddleware")
+	// Cap the number of packets processed in a single EndBlock to prevent
+	// unbounded gas consumption when many packets accumulate.
+	if len(rollappPendingPackets) > finalizePacketsBatchSize {
+		logger.Warn("capping rollapp packet finalization batch",
+			"rollappID", rollappID,
+			"total", len(rollappPendingPackets),
+			"processing", finalizePacketsBatchSize,
+			"deferred", len(rollappPendingPackets)-finalizePacketsBatchSize)
+		rollappPendingPackets = rollappPendingPackets[:finalizePacketsBatchSize]
+	}
 	// Get the packets for the rollapp until height
 	logger.Debug("finalizing IBC rollapp packets",
 		"rollappID", rollappID,


### PR DESCRIPTION
## Summary
Caps `FinalizeRollappPackets` to `finalizePacketsBatchSize = 1000` packets per call, matching the existing epoch deletion batch limit.

Fixes #794

## Problem
`FinalizeRollappPackets()` processes ALL pending packets in a single EndBlock with no limit. Each packet replays full IBC handlers (recv/ack/timeout) with state writes and bank transfers. A rollapp with high IBC throughput can accumulate thousands of packets during a long state-update window, causing EndBlock gas to exceed block limits and halting chain consensus.

The deletion path (`hooks.go`) already uses `deletePacketsBatchSize = 1000` — but finalization had none.

## Fix
- Add `finalizePacketsBatchSize = 1000` constant
- Slice packet list to batch cap before processing
- Log a warning when capping occurs so operators can monitor
- Deferred packets remain PENDING and process on the next `AfterStateFinalized` call (the next state update covers new heights, so these will be picked up naturally)

## Testing
- Build passes locally
- No state-breaking changes — packets still finalize, just in bounded batches
