### PR TITLE
fix: preserve megroup state in genesis

### DIFF
--- a/x/megroup/genesis.go
+++ b/x/megroup/genesis.go
@@ -8,52 +8,42 @@ import (
 
 // InitGenesis initializes the module's state from a provided genesis state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
-	// Set all the group
-	//todo:稍后在做，等宁那边确定格式后
-	return
-	/*
-		for _, elem := range genState.GroupList {
-			if err := k.AppendGroup(ctx, &elem);err != nil{
+	k.SetParams(ctx, genState.Params)
 
-			}
+	lastGroupID := genState.GroupCount
+	for _, elem := range genState.Groups {
+		k.SetGroupInfo(ctx, elem)
+		if elem.RegionID != "" {
+			k.SetGroupToRegion(ctx, elem.RegionID, elem.Id)
 		}
+		if elem.Id > lastGroupID {
+			lastGroupID = elem.Id
+		}
+	}
+	k.SetLastGroupID(ctx, lastGroupID)
 
-		// Set group count
-		k.SetGroupCount(ctx, genState.GroupCount)
-		// Set all the groupMember
-		for _, elem := range genState.GroupMemberList {
-			k.LoadMemberStoreByGroupID(ctx, elem.GroupID).SetGroupMember(elem)
-		}
+	for _, elem := range genState.GroupMembers {
+		k.SetGroupMember(ctx, elem)
+	}
 
-		// Set all the memberJoined
-		for _, elem := range genState.MemberJoinedList {
-			k.SetMemberJoined(ctx, elem)
-		}
-		// Set all the groupMemberCount
-		for _, elem := range genState.GroupMemberCountList {
-			k.SetGroupMemberCount(ctx, elem)
-		}
-		// this line is used by starport scaffolding # genesis/module/init
-		k.SetParams(ctx, genState.Params)
+	for _, elem := range genState.MemberJoinedList {
+		k.SetMemberJoined(ctx, elem)
+	}
 
-	*/
+	for _, elem := range genState.GroupMemberCountList {
+		k.SetGroupMemberCount(ctx, elem.GroupId, elem.Num)
+	}
 }
 
 // ExportGenesis returns the module's exported genesis
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
-	//todo:稍后在做，等宁那边确定格式后
-	/*
-		genesis.Params = k.GetParams(ctx)
-
-		genesis.GroupList = k.GetAllGroup(ctx)
-		genesis.GroupCount = k.GetGroupCount(ctx)
-		genesis.GroupMemberList = k.GetAllGroupMember(ctx)
-		genesis.MemberJoinedList = k.GetAllMemberJoined(ctx)
-		genesis.GroupMemberCountList = k.GetAllGroupMemberCount(ctx)
-		// this line is used by starport scaffolding # genesis/module/export
-
-	*/
+	genesis.Params = k.GetParams(ctx)
+	genesis.Groups = k.GetAllGroup(ctx)
+	genesis.GroupCount = k.GetLastGroupID(ctx)
+	genesis.GroupMembers = k.GetAllGroupMember(ctx)
+	genesis.MemberJoinedList = k.GetAllMemberJoined(ctx)
+	genesis.GroupMemberCountList = k.GetAllGroupMemberCount(ctx)
 
 	return genesis
 }

