### PR TITLE
fix(delayedack): log hook error instead of aborting packet finalization

### DIFF
--- a/x/delayedack/keeper/finalize.go
+++ b/x/delayedack/keeper/finalize.go
@@ -72,11 +72,22 @@ func (k Keeper) finalizeRollappPacket(
 		rollappPacket.Error = packetErr.Error()
 	}
 	// Update status to finalized
+	// NOTE: UpdateRollappPacketWithStatus deletes the old PENDING key and writes
+	// the new FINALIZED key BEFORE calling hooks. If a downstream hook (e.g.
+	// eIBC demand-order status update) errors, returning that error here causes
+	// the parent ApplyFuncIfNoError in finalizeStateForIndex to roll back ALL
+	// state changes — leaving the packet PENDING again. Because the
+	// finalization queue entry is retained on failure, every subsequent block
+	// retries the same packet and hits the same hook error, permanently wedging
+	// the rollapp's state finalization.
+	//
+	// To prevent a single bad hook from blocking an entire rollapp, we log the
+	// error and continue. The packet is already moved to FINALIZED in the KV
+	// store; the hook (eIBC demand-order update) failure is non-fatal.
 	_, err := k.UpdateRollappPacketWithStatus(ctx, rollappPacket, commontypes.Status_FINALIZED)
 	if err != nil {
-		// If we failed finalizing the packet we return an error to abort the end blocker otherwise it's
-		// invariant breaking
-		return err
+		logger.Error("hook error during packet finalization, continuing to next packet",
+			append(logContext, "error", err.Error())...)
 	}
 
 	logger.Debug("finalized IBC rollapp packet", logContext...)


### PR DESCRIPTION
## Summary
Prevents a single poisoned packet's hook error from permanently wedging a rollapp's state finalization.

Fixes #796

## Problem
`UpdateRollappPacketWithStatus` deletes the old PENDING key and writes the new FINALIZED key BEFORE calling hooks (eIBC demand-order status update). If the hook errors, `finalizeRollappPacket` returns the error, which propagates through `FinalizeRollappPackets` → `finalizePendingState` → `osmoutils.ApplyFuncIfNoError`, which rolls back ALL state changes. The packet reverts to PENDING, and the finalization queue entry is retained. Every subsequent block retries and hits the same error — **permanent wedge**.

## Fix
Log the hook error and continue instead of returning it. The packet is already moved to FINALIZED in the KV store before hooks fire. The hook (eIBC demand-order update) is a non-fatal notification that shouldn't block an entire rollapp's finalization.

This matches the pattern in the deletion path (`hooks.go:40`) where `AfterPacketDeleted` errors are also logged rather than propagated.

## Testing
- Existing tests pass (hook errors are logged, packets still finalized)
- The change only affects error propagation — no logic change for successful hook calls
