### PR TITLE
fix(gravity): observe attestations only after successful processing

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -102,15 +102,16 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 			continue
 		}
 
-		k.SetLastObservedEventNonce(ctx, claim.GetEventNonce())
-
-		// in case of web3 event is long time ago, we set the last observed me block height need long enough.
-		k.SetLastObservedBlockHeight(ctx, claim.GetBlockHeight(), uint64(ctx.BlockHeight()))
-
-		att.Observed = true
-		k.SetAttestation(ctx, claim.GetEventNonce(), claim.ClaimHash(), att)
-
 		err = k.processAttestation(ctx, claim)
+		if err == nil {
+			k.SetLastObservedEventNonce(ctx, claim.GetEventNonce())
+
+			// in case of web3 event is long time ago, we set the last observed me block height need long enough.
+			k.SetLastObservedBlockHeight(ctx, claim.GetBlockHeight(), uint64(ctx.BlockHeight()))
+
+			att.Observed = true
+			k.SetAttestation(ctx, claim.GetEventNonce(), claim.ClaimHash(), att)
+		}
 		ctx.EventManager().EmitEvent(sdk.NewEvent(
 			types.EventTypeContractEvent,
 			sdk.NewAttribute(sdk.AttributeKeyModule, k.moduleName),
@@ -133,9 +134,9 @@ func (k Keeper) processAttestation(ctx sdk.Context, claim types.ExternalClaim) e
 	xCtx, commit := ctx.CacheContext()
 	if err := k.AttestationHandler(xCtx, claim); err != nil {
 		// execute with a transient storage
-		// If the attestation fails, something has gone wrong and we can't recover it. Log and move on
-		// The attestation will still be marked "Observed", and validators can still be slashed for not
-		// having voted for it.
+		// If the attestation fails, something has gone wrong. Log it without
+		// advancing the observed nonce, so the attestation can be retried after
+		// the underlying condition is fixed.
 		k.Logger(ctx).Error("attestation failed", "cause", err.Error(), "claim type", claim.GetType(),
 			"id", hex.EncodeToString(types.GetAttestationKey(claim.GetEventNonce(), claim.ClaimHash())),
 			"nonce", fmt.Sprint(claim.GetEventNonce()),

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -131,6 +131,7 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 	preObserved := k.GetLastObservedEventNonce(s.Ctx)
 	s.Require().EqualValues(uint64(1), preObserved,
 		"test precondition: relayer set update claim should be observed at nonce 1")
+	preObservedHeight := k.GetLastObservedBlockHeight(s.Ctx)
 
 	// Use a bridge-token contract that has NEVER been registered. The handler
 	// path for MsgSendToMeClaim calls GetBridgeTokenByContract first and
@@ -144,10 +145,11 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 	// error and returns OK; we assert on the persisted state, not on err.
 	receiver := s.relayerAddrs[0]
 	sender := s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)
+	failedClaimBlockHeight := uint64(2)
 	for i, relayer := range s.relayerAddrs {
 		claim := &types.MsgSendToMeClaim{
 			EventNonce:     k.GetLastEventNonceByRelayer(s.Ctx, relayer) + 1,
-			BlockHeight:    1,
+			BlockHeight:    failedClaimBlockHeight,
 			TokenContract:  unknownContract,
 			Amount:         sdkmath.NewIntWithDecimal(1, 6),
 			Sender:         sender,
@@ -172,13 +174,18 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 			"AttestationHandler returned an error (bridge token does not exist). "+
 			"This permanently locks the nonce and bricks the bridge for retries.",
 		preObserved, postObserved)
+	postObservedHeight := k.GetLastObservedBlockHeight(s.Ctx)
+	s.Require().Equalf(preObservedHeight, postObservedHeight,
+		"GRAV-004: lastObservedBlockHeight advanced from %+v to %+v even though "+
+			"AttestationHandler returned an error (bridge token does not exist).",
+		preObservedHeight, postObservedHeight)
 
 	// Assertion 2: the attestation record for the failed claim should NOT
 	// be marked Observed, so a future retry (after the underlying condition
 	// is fixed) can still reach quorum. We recreate the claim hash here.
 	probeClaim := &types.MsgSendToMeClaim{
 		EventNonce:     preObserved + 1,
-		BlockHeight:    1,
+		BlockHeight:    failedClaimBlockHeight,
 		TokenContract:  unknownContract,
 		Amount:         sdkmath.NewIntWithDecimal(1, 6),
 		Sender:         sender,


### PR DESCRIPTION
## Summary
- process Gravity attestations before advancing `lastObservedEventNonce` or marking them `Observed`
- leave failed attestations retryable instead of permanently locking the nonce
- strengthen the existing GRAV-004 regression test to cover `lastObservedBlockHeight` as well

## Bounty
- Refs #161
- Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./x/gravity/keeper -run TestGravityKeeperTestSuite/TestGrav004_FailedAttestationMustNotLockNonce -count=1 -v`
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/(TestGrav|TestAttestation)' -count=1 -v`\n- `git diff --check`\n\n## Baseline note\n- `go test ./x/gravity/keeper -count=1 -v` still fails on this branch and on clean `origin/main` with existing unrelated failures in `TestMsgBondedRelayer` error-string expectations and `TestRelayerSetSlash`.\n