### PR TITLE
fix: reject kyc remove vc through did

### DIFF
--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/x/did/types"
+	kyctypes "github.com/openmetaearth/me-hub/x/kyc/types"
 )
 
 type msgServer struct {
@@ -213,6 +214,10 @@ func (m msgServer) UpdateVC(goCtx context.Context, msg *types.MsgUpdateVC) (*typ
 
 func (m msgServer) RemoveVC(goCtx context.Context, msg *types.MsgRemoveVC) (*types.MsgRemoveVCResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if msg.Sid == kyctypes.ModuleName {
+		return &types.MsgRemoveVCResponse{}, types.ErrReservedCredentialService
+	}
 
 	// check credential service
 	svc, found := m.GetService(ctx, msg.Sid)

--- a/x/did/keeper/msg_server_reserved_service_test.go
+++ b/x/did/keeper/msg_server_reserved_service_test.go
@@ -1,0 +1,51 @@
+package keeper_test
+
+import (
+	"testing"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/openmetaearth/me-hub/testutil/keeper"
+	didkeeper "github.com/openmetaearth/me-hub/x/did/keeper"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	kyctypes "github.com/openmetaearth/me-hub/x/kyc/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgServerRemoveVCRejectsKycReservedSid(t *testing.T) {
+	k, ctx := keepertest.DidKeeper(t)
+	msgServer := didkeeper.NewMsgServerImpl(k)
+
+	issuerAddr := sdk.MustAccAddressFromBech32("me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4")
+	issuerDid := "0000000000000001"
+	holderDid := "1000000000000001"
+	regionFilter := []byte("me_earth")
+
+	k.SetDID(ctx, issuerAddr, issuerDid)
+	k.SetDidInfo(ctx, issuerDid, didtypes.DidInfo{
+		Did:    issuerDid,
+		Status: didtypes.DID_STATUS_ACTIVE,
+	})
+	k.SetDidInfo(ctx, holderDid, didtypes.DidInfo{
+		Did:    holderDid,
+		Status: didtypes.DID_STATUS_ACTIVE,
+	})
+	k.SetService(ctx, kyctypes.ModuleName, didtypes.Service{
+		Sid:     kyctypes.ModuleName,
+		Issuers: []string{issuerDid},
+		Status:  didtypes.SERVICE_STATUS_ACTIVE,
+	})
+
+	credential := didtypes.NewCredential(holderDid, kyctypes.ModuleName, "hash", "uri", regionFilter)
+	k.SetCredential(ctx, holderDid, kyctypes.ModuleName, credential)
+	k.AddFilters(ctx, holderDid, kyctypes.ModuleName, [][]byte{regionFilter}, credential)
+
+	_, err := msgServer.RemoveVC(ctx, didtypes.NewMsgRemoveVC(issuerAddr.String(), holderDid, kyctypes.ModuleName))
+
+	require.Error(t, err)
+	require.True(t, errorsmod.IsOf(err, didtypes.ErrReservedCredentialService))
+	require.True(t, k.HasCredential(ctx, holderDid, kyctypes.ModuleName))
+	filters, found := k.GetFilters(ctx, holderDid, kyctypes.ModuleName)
+	require.True(t, found)
+	require.Equal(t, [][]byte{regionFilter}, filters)
+}

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -31,4 +31,6 @@ var (
 
 	ErrCredentialExists   = errors.Register(ModuleName, 150, "credential already exists")
 	ErrCredentialNotFound = errors.Register(ModuleName, 151, "credential not found")
+
+	ErrReservedCredentialService = errors.Register(ModuleName, 160, "reserved credential service")
 )


### PR DESCRIPTION
Fixes #365.

## Summary
- reject generic DID `RemoveVC` requests for the reserved KYC service id
- add a DID keeper regression test proving KYC credentials and filters remain intact when the generic DID route is used
- add a dedicated DID error for reserved credential services

## Tests
- `go test ./x/did/keeper -run TestMsgServerRemoveVCRejectsKycReservedSid -count=1 -v`
- `go test ./x/did/keeper -count=1 -v`
- `go test ./x/did/types -count=1`
- `git diff --check`
- `git diff --cached --check`

Baseline notes reproduced on clean `origin/main` at `9ca8f8fb`:
- `go test ./x/did -count=1 -v` fails in existing `TestInitExportGenesis` with `empty address string is not allowed`
- `go test ./x/kyc/types -count=1` fails in existing `TestGenesisState_Validate` expectations

Bounty payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`.