### PR TITLE
fix: enforce rollapp DRS violations

### DIFF
--- a/x/rollapp/keeper/drs_violation.go
+++ b/x/rollapp/keeper/drs_violation.go
@@ -1,0 +1,60 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+)
+
+const drsViolationCauseGenesisTransferAfterOpen = "genesis_transfer_after_bridge_open"
+
+// HandleDRSViolation freezes a rollapp that sends genesis transfers after the bridge is open.
+func (k Keeper) HandleDRSViolation(ctx sdk.Context, rollappID string) error {
+	rollapp, found := k.GetRollapp(ctx, rollappID)
+	if !found {
+		return types.ErrUnknownRollappID
+	}
+
+	rollapp.Frozen = true
+	k.SetRollapp(ctx, rollapp)
+
+	stateInfo, hasLatestState := k.latestStateInfo(ctx, rollappID)
+	if hasLatestState && stateInfo.Sequencer != "" {
+		fraudHeight := stateInfo.StartHeight + stateInfo.NumBlocks - 1
+		if err := k.hooks.FraudSubmitted(ctx, rollappID, fraudHeight, stateInfo.Sequencer); err != nil {
+			return err
+		}
+	}
+
+	k.RevertPendingStates(ctx, rollappID)
+
+	attrs := []sdk.Attribute{
+		sdk.NewAttribute(types.AttributeKeyRollappId, rollappID),
+		sdk.NewAttribute(types.AttributeKeyDRSViolationCause, drsViolationCauseGenesisTransferAfterOpen),
+	}
+	if hasLatestState {
+		attrs = append(attrs,
+			sdk.NewAttribute(types.AttributeKeyFraudHeight, fmt.Sprint(stateInfo.StartHeight+stateInfo.NumBlocks-1)),
+			sdk.NewAttribute(types.AttributeKeyFraudSequencer, stateInfo.Sequencer),
+		)
+	}
+
+	ctx.EventManager().EmitEvent(sdk.NewEvent(types.EventTypeDRSViolation, attrs...))
+
+	return nil
+}
+
+func (k Keeper) latestStateInfo(ctx sdk.Context, rollappID string) (types.StateInfo, bool) {
+	stateInfoIndex, found := k.GetLatestStateInfoIndex(ctx, rollappID)
+	if !found {
+		return types.StateInfo{}, false
+	}
+
+	stateInfo, found := k.GetStateInfo(ctx, rollappID, stateInfoIndex.Index)
+	if !found {
+		return types.StateInfo{}, false
+	}
+
+	return stateInfo, true
+}

--- a/x/rollapp/keeper/drs_violation_test.go
+++ b/x/rollapp/keeper/drs_violation_test.go
@@ -1,0 +1,57 @@
+package keeper_test
+
+import (
+	common "github.com/openmetaearth/me-hub/x/common/types"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
+	sequencertypes "github.com/openmetaearth/me-hub/x/sequencer/types"
+)
+
+func (suite *RollappTestSuite) TestHandleDRSViolationFreezesRollappAndRevertsPendingState() {
+	suite.SetupTest()
+	ctx := &suite.Ctx
+	keeper := suite.App.RollappKeeper
+
+	rollappID := suite.CreateDefaultRollapp()
+	proposer := suite.CreateDefaultSequencer(*ctx, rollappID)
+	suite.CreateDefaultSequencer(*ctx, rollappID)
+
+	_, err := suite.PostStateUpdate(*ctx, rollappID, proposer, 1, 10)
+	suite.Require().NoError(err)
+
+	stateInfo, err := keeper.FindStateInfoByHeight(*ctx, rollappID, 1)
+	suite.Require().NoError(err)
+	suite.Require().Equal(common.Status_PENDING, stateInfo.Status)
+
+	err = keeper.HandleDRSViolation(*ctx, rollappID)
+	suite.Require().NoError(err)
+
+	rollapp, found := keeper.GetRollapp(*ctx, rollappID)
+	suite.Require().True(found)
+	suite.Require().True(rollapp.Frozen)
+
+	stateInfo, err = keeper.FindStateInfoByHeight(*ctx, rollappID, 1)
+	suite.Require().NoError(err)
+	suite.Require().Equal(common.Status_REVERTED, stateInfo.Status)
+
+	sequencers := suite.App.SequencerKeeper.GetSequencersByRollapp(*ctx, rollappID)
+	for _, sequencer := range sequencers {
+		suite.Require().Equal(sequencertypes.Unbonded, sequencer.Status)
+	}
+}
+
+func (suite *RollappTestSuite) TestUpdateStateRejectsFrozenRollapp() {
+	suite.SetupTest()
+	ctx := &suite.Ctx
+	keeper := suite.App.RollappKeeper
+
+	rollappID := suite.CreateDefaultRollapp()
+	proposer := suite.CreateDefaultSequencer(*ctx, rollappID)
+
+	rollapp, found := keeper.GetRollapp(*ctx, rollappID)
+	suite.Require().True(found)
+	rollapp.Frozen = true
+	keeper.SetRollapp(*ctx, rollapp)
+
+	_, err := suite.PostStateUpdate(*ctx, rollappID, proposer, 1, 10)
+	suite.Require().ErrorIs(err, rollapptypes.ErrRollappFrozen)
+}

