### PR TITLE
fix(ante): include fee payer fees in fund check

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -95,6 +95,7 @@ func (suite *AnteTestSuite) TestCosmosAnteHandlerEip712() {
 	suite.mockDaoKeeper.EXPECT().GetGlobalDao(gomock.Any()).Return(devOperator.Address)
 	suite.mockDaoKeeper.EXPECT().GetMeidDao(gomock.Any()).Return(devOperator.Address)
 	suite.mockDaoKeeper.EXPECT().GetGlobalDaoFeePoolAddr(gomock.Any()).Return(devOperator.GetAddress())
+	suite.mockDaoKeeper.EXPECT().IsDao(gomock.Any(), addr.Address).Return(false)
 	suite.mockDaoKeeper.EXPECT().CheckFreeGasAccount(gomock.Any(), addr.Address).Return(false)
 
 	amt := sdk.NewInt(100)

--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -285,12 +285,10 @@ func (dfd DeductFeeDecorator) CheckFunds(ctx sdk.Context, tx sdk.Tx, feePayer st
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "denom is empty")
 	}
 
-	fromAddress := ""
 	userSendAmount := make(map[string]sdk.Coins)
 	for _, msg := range tx.GetMsgs() {
 		switch txMsg := msg.(type) {
 		case *banktypes.MsgSend:
-			fromAddress = txMsg.FromAddress
 			sendAmount := userSendAmount[txMsg.FromAddress]
 			sendAmount = sendAmount.Add(txMsg.Amount...)
 			userSendAmount[txMsg.FromAddress] = sendAmount
@@ -298,19 +296,17 @@ func (dfd DeductFeeDecorator) CheckFunds(ctx sdk.Context, tx sdk.Tx, feePayer st
 			if len(txMsg.Inputs) == 0 {
 				return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "no input coins provided")
 			}
-			fromAddress = txMsg.Inputs[0].Address
+			fromAddress := txMsg.Inputs[0].Address
 			sendAmount := userSendAmount[fromAddress]
 			for _, output := range txMsg.Outputs {
 				sendAmount = sendAmount.Add(output.Coins...)
 			}
 			userSendAmount[fromAddress] = sendAmount
 		case *stakingtypes.MsgDelegate:
-			fromAddress = txMsg.DelegatorAddress
 			sendAmount := userSendAmount[txMsg.DelegatorAddress]
 			sendAmount = sendAmount.Add(txMsg.Amount)
 			userSendAmount[txMsg.DelegatorAddress] = sendAmount
 		case *wstakingtypes.MsgDoFixedDeposit:
-			fromAddress = txMsg.Account
 			sendAmount := userSendAmount[txMsg.Account]
 			sendAmount = sendAmount.Add(txMsg.Principal)
 			userSendAmount[txMsg.Account] = sendAmount
@@ -320,9 +316,7 @@ func (dfd DeductFeeDecorator) CheckFunds(ctx sdk.Context, tx sdk.Tx, feePayer st
 	if _, exists := userSendAmount[feePayer]; !exists {
 		userSendAmount[feePayer] = fees
 	} else {
-		if fromAddress == feePayer {
-			userSendAmount[feePayer] = userSendAmount[feePayer].Add(fees...)
-		}
+		userSendAmount[feePayer] = userSendAmount[feePayer].Add(fees...)
 	}
 
 	for address, sendAmount := range userSendAmount {

--- a/app/ante/fee_deduct_test.go
+++ b/app/ante/fee_deduct_test.go
@@ -391,3 +391,62 @@ func TestCheckFunds(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckFundsAlwaysAddsFeeToFeePayerSendAmount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := sdk.Context{}
+	mockBankKeeper := mock.NewMockBankKeeper(ctrl)
+	mockAccountKeeper := authantetestutil.NewMockAccountKeeper(ctrl)
+	mockFeegrantKeeper := authantetestutil.NewMockFeegrantKeeper(ctrl)
+	mockStakingKeeper := mock.NewMockStakingKeeper(ctrl)
+	mockKycKeeper := mock.NewMockKycKeeper(ctrl)
+	mockDaoKeeper := mock.NewMockDaoKeeper(ctrl)
+	mockWasmKeeper := mock.NewMockWasmKeeper(ctrl)
+
+	decorator := ante.NewDeductFeeDecorator(
+		mockAccountKeeper,
+		mockBankKeeper,
+		mockFeegrantKeeper,
+		mockDaoKeeper,
+		mockStakingKeeper,
+		mockKycKeeper,
+		nil,
+		mockWasmKeeper,
+	)
+
+	feePayer := NewAccount()
+	receiver := NewAccount()
+	laterSender := NewAccount()
+	fees := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(10)))
+
+	mockBankKeeper.EXPECT().
+		GetAllBalances(gomock.Any(), feePayer.GetAddress()).
+		Return(sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(100)))).
+		AnyTimes()
+	mockBankKeeper.EXPECT().
+		GetAllBalances(gomock.Any(), laterSender.GetAddress()).
+		Return(sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(1)))).
+		AnyTimes()
+
+	tx := &mock.MockTx{
+		Msgs: []sdk.Msg{
+			&banktypes.MsgSend{
+				FromAddress: feePayer.Address,
+				ToAddress:   receiver.Address,
+				Amount:      sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(100))),
+			},
+			&stakingtypes.MsgDelegate{
+				DelegatorAddress: laterSender.Address,
+				ValidatorAddress: sdk.ValAddress(receiver.GetAddress()).String(),
+				Amount:           sdk.NewCoin(params.BaseDenom, sdk.NewInt(1)),
+			},
+		},
+	}
+
+	err := decorator.CheckFunds(ctx, tx, feePayer.Address, fees)
+	require.Error(t, err)
+	require.True(t, sdkerrors.ErrInsufficientFunds.Is(err))
+	require.Contains(t, err.Error(), "required: 110umec")
+}