--- a/x/megroup/genesis_export_import_test.go
+++ b/x/megroup/genesis_export_import_test.go
@@ -1,0 +1,161 @@
+package megroup
+
+import (
+	"testing"
+	"time"
+
+	tmdb "github.com/cometbft/cometbft-db"
+	"github.com/cometbft/cometbft/libs/log"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	"github.com/openmetaearth/me-hub/x/kyc/handler"
+	"github.com/openmetaearth/me-hub/x/megroup/keeper"
+	"github.com/openmetaearth/me-hub/x/megroup/types"
+	"github.com/stretchr/testify/require"
+)
+
+type megroupGenesisKycKeeper struct{}
+
+func (megroupGenesisKycKeeper) RegisterEventHandler(string, int, string, handler.HandlerFunc) {}
+
+func (megroupGenesisKycKeeper) GetDID(sdk.Context, sdk.AccAddress) (string, bool) {
+	return "", false
+}
+
+func (megroupGenesisKycKeeper) GetDidInfo(sdk.Context, string) (didtypes.DidInfo, bool) {
+	return didtypes.DidInfo{}, false
+}
+
+func setupMegroupGenesisKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
+	t.Helper()
+
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+	db := tmdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, storetypes.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+	paramsSubspace := paramtypes.NewSubspace(cdc, types.Amino, storeKey, memStoreKey, "MegroupParams")
+	k := keeper.NewKeeper(cdc, storeKey, paramsSubspace, nil, nil, nil, nil, megroupGenesisKycKeeper{})
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+	k.SetParams(ctx, types.DefaultParams())
+
+	return k, ctx
+}
+
+func megroupGenesisFixture() types.GenesisState {
+	addedAt := time.Unix(1700000000, 0).UTC()
+
+	return types.GenesisState{
+		Params: types.DefaultParams(),
+		Groups: []types.GroupInfo{
+			{
+				Id:          7,
+				Admin:       "admin-address",
+				Metadata:    "metadata",
+				Version:     1,
+				TotalWeight: "1",
+				CreatedAt:   addedAt,
+				RegionID:    "region-7",
+			},
+		},
+		GroupCount: 7,
+		GroupMembers: []types.GroupMember{
+			{
+				GroupId: 7,
+				Member: &types.Member{
+					Address:  "member-address",
+					Weight:   "1",
+					Metadata: "member-metadata",
+					AddedAt:  addedAt,
+				},
+			},
+		},
+		MemberJoinedList: []types.MemberJoined{
+			{
+				Address: "member-address",
+				GroupId: 7,
+			},
+		},
+		GroupMemberCountList: []types.GroupMemberCount{
+			{
+				GroupId: 7,
+				Num:     1,
+			},
+		},
+	}
+}
+
+func TestExportGenesisMustPreserveGroupRewardState(t *testing.T) {
+	k, ctx := setupMegroupGenesisKeeper(t)
+	fixture := megroupGenesisFixture()
+
+	group := fixture.Groups[0]
+	k.SetGroupInfo(ctx, group)
+	k.SetGroupToRegion(ctx, group.RegionID, group.Id)
+	k.SetLastGroupID(ctx, fixture.GroupCount)
+	k.SetGroupMember(ctx, fixture.GroupMembers[0])
+	k.SetMemberJoined(ctx, fixture.MemberJoinedList[0])
+	k.SetGroupMemberCount(ctx, fixture.GroupMemberCountList[0].GroupId, fixture.GroupMemberCountList[0].Num)
+
+	exported := ExportGenesis(ctx, *k)
+	require.Equal(t, fixture.GroupCount, exported.GroupCount)
+	require.Equal(t, fixture.Groups, exported.Groups)
+	require.Equal(t, fixture.GroupMembers, exported.GroupMembers)
+	require.Equal(t, fixture.MemberJoinedList, exported.MemberJoinedList)
+	require.Equal(t, fixture.GroupMemberCountList, exported.GroupMemberCountList)
+}
+
+func TestInitGenesisMustRestoreGroupRewardState(t *testing.T) {
+	k, ctx := setupMegroupGenesisKeeper(t)
+	fixture := megroupGenesisFixture()
+
+	InitGenesis(ctx, *k, fixture)
+
+	group, found := k.GetGroupInfo(ctx, fixture.Groups[0].Id)
+	require.True(t, found)
+	require.Equal(t, fixture.Groups[0], group)
+
+	regionGroupID, found := k.GetGroupIdByRegion(ctx, fixture.Groups[0].RegionID)
+	require.True(t, found)
+	require.Equal(t, fixture.Groups[0].Id, regionGroupID)
+	require.Equal(t, fixture.GroupCount, k.GetLastGroupID(ctx))
+
+	groupMembers := k.GetAllGroupMember(ctx)
+	require.Equal(t, fixture.GroupMembers, groupMembers)
+
+	memberJoined, found := k.GetMemberJoined(ctx, fixture.MemberJoinedList[0].Address)
+	require.True(t, found)
+	require.Equal(t, fixture.MemberJoinedList[0], memberJoined)
+
+	groupMemberCount, found := k.GetGroupMemberCount(ctx, fixture.GroupMemberCountList[0].GroupId)
+	require.True(t, found)
+	require.Equal(t, fixture.GroupMemberCountList[0].Num, groupMemberCount)
+	require.Equal(t, fixture.GroupMemberCountList, k.GetAllGroupMemberCount(ctx))
+
+	restored := ExportGenesis(ctx, *k)
+	require.Equal(t, fixture, *restored)
+}
+
+func TestInitGenesisMustAllowExportOnEmptyState(t *testing.T) {
+	k, ctx := setupMegroupGenesisKeeper(t)
+
+	InitGenesis(ctx, *k, *types.DefaultGenesis())
+
+	exported := ExportGenesis(ctx, *k)
+	require.Equal(t, types.DefaultParams(), exported.Params)
+	require.Empty(t, exported.Groups)
+	require.Empty(t, exported.GroupMembers)
+	require.Empty(t, exported.MemberJoinedList)
+	require.Empty(t, exported.GroupMemberCountList)
+}

