### PR TITLE
fix(wgov): make active tally query read-only

### DIFF
--- a/x/wgov/keeper/query.go
+++ b/x/wgov/keeper/query.go
@@ -42,7 +42,8 @@ func (q Keeper) MeTallyResult(c context.Context, req *types.QueryMeTallyResultRe
 
 	default:
 		// proposal is in voting period
-		_, _, tallyResult = q.Tally(ctx, proposal)
+		cacheCtx, _ := ctx.CacheContext()
+		_, _, tallyResult = q.Tally(cacheCtx, proposal)
 	}
 
 	return &types.QueryMeTallyResultResponse{Tally: &tallyResult}, nil

--- a/x/wgov/keeper/query_test.go
+++ b/x/wgov/keeper/query_test.go
@@ -1,0 +1,25 @@
+package keeper
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMeTallyResultUsesCacheContextForActiveProposalTally(t *testing.T) {
+	source, err := os.ReadFile("query.go")
+	if err != nil {
+		t.Fatalf("read query.go: %v", err)
+	}
+
+	text := string(source)
+	if !strings.Contains(text, "cacheCtx, _ := ctx.CacheContext()") {
+		t.Fatalf("MeTallyResult must create a cache context before tallying active proposals")
+	}
+	if !strings.Contains(text, "q.Tally(cacheCtx, proposal)") {
+		t.Fatalf("MeTallyResult must tally active proposals against cacheCtx")
+	}
+	if strings.Contains(text, "q.Tally(ctx, proposal)") {
+		t.Fatalf("MeTallyResult must not tally active proposals against the write-through ctx")
+	}
+}


### PR DESCRIPTION
## Summary
- Run `MeTallyResult` active-proposal tally against a cache context so query-time tally side effects are discarded.
- Prevent the read-only gRPC query from committing `Tally` vote deletions into chain state.
- Add a focused regression that fails if active proposal tallying is wired back to the write-through context.

Fixes #230.

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

## Tests
- go test ./x/wgov/keeper -count=1 -v
- go test ./x/wgov -count=1
- go test ./x/wgov/... -count=1
- git diff --check

## Note
- #231 is already fixed on current `origin/main`, so this PR targets #230 only.
