### PR TITLE
fix(wdistri): reserve zero-share treasury rewards

### DIFF
--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -84,8 +84,10 @@ func (k Keeper) AllocateBlockRewardEveryday(ctx sdk.Context, req abci.RequestEnd
 func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 	feeCollectorAddr := k.authKeeper.GetModuleAddress(k.GetTreasuryModuleAccount())
 	totalMintCoin := k.bankKeeper.GetAllBalances(ctx, feeCollectorAddr)
-	if totalMintCoin.AmountOf(params.BaseDenom).IsZero() {
+	totalMintAmount := totalMintCoin.AmountOf(params.BaseDenom)
+	if totalMintAmount.IsZero() {
 		ctx.Logger().Info("totalMintCoin is zero, no need to allocate reward")
+		k.SetZeroShareTreasuryBalance(ctx, sdkmath.ZeroInt())
 		return nil
 	}
 	regions := k.stakingKeeper.GetAllRegionI(ctx)
@@ -95,13 +97,25 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 	}
 	totalRegionShareDec := sdk.NewDecFromInt(totalRegionShare)
 	if totalRegionShare.IsZero() {
+		k.SetZeroShareTreasuryBalance(ctx, totalMintAmount)
+		ctx.Logger().Info("totalRegionShare is zero, treasury balance reserved from later region allocation")
+		return nil
+	}
+	zeroShareTreasuryBalance := k.GetZeroShareTreasuryBalance(ctx)
+	if zeroShareTreasuryBalance.GT(totalMintAmount) {
+		zeroShareTreasuryBalance = totalMintAmount
+		k.SetZeroShareTreasuryBalance(ctx, zeroShareTreasuryBalance)
+	}
+	distributableAmount := totalMintAmount.Sub(zeroShareTreasuryBalance)
+	if distributableAmount.IsZero() {
+		ctx.Logger().Info("distributable treasury balance is zero, no need to allocate reward")
 		return nil
 	}
 	for _, region := range regions {
 		// calculate every region coins: RegionShare * totalMintCoins / totalRegionShare
-		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(totalMintCoin.AmountOf(params.BaseDenom).ToLegacyDec()).Quo(totalRegionShareDec)
+		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(distributableAmount.ToLegacyDec()).Quo(totalRegionShareDec)
 		regionAmount := amount.TruncateInt()
-		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
+		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, regionAmount))
 		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()), regionCoins)
 		if err != nil {
 			return err
@@ -116,4 +130,22 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		})
 	}
 	return nil
+}
+
+func (k Keeper) GetZeroShareTreasuryBalance(ctx sdk.Context) sdkmath.Int {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.ZeroShareTreasuryBalanceKey)
+	if bz == nil {
+		return sdkmath.ZeroInt()
+	}
+	return sdkmath.NewIntFromBigInt(sdkmath.NewInt(0).BigInt().SetBytes(bz))
+}
+
+func (k Keeper) SetZeroShareTreasuryBalance(ctx sdk.Context, amount sdkmath.Int) {
+	store := ctx.KVStore(k.storeKey)
+	if amount.IsZero() {
+		store.Delete(types.ZeroShareTreasuryBalanceKey)
+		return
+	}
+	store.Set(types.ZeroShareTreasuryBalanceKey, amount.BigInt().Bytes())
 }

--- a/x/wdistri/keeper/keeper_test.go
+++ b/x/wdistri/keeper/keeper_test.go
@@ -237,6 +237,28 @@ func (suite *KeeperTestSuite) TestEndBlocker() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestSkippedZeroShareRewardsMustNotBeReassignedToLaterRegion() {
+	ctx := suite.HelperNewContextWith(types.OneDayTotalBlocks)
+
+	suite.SetMockGetBalance(ctx, sdk.NewInt(100))
+	suite.stakingKeeper.EXPECT().GetAllRegionI(ctx).Return(nil)
+
+	err := suite.App.DistrKeeper.AllocateBlockReward(ctx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewInt(100), suite.App.DistrKeeper.GetZeroShareTreasuryBalance(ctx))
+
+	suite.SetMockGetBalance(ctx, sdk.NewInt(200))
+	addrs := suite.mockGetRegionI(ctx, 1)
+	suite.setMockSendCoinsFromModuleToAccountExpect(ctx, coinAndAddr{
+		num:  100,
+		addr: addrs[0],
+	})
+
+	err = suite.App.DistrKeeper.AllocateBlockReward(ctx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdk.NewInt(100), suite.App.DistrKeeper.GetZeroShareTreasuryBalance(ctx))
+}
+
 func (suite *KeeperTestSuite) mockGetRegionI(ctx sdk.Context, regionShare ...int) []string {
 	var addrs []string
 	if len(regionShare) == 0 {

--- a/x/wdistri/types/types.go
+++ b/x/wdistri/types/types.go
@@ -3,3 +3,5 @@ package types
 import wmintTypes "github.com/openmetaearth/me-hub/x/wmint/types"
 
 const OneDayTotalBlocks = wmintTypes.OneDayTotalBlocks
+
+var ZeroShareTreasuryBalanceKey = []byte("wdistri/zero-share-treasury-balance")


### PR DESCRIPTION
Fixes #372.

This PR prevents rewards that accumulated while all region shares were zero from being reassigned to later regions.

What changed:
- records the current treasury base-denom balance when allocation sees zero total region share;
- excludes that reserved zero-share balance from future region reward allocation;
- clamps the reserved balance if the treasury balance is later lower;
- avoids the old Int64 conversion when creating region reward coins.

Verification:
- go test ./x/wdistri/keeper -run TestKeeperTestSuite/TestSkippedZeroShareRewardsMustNotBeReassignedToLaterRegion -count=1 -v
- go test ./x/wdistri/keeper -count=1 -v
- go test ./x/wdistri -count=1
- go test ./x/wdistri/... -count=1
- git diff --check

Payout wallet for accepted bounty work: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099