### PR TITLE
fix: block relayer unbond while external set still trusts it

### DIFF
--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -195,6 +195,61 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 	}
 }
 
+func (s *KeeperTestSuite) TestRemovedRelayerCannotUnbondBeforeExternalSetStopsTrustingIt() {
+	k := s.Keeper()
+	s.setupBondedRelayerSetForAuditTest()
+
+	removedRelayer := s.relayerAddrs[0]
+	relayer, found := k.GetRelayer(s.Ctx, removedRelayer)
+	s.Require().True(found)
+	s.Require().True(relayer.Online)
+
+	lastObserved := k.GetLastObservedRelayerSet(s.Ctx)
+	s.Require().NotNil(lastObserved)
+	s.Require().True(relayerSetHasExternalAddress(lastObserved, relayer.ExternalAddress),
+		"test precondition: external bridge still trusts the relayer")
+
+	newRelayerList := make([]string, 0, len(s.relayerAddrs)-1)
+	for _, relayerAddr := range s.relayerAddrs[1:] {
+		newRelayerList = append(newRelayerList, relayerAddr.String())
+	}
+	_, err := s.MsgServer().ProposalRelayers(s.Ctx, &types.MsgProposalRelayers{
+		Relayers:  newRelayerList,
+		Authority: s.Dao.GlobalDao,
+		ChainName: s.chainName,
+	})
+	s.Require().NoError(err)
+
+	relayer, found = k.GetRelayer(s.Ctx, removedRelayer)
+	s.Require().True(found)
+	s.Require().False(relayer.Online)
+
+	_, err = s.MsgServer().UnbondedRelayer(s.Ctx, &types.MsgUnbondedRelayer{
+		ChainName:      s.chainName,
+		RelayerAddress: removedRelayer.String(),
+	})
+	s.Require().Error(err,
+		"relayer stake must stay locked until a newer external relayer-set update no longer trusts it")
+
+	relayer, found = k.GetRelayer(s.Ctx, removedRelayer)
+	s.Require().True(found, "rejected unbond must keep the relayer record")
+	relayerAddr, found := k.GetRelayerByExternalAddress(s.Ctx, relayer.ExternalAddress)
+	s.Require().True(found, "rejected unbond must keep the external address mapping")
+	s.Require().Equal(removedRelayer.String(), relayerAddr.String())
+}
+
+func relayerSetHasExternalAddress(relayerSet *types.RelayerSet, externalAddress string) bool {
+	if relayerSet == nil {
+		return false
+	}
+	for _, member := range relayerSet.Members {
+		if member.ExternalAddress == externalAddress {
+			return true
+		}
+	}
+	return false
+}
+
 // ---------------------------------------------------------------------------
 // Helper: bond relayers, confirm and observe the initial relayer set.
 // Mirrors the opening of TestRequestBatchBaseFee in msg_server_test.go, but

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -163,6 +163,9 @@ func (s MsgServer) UnbondedRelayer(c context.Context, msg *types.MsgUnbondedRela
 	if relayer.Online {
 		return nil, errorsmod.Wrap(types.ErrInvalid, "relayer on line")
 	}
+	if relayerSetContainsExternalAddress(s.GetLastObservedRelayerSet(ctx), relayer.ExternalAddress) {
+		return nil, errorsmod.Wrap(types.ErrInvalid, "relayer still trusted by last observed relayer set")
+	}
 
 	slashAmount := relayer.GetSlashAmount(s.GetSlashFraction(ctx))
 	if slashAmount.IsPositive() {
@@ -191,6 +194,18 @@ func (s MsgServer) UnbondedRelayer(c context.Context, msg *types.MsgUnbondedRela
 		sdk.NewAttribute(types.AttributeKeyUnbondAmount, unbondAmount.String()),
 	))
 	return &types.MsgUnbondedRelayerResponse{}, nil
+}
+
+func relayerSetContainsExternalAddress(relayerSet *types.RelayerSet, externalAddress string) bool {
+	if relayerSet == nil {
+		return false
+	}
+	for _, member := range relayerSet.Members {
+		if member.ExternalAddress == externalAddress {
+			return true
+		}
+	}
+	return false
 }
 
 func (s MsgServer) RelayerSetConfirm(c context.Context, msg *types.MsgRelayerSetConfirm) (*types.MsgRelayerSetConfirmResponse, error) {


### PR DESCRIPTION
## Summary

Fixes #303.

`UnbondedRelayer` now refuses to release stake or delete relayer mappings while `LastObservedRelayerSet` still contains the relayer external address. This keeps the local economic bond in place until a newer externally observed relayer set no longer trusts that key.

Bounty payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests

Passed:

```bash
go test ./x/gravity/keeper -run TestGravityKeeperTestSuite/TestRemovedRelayerCannotUnbondBeforeExternalSetStopsTrustingIt -count=1 -v
go test ./x/gravity/keeper -run TestGravityKeeperTestSuite/TestRelayerDelete -count=1 -v
go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(RemovedRelayerCannotUnbondBeforeExternalSetStopsTrustingIt|RelayerDelete)$' -count=1 -v\ngit diff --check\ngit diff --cached --check\n```\n\nKnown unrelated baseline failure:\n\n```bash\ngo test ./x/gravity/keeper -count=1\n```\n\nIt currently fails in existing tests unrelated to this unbond guard: `TestGrav004_FailedAttestationMustNotLockNonce`, `TestMsgBondedRelayer` error string expectations, and `TestRelayerSetSlash`.\n\nDuplicate check: no open PR directly targets #303. PR #424 touches attestation vote counting against last observed set, but does not block `UnbondedRelayer` from releasing stake while the external bridge still trusts the key.