### PR TITLE
fix: remove empty rollapp finalization queues

### DIFF
--- a/x/rollapp/keeper/block_height_to_finalization_queue.go
+++ b/x/rollapp/keeper/block_height_to_finalization_queue.go
@@ -109,6 +109,10 @@ func (k Keeper) updateQueueForHeight(ctx sdk.Context, blockHeightToFinalizationQ
 			idx, failed := failedRollapps[si.RollappId]
 			return !failed || si.Index < idx
 		})
+	if len(blockHeightToFinalizationQueue.FinalizationQueue) == 0 {
+		k.RemoveBlockHeightToFinalizationQueue(ctx, blockHeightToFinalizationQueue.CreationHeight)
+		return
+	}
 	// save the current queue with "leftover" rollapp's state changes
 	k.SetBlockHeightToFinalizationQueue(ctx, blockHeightToFinalizationQueue)
 }

--- a/x/rollapp/keeper/block_height_to_finalization_queue_test.go
+++ b/x/rollapp/keeper/block_height_to_finalization_queue_test.go
@@ -454,6 +454,30 @@ func (suite *RollappTestSuite) TestKeeperFinalizePending() {
 				},
 			},
 		}, {
+			name: "finalize pending: failed rollapp must not keep unrelated later successful queue as empty state",
+			pendingFinalizationQueue: []types.BlockHeightToFinalizationQueue{
+				{
+					CreationHeight: 1,
+					FinalizationQueue: []types.StateInfoIndex{
+						{RollappId: "rollapp1", Index: 1},
+					},
+				}, {
+					CreationHeight: 2,
+					FinalizationQueue: []types.StateInfoIndex{
+						{RollappId: "rollapp2", Index: 1},
+					},
+				},
+			},
+			errFinalizeIndices: []types.StateInfoIndex{{RollappId: "rollapp1", Index: 1}},
+			expectQueueAfter: []types.BlockHeightToFinalizationQueue{
+				{
+					CreationHeight: 1,
+					FinalizationQueue: []types.StateInfoIndex{
+						{RollappId: "rollapp1", Index: 1},
+					},
+				},
+			},
+		}, {
 			name: "finalize pending: all rollapps failed to finalize",
 			pendingFinalizationQueue: []types.BlockHeightToFinalizationQueue{
 				{


### PR DESCRIPTION
Fixes #302.

## Summary
- remove a rollapp finalization queue when all entries were successfully pruned from that height
- add a regression case where an earlier failed rollapp must not keep a later unrelated successful queue as an empty store entry

## Tests
- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestKeeperFinalizePending/finalize_pending:_failed_rollapp_must_not_keep_unrelated_later_successful_queue_as_empty_state' -count=1 -v`\n- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestFinalize$' -count=1 -v`\n- `git diff --check`\n- `git diff --cached --check`\n\nNote: the full existing `TestKeeperFinalizePending` table still has a separate pre-existing failing case (`finalize pending: 2 rollapps failed at 2 heights, one in each height`) whose expected queue does not match current failed-rollapp ordering behavior. This PR keeps scope limited to #302.