--- a/x/rollapp/keeper/msg_server_update_state.go
+++ b/x/rollapp/keeper/msg_server_update_state.go
@@ -25,6 +25,9 @@ func (k msgServer) UpdateState(goCtx context.Context, msg *types.MsgUpdateState)
 	if !isFound {
 		return nil, types.ErrUnknownRollappID
 	}
+	if rollapp.Frozen {
+		return nil, types.ErrRollappFrozen
+	}
 
 	// check rollapp version
 	if rollapp.Version != msg.Version {

--- a/x/rollapp/transfergenesis/ibc_module.go
+++ b/x/rollapp/transfergenesis/ibc_module.go
@@ -155,9 +155,7 @@ func (w IBCModule) OnRecvPacket(
 }
 
 func (w IBCModule) handleDRSViolation(ctx sdk.Context, rollappID string) error {
-	// handleFraud : the rollapp has violated the DRS!
-	// TODO: finish implementing this method
-	return nil
+	return w.rollappKeeper.HandleDRSViolation(ctx, rollappID)
 }
 
 func getMemo(rawMemo string) (rollapptypes.GenesisTransferMemo, error) {

--- a/x/rollapp/types/errors.go
+++ b/x/rollapp/types/errors.go
@@ -33,6 +33,7 @@ var (
 	ErrNotFound                       = errorsmod.Register(ModuleName, 1037, "not found")
 	ErrLogic                          = errorsmod.Register(ModuleName, 1038, "internal logic error")
 	ErrInvalidAddress                 = errorsmod.Register(ModuleName, 1040, "invalid address")
+	ErrRollappFrozen                  = errorsmod.Register(ModuleName, 1041, "rollapp is frozen")
 
 	/* ------------------------------ fraud related ----------------------------- */
 	ErrDisputeAlreadyFinalized = errorsmod.Register(ModuleName, 2000, "disputed height already finalized")

--- a/x/rollapp/types/events.go
+++ b/x/rollapp/types/events.go
@@ -19,4 +19,8 @@ const (
 
 	// EventTypeTransferGenesisTransfersEnabled is when the bridge is enabled
 	EventTypeTransferGenesisTransfersEnabled = "transfer_genesis_transfers_enabled"
+
+	// EventTypeDRSViolation is emitted when a rollapp violates the genesis transfer window.
+	EventTypeDRSViolation         = "drs_violation"
+	AttributeKeyDRSViolationCause = "drs_violation_cause"
 )


### PR DESCRIPTION
Fixes #682

Wallet for bounty/reward: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

Summary:
- Replace the no-op transfergenesis handleDRSViolation path with rollapp keeper enforcement.
- Freeze rollapps that send genesis transfers after transfers are already enabled.
- Use existing fraud hooks when a latest state/sequencer exists so sequencers are penalized and pending delayed packets are handled.
- Revert pending rollapp states and emit a DRS violation event.
- Reject future UpdateState calls for frozen rollapps.

Tests:
- PASS: go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/Test(HandleDRSViolationFreezesRollappAndRevertsPendingState|UpdateStateRejectsFrozenRollapp)$' -count=1 -v\n- PASS: go test ./x/rollapp/transfergenesis -count=1\n- PASS: git diff --check\n- PASS: git diff --cached --check\n- NOTE: go test ./x/rollapp/keeper -count=1 -v still fails on existing unrelated tests: TestCreateRollappId/default_is_valid_without_revision_number, TestCreateRollappUnauthorizedRollappCreator, and TestKeeperFinalizePending.\n\nDuplicate check:\n- Checked open PRs for issue 682 and handleDRSViolation wording before starting; no duplicate PR was found.