### PR TITLE
fix(eibc): validate updated demand orders

### DIFF
--- a/x/eibc/keeper/msg_server.go
+++ b/x/eibc/keeper/msg_server.go
@@ -118,6 +118,10 @@ func (m msgServer) UpdateDemandOrder(goCtx context.Context, msg *types.MsgUpdate
 	demandOrder.Fee = sdk.NewCoins(sdk.NewCoin(denom, newFeeInt))
 	demandOrder.Price = sdk.NewCoins(sdk.NewCoin(denom, newPrice))
 
+	if err := demandOrder.Validate(); err != nil {
+		return nil, err
+	}
+
 	err = m.SetDemandOrder(ctx, demandOrder)
 	if err != nil {
 		return nil, err

--- a/x/eibc/keeper/msg_server_test.go
+++ b/x/eibc/keeper/msg_server_test.go
@@ -276,6 +276,31 @@ func (suite *KeeperTestSuite) TestMsgUpdateDemandOrder() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestUpdateDemandOrderValidatesBeforePersisting() {
+	testAddresses := apptesting.AddTestAddrs(suite.App, suite.Ctx, 1, sdk.NewInt(100_000))
+	eibcSupplyAddr := testAddresses[0]
+
+	dackParams := dacktypes.NewParams("hour", sdk.NewDecWithPrec(1, 2), 0) // 1%
+	suite.App.DelayedAckKeeper.SetParams(suite.Ctx, dackParams)
+	suite.App.DelayedAckKeeper.SetRollappPacket(suite.Ctx, *rollappPacket)
+
+	invalidIBCDenom := "transfer/"
+	initialFee := sdk.NewInt(100)
+	initialPrice := sdk.NewInt(890)
+	demandOrder := types.NewDemandOrder(*rollappPacket, initialPrice, initialFee, invalidIBCDenom, eibcSupplyAddr.String())
+	err := suite.App.EIBCKeeper.SetDemandOrder(suite.Ctx, demandOrder)
+	suite.Require().NoError(err)
+
+	msg := types.NewMsgUpdateDemandOrder(eibcSupplyAddr.String(), demandOrder.Id, "400")
+	_, err = suite.msgServer.UpdateDemandOrder(suite.Ctx, msg)
+	suite.Require().Error(err)
+
+	storedDemandOrder, err := suite.App.EIBCKeeper.GetDemandOrder(suite.Ctx, rollappPacket.Status, demandOrder.Id)
+	suite.Require().NoError(err)
+	suite.Require().Equal(initialFee, storedDemandOrder.Fee.AmountOf(invalidIBCDenom))
+	suite.Require().Equal(initialPrice, storedDemandOrder.Price.AmountOf(invalidIBCDenom))
+}
+
 func (suite *KeeperTestSuite) TestUpdateDemandOrderOnAckOrTimeout() {
 	// Create and fund the account
 	testAddresses := apptesting.AddTestAddrs(suite.App, suite.Ctx, 2, sdk.NewInt(100_000))


### PR DESCRIPTION
## Summary
- Validate the mutated `DemandOrder` before `UpdateDemandOrder` writes it back to the store.
- Keep the update path aligned with the creation path, which already validates demand orders before persisting them.
- Add a regression proving invalid post-mutation state is rejected and the stored order remains unchanged.

Fixes #709.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./x/eibc/keeper -run 'TestKeeperTestSuite/Test(UpdateDemandOrderValidatesBeforePersisting|MsgUpdateDemandOrder|UpdateDemandOrderOnAckOrTimeout)' -count=1 -v\n- go test ./x/eibc/types -count=1\n- git diff --check\n\n## Known baseline failures\n- go test ./x/eibc/keeper -count=1 still fails on existing unrelated fulfillment tests because local test accounts have insufficient spendable `stake` balances:\n  - TestFulfillOrderEvent\n  - TestMsgFulfillOrder/Test_demand_order_fulfillment_-_success\n  - TestMsgFulfillOrder/order_with_zero_fee_-_success\n