--- a/app/ante/mock/expected_keepers_mocks.go
+++ b/app/ante/mock/expected_keepers_mocks.go
@@ -52,6 +52,20 @@ func (mr *MockDaoKeeperMockRecorder) CheckFreeGasAccount(ctx, address interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckFreeGasAccount", reflect.TypeOf((*MockDaoKeeper)(nil).CheckFreeGasAccount), ctx, address)
 }
 
+// IsDao mocks base method.
+func (m *MockDaoKeeper) IsDao(ctx types0.Context, addr string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDao", ctx, addr)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDao indicates an expected call of IsDao.
+func (mr *MockDaoKeeperMockRecorder) IsDao(ctx, addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDao", reflect.TypeOf((*MockDaoKeeper)(nil).IsDao), ctx, addr)
+}
+
 // GetAirdropAddress mocks base method.
 func (m *MockDaoKeeper) GetAirdropAddress(ctx types0.Context) string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary
- Always include transaction fees in the fee payer's aggregated fund check when the fee payer also sends funds in the same multi-message transaction.
- Remove the stale dependency on the last handled message sender, which let a later sender hide fees from the fee payer balance check.
- Refresh the ante DaoKeeper mock with the existing IsDao method so app/ante tests compile against the current interface.
- Add a regression for #169 where the fee payer spends 100umec, a later sender delegates, and the fee payer must still be checked for 110umec including fees.

Fixes #169.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./app/ante -run 'TestCheckFunds|TestCheckFundsAlwaysAddsFeeToFeePayerSendAmount' -count=1 -v\n- go test ./app/ante -count=1\n- git diff --check\n\n## Note\n- Existing open PR #574 also refreshes the generated DaoKeeper mock for #201. This PR includes the same mock-interface sync because current origin/main cannot compile app/ante tests after DaoKeeper gained IsDao.\n