### PR TITLE
fix(ante): reject malformed fee addresses without panic

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -95,6 +95,7 @@ func (suite *AnteTestSuite) TestCosmosAnteHandlerEip712() {
 	suite.mockDaoKeeper.EXPECT().GetGlobalDao(gomock.Any()).Return(devOperator.Address)
 	suite.mockDaoKeeper.EXPECT().GetMeidDao(gomock.Any()).Return(devOperator.Address)
 	suite.mockDaoKeeper.EXPECT().GetGlobalDaoFeePoolAddr(gomock.Any()).Return(devOperator.GetAddress())
+	suite.mockDaoKeeper.EXPECT().IsDao(gomock.Any(), addr.Address).Return(false)
 	suite.mockDaoKeeper.EXPECT().CheckFreeGasAccount(gomock.Any(), addr.Address).Return(false)
 
 	amt := sdk.NewInt(100)

--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -130,8 +130,14 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	)
 
 	feePending := feeTx.GetFee()
-	feePayer := feeTx.FeePayer()
-	feeGranter := feeTx.FeeGranter()
+	feePayer, err := safeFeePayer(feeTx)
+	if err != nil {
+		return ctx, err
+	}
+	feeGranter, err := safeFeeGranter(feeTx)
+	if err != nil {
+		return ctx, err
+	}
 
 	isDao := dfd.daoKeeper.IsDao(ctx, feePayer.String())
 	isFreeGasAccount := dfd.daoKeeper.CheckFreeGasAccount(ctx, feePayer.String())
@@ -278,6 +284,24 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	}
 	newCtx := ctx.WithPriority(priority)
 	return next(newCtx, tx, simulate)
+}
+
+func safeFeePayer(feeTx sdk.FeeTx) (feePayer sdk.AccAddress, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid fee payer: %v", r)
+		}
+	}()
+	return feeTx.FeePayer(), nil
+}
+
+func safeFeeGranter(feeTx sdk.FeeTx) (feeGranter sdk.AccAddress, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid fee granter: %v", r)
+		}
+	}()
+	return feeTx.FeeGranter(), nil
 }
 
 func (dfd DeductFeeDecorator) CheckFunds(ctx sdk.Context, tx sdk.Tx, feePayer string, fees sdk.Coins) error {

--- a/app/ante/fee_deduct_test.go
+++ b/app/ante/fee_deduct_test.go
@@ -32,6 +32,47 @@ func NewAccountWithEthPrivKey() (*authtypes.BaseAccount, *ethsecp256k1.PrivKey) 
 	return acc, senderPrivKey
 }
 
+type panicFeeTx struct {
+	msgs          []sdk.Msg
+	fee           sdk.Coins
+	gas           uint64
+	feePayer      sdk.AccAddress
+	feeGranter    sdk.AccAddress
+	panicPayer    bool
+	panicGranter  bool
+	validateBasic error
+}
+
+func (tx panicFeeTx) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx panicFeeTx) ValidateBasic() error {
+	return tx.validateBasic
+}
+
+func (tx panicFeeTx) GetFee() sdk.Coins {
+	return tx.fee
+}
+
+func (tx panicFeeTx) GetGas() uint64 {
+	return tx.gas
+}
+
+func (tx panicFeeTx) FeePayer() sdk.AccAddress {
+	if tx.panicPayer {
+		panic("malformed auth_info fee payer")
+	}
+	return tx.feePayer
+}
+
+func (tx panicFeeTx) FeeGranter() sdk.AccAddress {
+	if tx.panicGranter {
+		panic("malformed auth_info fee granter")
+	}
+	return tx.feeGranter
+}
+
 func TestMockBankKeeper(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -46,6 +87,67 @@ func TestMockBankKeeper(t *testing.T) {
 
 	balances := mockBankKeeper.GetAllBalances(ctx, addr)
 	require.Equal(t, expectedBalances, balances)
+}
+
+func TestDeductFeeRejectsMalformedAuthInfoFeeAddressesWithoutPanic(t *testing.T) {
+	tests := []struct {
+		name         string
+		panicPayer   bool
+		panicGranter bool
+	}{
+		{
+			name:       "fee payer",
+			panicPayer: true,
+		},
+		{
+			name:         "fee granter",
+			panicGranter: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := sdk.Context{}
+			mockBankKeeper := mock.NewMockBankKeeper(ctrl)
+			mockAccountKeeper := authantetestutil.NewMockAccountKeeper(ctrl)
+			mockFeegrantKeeper := authantetestutil.NewMockFeegrantKeeper(ctrl)
+			mockStakingKeeper := mock.NewMockStakingKeeper(ctrl)
+			mockKycKeeper := mock.NewMockKycKeeper(ctrl)
+			mockDaoKeeper := mock.NewMockDaoKeeper(ctrl)
+			mockWasmKeeper := mock.NewMockWasmKeeper(ctrl)
+
+			decorator := ante.NewDeductFeeDecorator(
+				mockAccountKeeper,
+				mockBankKeeper,
+				mockFeegrantKeeper,
+				mockDaoKeeper,
+				mockStakingKeeper,
+				mockKycKeeper,
+				nil,
+				mockWasmKeeper,
+			)
+
+			feePayer := NewAccount()
+			tx := panicFeeTx{
+				fee:          sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(10000))),
+				gas:          200000,
+				feePayer:     feePayer.GetAddress(),
+				panicPayer:   tc.panicPayer,
+				panicGranter: tc.panicGranter,
+			}
+
+			require.NotPanics(t, func() {
+				_, err := decorator.AnteHandle(ctx, tx, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+					return ctx, nil
+				})
+				require.Error(t, err)
+				require.True(t, sdkerrors.ErrInvalidAddress.Is(err))
+			})
+		})
+	}
 }
 
 func TestCheckFunds(t *testing.T) {

--- a/app/ante/mock/expected_keepers_mocks.go
+++ b/app/ante/mock/expected_keepers_mocks.go
@@ -52,6 +52,20 @@ func (mr *MockDaoKeeperMockRecorder) CheckFreeGasAccount(ctx, address interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckFreeGasAccount", reflect.TypeOf((*MockDaoKeeper)(nil).CheckFreeGasAccount), ctx, address)
 }
 
+// IsDao mocks base method.
+func (m *MockDaoKeeper) IsDao(ctx types0.Context, addr string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDao", ctx, addr)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDao indicates an expected call of IsDao.
+func (mr *MockDaoKeeperMockRecorder) IsDao(ctx, addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDao", reflect.TypeOf((*MockDaoKeeper)(nil).IsDao), ctx, addr)
+}
+
 // GetAirdropAddress mocks base method.
 func (m *MockDaoKeeper) GetAirdropAddress(ctx types0.Context) string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary
- Wrap fee payer and fee granter extraction so malformed `auth_info.fee.payer` or `auth_info.fee.granter` becomes `ErrInvalidAddress` instead of a panic.
- Add regressions proving `DeductFeeDecorator` does not panic when `FeePayer()` or `FeeGranter()` panics on malformed fee address input.
- Refresh the ante DaoKeeper mock with the existing IsDao method so app/ante tests compile against the current interface.

Fixes #178.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./app/ante -run TestDeductFeeRejectsMalformedAuthInfoFeeAddressesWithoutPanic -count=1 -v
- go test ./app/ante -count=1
- git diff --check

## Note
- Existing open PR #574 also refreshes the generated DaoKeeper mock for #201. This PR includes the same mock-interface sync because current origin/main cannot compile app/ante tests after DaoKeeper gained IsDao.