--- a/x/megroup/keeper/group_member_count.go
+++ b/x/megroup/keeper/group_member_count.go
@@ -33,8 +33,6 @@ func (k Keeper) RemoveGroupMemberCount(
 	store.Delete(types.GetBytesFromUint64(groupId))
 }
 
-// GetAllGroupMemberCount returns all groupMemberCount
-/*
 func (k Keeper) GetAllGroupMemberCount(ctx sdk.Context) (list []types.GroupMemberCount) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GroupMemberCountKeyPrefix))
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})
@@ -42,12 +40,11 @@ func (k Keeper) GetAllGroupMemberCount(ctx sdk.Context) (list []types.GroupMembe
 	defer iterator.Close()
 
 	for ; iterator.Valid(); iterator.Next() {
-		var val types.GroupMemberCount
-		k.cdc.MustUnmarshal(iterator.Value(), &val)
-		list = append(list, val)
+		list = append(list, types.GroupMemberCount{
+			GroupId: types.GetUint64FromBytes(iterator.Key()),
+			Num:     types.GetUint64FromBytes(iterator.Value()),
+		})
 	}
 
 	return
 }
-
-*/

--- a/x/megroup/keeper/member_joined.go
+++ b/x/megroup/keeper/member_joined.go
@@ -29,6 +29,17 @@ func (k *Keeper) AddGroupMember(ctx sdk.Context, grpMember *types.GroupMember) e
 	return nil
 }
 
+func (k Keeper) SetGroupMember(ctx sdk.Context, groupMember types.GroupMember) {
+	if groupMember.Member == nil {
+		return
+	}
+
+	grpMemberPrefix := fmt.Sprintf("%s%d/", types.GroupMemberKey, groupMember.GroupId)
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(grpMemberPrefix))
+	val := k.cdc.MustMarshal(&groupMember)
+	store.Set([]byte(groupMember.Member.Address), val)
+}
+
 // GetMemberJoined returns a memberJoined from its index
 func (k Keeper) GetMemberJoined(
 	ctx sdk.Context,
@@ -69,6 +80,21 @@ func (k Keeper) GetAllMemberJoined(ctx sdk.Context) (list []types.MemberJoined) 
 
 	for ; iterator.Valid(); iterator.Next() {
 		var val types.MemberJoined
+		k.cdc.MustUnmarshal(iterator.Value(), &val)
+		list = append(list, val)
+	}
+
+	return
+}
+
+func (k Keeper) GetAllGroupMember(ctx sdk.Context) (list []types.GroupMember) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.GroupMemberKey))
+	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var val types.GroupMember
 		k.cdc.MustUnmarshal(iterator.Value(), &val)
 		list = append(list, val)
 	}


### PR DESCRIPTION
Fixes #356

Wallet for bounty/reward: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

Summary:
- Implement MEGroup InitGenesis and ExportGenesis instead of returning an empty default state.
- Preserve groups, last group id, group members, member joined indexes, and group member counts.
- Rebuild the region-to-group derived index during InitGenesis from GroupInfo.RegionID.
- Add regression tests for export, import, and empty-state genesis behavior.

Tests:
- PASS: go test ./x/megroup -run 'Test(ExportGenesisMustPreserveGroupRewardState|InitGenesisMustRestoreGroupRewardState|InitGenesisMustAllowExportOnEmptyState)' -count=1 -v\n- PASS: go test ./x/megroup -count=1 -v\n- PASS: git diff --check\n- PASS: git diff --cached --check\n- NOTE: go test ./x/megroup/... -count=1 currently fails in existing x/megroup/types TestMsgCreateGroup_ValidateBasic with nil pointer in MsgCreateGroup.ValidateBasic; this is outside this genesis change.\n\nDuplicate check:\n- Checked open PRs for issue 356 and MEGroup/AppHash wording before starting; no duplicate PR was found.