### PR TITLE
fix(gravity): guard offline relayer concentration

### DIFF
--- a/x/gravity/keeper/abci_test.go
+++ b/x/gravity/keeper/abci_test.go
@@ -553,3 +553,59 @@ func (s *KeeperTestSuite) TestSlashRelayer() {
 		s.Require().Equal(int64(1), relayer.SlashTimes)
 	}
 }
+
+func (s *KeeperTestSuite) TestOfflineRelayersDoNotConcentrateAttestationPower() {
+	delegateAmount := sdk.NewInt(10 * 1e8)
+
+	for i := 0; i < len(s.relayerAddrs); i++ {
+		msgBondedRelayer := &types.MsgBondedRelayer{
+			RelayerAddress:  s.relayerAddrs[i].String(),
+			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[i].PublicKey),
+			DelegateAmount:  sdk.NewCoin(params.BaseDenom, delegateAmount),
+			ChainName:       s.chainName,
+		}
+		s.Require().NoError(msgBondedRelayer.ValidateBasic())
+		_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msgBondedRelayer)
+		s.Require().NoError(err)
+	}
+
+	initialTotalPower := s.Keeper().GetLastTotalPower(s.Ctx)
+	remainingRelayer, found := s.Keeper().GetRelayer(s.Ctx, s.relayerAddrs[0])
+	s.Require().True(found)
+	initialShare := remainingRelayer.GetPower().
+		Mul(sdkmath.NewInt(int64(types.PowerBase))).
+		Quo(initialTotalPower)
+	s.Require().True(initialShare.LTE(types.AttestationProposalRelayerChangePowerThreshold))
+
+	for i := 1; i < len(s.relayerAddrs); i++ {
+		err := s.Keeper().SlashRelayer(s.Ctx, s.relayerAddrs[i].String())
+		s.Require().NoError(err)
+
+		slashedRelayer, found := s.Keeper().GetRelayer(s.Ctx, s.relayerAddrs[i])
+		s.Require().True(found)
+		s.Require().False(slashedRelayer.Online)
+	}
+
+	s.Keeper().SetLastTotalPower(s.Ctx)
+	recomputedTotalPower := s.Keeper().GetLastTotalPower(s.Ctx)
+	s.Require().Equal(initialTotalPower.String(), recomputedTotalPower.String())
+
+	bridgeToken := helpers.GenExternalAddr(s.chainName)
+	claim := &types.MsgBridgeTokenClaim{
+		EventNonce:     1,
+		BlockHeight:    1000,
+		TokenContract:  bridgeToken,
+		Name:           "Concentration Guard Token",
+		Symbol:         "CGT",
+		Decimals:       6,
+		RelayerAddress: s.relayerAddrs[0].String(),
+		ChainName:      s.chainName,
+	}
+	_, err := s.MsgServer().BridgeTokenClaim(sdk.WrapSDKContext(s.Ctx), claim)
+	s.Require().NoError(err)
+
+	attestation := s.Keeper().GetAttestation(s.Ctx, claim.EventNonce, claim.ClaimHash())
+	s.Require().NotNil(attestation)
+	s.Require().False(attestation.Observed)
+	s.Require().Len(attestation.Votes, 1)
+}

--- a/x/gravity/keeper/relayer.go
+++ b/x/gravity/keeper/relayer.go
@@ -81,13 +81,38 @@ func (k Keeper) GetLastTotalPower(ctx sdk.Context) sdkmath.Int {
 
 // SetLastTotalPower Set the last total relayer power.
 func (k Keeper) SetLastTotalPower(ctx sdk.Context) {
-	relayers := k.GetAllRelayers(ctx, true)
+	relayers := k.GetAllRelayers(ctx, false)
 	totalPower := sdkmath.ZeroInt()
+	bondedPower := sdkmath.ZeroInt()
+	maxOnlinePower := sdkmath.ZeroInt()
 	for _, relayer := range relayers {
-		totalPower = totalPower.Add(relayer.GetPower())
+		power := relayer.GetPower()
+		bondedPower = bondedPower.Add(power)
+		if !relayer.Online {
+			continue
+		}
+		totalPower = totalPower.Add(power)
+		if power.GT(maxOnlinePower) {
+			maxOnlinePower = power
+		}
+	}
+
+	if k.isOnlineRelayerSetOverConcentrated(totalPower, maxOnlinePower) && bondedPower.GT(totalPower) {
+		totalPower = bondedPower
 	}
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.LastTotalPowerKey, k.cdc.MustMarshal(&sdk.IntProto{Int: totalPower}))
+}
+
+func (k Keeper) isOnlineRelayerSetOverConcentrated(totalPower, maxOnlinePower sdkmath.Int) bool {
+	if totalPower.IsZero() || maxOnlinePower.IsZero() {
+		return false
+	}
+
+	maxAllowedPower := types.AttestationProposalRelayerChangePowerThreshold.
+		Mul(totalPower).
+		Quo(sdkmath.NewInt(int64(types.PowerBase)))
+	return maxOnlinePower.GT(maxAllowedPower)
 }
 
 // --- RELAYERS --- //


### PR DESCRIPTION
## Summary
- Keep `LastTotalPower` from collapsing to a dangerously concentrated online relayer set after other relayers go offline.
- When the online set would exceed the relayer power-change threshold, use the still-bonded relayer power as the attestation denominator floor.
- Add a regression covering the #783 scenario: one remaining relayer no longer observes a bridge attestation alone after the other relayers are slashed offline.

Fixes #783.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestOfflineRelayersDoNotConcentrateAttestationPower' -count=1 -v\n- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(SlashRelayer|OfflineRelayersDoNotConcentrateAttestationPower)' -count=1 -v\n- go test ./x/gravity/keeper -run '^$' -count=1\n- git diff --check\n\n## Known baseline failures\n- go test ./x/gravity/keeper -count=1 still fails on existing unrelated tests:\n  - TestGrav004_FailedAttestationMustNotLockNonce: expected nonce 1, actual 2\n  - TestMsgBondedRelayer expected older error strings\n  - TestRelayerSetSlash at abci_test.go:506\n