### PR TITLE
fix: pass through denom metadata ack for non-rollapps

### DIFF
--- a/x/denommetadata/ibc_middleware.go
+++ b/x/denommetadata/ibc_middleware.go
@@ -139,7 +139,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 
 	// if denom metadata was found in the memo, it means we should have the rollapp record
 	if rollapp == nil {
-		return gerrc.ErrNotFound
+		return im.IBCModule.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 	}
 
 	if !Contains(rollapp.RegisteredDenoms, dm.Base) {

--- a/x/denommetadata/ibc_middleware_test.go
+++ b/x/denommetadata/ibc_middleware_test.go
@@ -15,7 +15,6 @@ import (
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
-	"github.com/openmetaearth/me-hub/utils/gerrc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmetaearth/me-hub/x/denommetadata"
@@ -340,6 +339,7 @@ func TestIBCModule_OnAcknowledgementPacket(t *testing.T) {
 		args        args
 		wantRollapp *rollapptypes.Rollapp
 		wantErr     error
+		wantAckCall bool
 	}{
 		{
 			name: "success: added token metadata to rollapp",
@@ -448,7 +448,7 @@ func TestIBCModule_OnAcknowledgementPacket(t *testing.T) {
 			wantRollapp: nil,
 			wantErr:     errortypes.ErrInvalidRequest,
 		}, {
-			name: "error: rollapp not found",
+			name: "pass through: rollapp not found",
 			fields: fields{
 				IBCModule:     &mockIBCModule{},
 				rollappKeeper: &mockRollappKeeper{},
@@ -461,7 +461,7 @@ func TestIBCModule_OnAcknowledgementPacket(t *testing.T) {
 				acknowledgement: okAck(),
 			},
 			wantRollapp: nil,
-			wantErr:     gerrc.ErrNotFound,
+			wantAckCall: true,
 		}, {
 			name: "return early: rollapp already has token metadata",
 			fields: fields{
@@ -504,6 +504,11 @@ func TestIBCModule_OnAcknowledgementPacket(t *testing.T) {
 			}
 
 			require.Equal(t, tt.wantRollapp, tt.fields.rollappKeeper.returnRollapp)
+			if tt.wantAckCall {
+				app, ok := tt.fields.IBCModule.(*mockIBCModule)
+				require.True(t, ok)
+				require.True(t, app.ackCalled)
+			}
 		})
 	}
 }
@@ -578,7 +583,8 @@ func mustMarshalJSON(v any) string {
 
 type mockIBCModule struct {
 	porttypes.IBCModule
-	sentData []byte
+	sentData  []byte
+	ackCalled bool
 }
 
 func okAck() []byte {
@@ -597,6 +603,7 @@ func (m *mockIBCModule) OnRecvPacket(_ sdk.Context, p channeltypes.Packet, _ sdk
 }
 
 func (m *mockIBCModule) OnAcknowledgementPacket(_ sdk.Context, _ channeltypes.Packet, ack []byte, _ sdk.AccAddress) error {
+	m.ackCalled = true
 	return nil
 }
 


### PR DESCRIPTION
Fixes #681

Wallet for bounty/reward: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099

Summary:
- Change denommetadata OnAcknowledgementPacket to pass through successful acknowledgements when metadata memo exists but the channel is not a rollapp.
- Keep rollapp metadata registration behavior unchanged when a rollapp is found.
- Update the regression test so the non-rollapp case must call the next middleware instead of returning gerrc.ErrNotFound.

Tests:
- PASS: go test ./x/denommetadata -run TestIBCModule_OnAcknowledgementPacket -count=1 -v
- PASS: go test ./x/denommetadata -count=1 -v
- PASS: git diff --check
- PASS: git diff --cached --check

Duplicate check:
- Checked open PRs for issue 681 and denommetadata OnAcknowledgementPacket wording before starting. PR #603 fixes a different OnRecvPacket path for issue #546; no direct duplicate for #681 was found.