### PR TITLE
fix(gravity): reduce slashed relayer voting power

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -36,6 +36,14 @@ func (k Keeper) Attest(ctx sdk.Context, relayerAddr sdk.AccAddress, claim types.
 		return nil, errorsmod.Wrapf(types.ErrNonContinuousEventNonce, "got %v, expected %v", claim.GetEventNonce(), expectedNonce)
 	}
 
+	relayer, found := k.GetRelayer(ctx, relayerAddr)
+	if !found {
+		return nil, types.ErrNotFoundRelayer
+	}
+	if !relayer.Online {
+		return nil, types.ErrRelayerNotOnLine
+	}
+
 	gasMeter := ctx.GasMeter()
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 
@@ -95,7 +103,12 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 				claim.GetEventNonce(), "claimType", claim.GetType(), "claimHeight", claim.GetBlockHeight())
 			continue
 		}
-		relayerPower := relayer.GetPower()
+		if !relayer.Online {
+			k.Logger(ctx).Error("TryAttestation", "relayer offline", relayerAddr.String(), "claimEventNonce",
+				claim.GetEventNonce(), "claimType", claim.GetType(), "claimHeight", claim.GetBlockHeight())
+			continue
+		}
+		relayerPower := k.GetRelayerEffectivePower(ctx, relayer)
 		// Add it to the attestation power's sum
 		attestationPower = attestationPower.Add(relayerPower)
 		if attestationPower.LT(requiredPower) {

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -10,6 +10,7 @@ package keeper_test
 // Coverage:
 //   GRAV-001  Attest must reject historical-nonce claims (no backward rewind)
 //   GRAV-004  Failed AttestationHandler must not advance lastObservedEventNonce
+//   GRAV-381  Slashed/offline relayers must not retain active attestation power
 
 import (
 	"encoding/hex"
@@ -196,26 +197,101 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 }
 
 // ---------------------------------------------------------------------------
+// GRAV-381: Slashed/offline relayers must not retain active attestation power
+// ---------------------------------------------------------------------------
+//
+// SlashRelayer increments SlashTimes, but the attestation denominator is stored
+// in LastTotalPower. If LastTotalPower is not refreshed after the slash, the
+// next quorum calculation can keep using stale pre-slash power.
+//
+// A slashed relayer may remain Online until MaxSlashTimes is reached. During
+// that window, its effective power should be DelegateAmount minus slash debt.
+func (s *KeeperTestSuite) TestGrav381_SlashRelayerUpdatesEffectiveTotalPower() {
+	k := s.Keeper()
+	relayerAddr := s.relayerAddrs[0]
+
+	gravityParams := k.GetParams(s.Ctx)
+	gravityParams.MaxSlashTimes = 2
+	s.Require().NoError(k.SetParams(s.Ctx, &gravityParams))
+
+	delegate := sdk.NewCoin(params.BaseDenom, sdkmath.NewInt(10*1e8))
+	s.bondAuditRelayer(0, delegate)
+
+	preSlashPower := k.GetLastTotalPower(s.Ctx)
+	s.Require().Equal(delegate.Amount.Quo(sdk.DefaultPowerReduction), preSlashPower)
+
+	s.Require().NoError(k.SlashRelayer(s.Ctx, relayerAddr.String()))
+
+	relayer, found := k.GetRelayer(s.Ctx, relayerAddr)
+	s.Require().True(found)
+	s.Require().True(relayer.Online, "test precondition: first slash should not force offline when MaxSlashTimes is 2")
+	s.Require().EqualValues(1, relayer.SlashTimes)
+
+	slashAmount := relayer.GetSlashAmount(k.GetSlashFraction(s.Ctx)).Amount
+	expectedPower := relayer.DelegateAmount.Sub(slashAmount).Quo(sdk.DefaultPowerReduction)
+	s.Require().Equal(expectedPower, k.GetLastTotalPower(s.Ctx),
+		"GRAV-381: LastTotalPower must reflect slashed effective relayer power")
+}
+
+func (s *KeeperTestSuite) TestGrav381_OfflineRelayerCannotAttestDirectly() {
+	k := s.Keeper()
+	relayerAddr := s.relayerAddrs[0]
+
+	gravityParams := k.GetParams(s.Ctx)
+	gravityParams.MaxSlashTimes = 1
+	s.Require().NoError(k.SetParams(s.Ctx, &gravityParams))
+
+	s.bondAuditRelayer(0, sdk.NewCoin(params.BaseDenom, sdkmath.NewInt(10*1e8)))
+	s.Require().NoError(k.SlashRelayer(s.Ctx, relayerAddr.String()))
+
+	relayer, found := k.GetRelayer(s.Ctx, relayerAddr)
+	s.Require().True(found)
+	s.Require().False(relayer.Online, "test precondition: first slash should force offline when MaxSlashTimes is 1")
+
+	claim := &types.MsgSendToMeClaim{
+		EventNonce:     1,
+		BlockHeight:    1,
+		TokenContract:  "0x0000000000000000000000000000000000000001",
+		Amount:         sdkmath.NewInt(1000),
+		Sender:         "0x0000000000000000000000000000000000000002",
+		Receiver:       s.relayerAddrs[1].String(),
+		RelayerAddress: relayerAddr.String(),
+		ChainName:      s.chainName,
+	}
+
+	_, err := k.Attest(s.Ctx, relayerAddr, claim)
+	s.Require().ErrorIs(err, types.ErrRelayerNotOnLine,
+		"GRAV-381: offline relayers must not be able to vote through direct Attest calls")
+	s.Require().Nil(k.GetAttestation(s.Ctx, claim.GetEventNonce(), claim.ClaimHash()),
+		"GRAV-381: rejected offline votes must not create attestation state")
+}
+
+// ---------------------------------------------------------------------------
 // Helper: bond relayers, confirm and observe the initial relayer set.
 // Mirrors the opening of TestRequestBatchBaseFee in msg_server_test.go, but
 // stops before BridgeTokenClaim so the state is a clean "bridge initialized,
 // no tokens registered" baseline for audit tests.
 // ---------------------------------------------------------------------------
 
+func (s *KeeperTestSuite) bondAuditRelayer(relayerIndex int, delegate sdk.Coin) {
+	msg := &types.MsgBondedRelayer{
+		RelayerAddress:  s.relayerAddrs[relayerIndex].String(),
+		ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[relayerIndex].PublicKey),
+		DelegateAmount:  delegate,
+		ChainName:       s.chainName,
+	}
+	_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msg)
+	s.Require().NoError(err)
+}
+
 func (s *KeeperTestSuite) setupBondedRelayerSetForAuditTest() {
 	totalPower := sdkmath.ZeroInt()
 	delegateAmounts := make([]sdkmath.Int, 0, len(s.relayerAddrs))
-	for i, relayer := range s.relayerAddrs {
-		msg := &types.MsgBondedRelayer{
-			RelayerAddress:  relayer.String(),
-			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[i].PublicKey),
-			DelegateAmount:  sdk.NewCoin(params.BaseDenom, sdkmath.NewInt(int64(1e9))),
-			ChainName:       s.chainName,
-		}
-		delegateAmounts = append(delegateAmounts, msg.DelegateAmount.Amount)
-		totalPower = totalPower.Add(msg.DelegateAmount.Amount.Quo(sdk.DefaultPowerReduction))
-		_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msg)
-		s.Require().NoError(err)
+	for i := range s.relayerAddrs {
+		delegate := sdk.NewCoin(params.BaseDenom, sdkmath.NewInt(int64(1e9)))
+		delegateAmounts = append(delegateAmounts, delegate.Amount)
+		totalPower = totalPower.Add(delegate.Amount.Quo(sdk.DefaultPowerReduction))
+		s.bondAuditRelayer(i, delegate)
 	}
 	s.Keeper().EndBlocker(s.Ctx)
 

--- a/x/gravity/keeper/proposal.go
+++ b/x/gravity/keeper/proposal.go
@@ -30,7 +30,7 @@ func (k Keeper) UpdateProposalRelayers(ctx sdk.Context, relayers []string) error
 
 	for _, relayer := range allRelayers {
 		if relayer.Online {
-			totalPower = totalPower.Add(relayer.GetPower())
+			totalPower = totalPower.Add(k.GetRelayerEffectivePower(ctx, relayer))
 		}
 		// relayer in new proposal
 		if _, ok := newRelayerMap[relayer.RelayerAddress]; ok {
@@ -40,7 +40,7 @@ func (k Keeper) UpdateProposalRelayers(ctx sdk.Context, relayers []string) error
 		if _, ok := oldRelayerMap[relayer.RelayerAddress]; ok {
 			unbondedRelayerList = append(unbondedRelayerList, relayer)
 			if relayer.Online {
-				deleteTotalPower = deleteTotalPower.Add(relayer.GetPower())
+				deleteTotalPower = deleteTotalPower.Add(k.GetRelayerEffectivePower(ctx, relayer))
 			}
 		}
 	}

--- a/x/gravity/keeper/relayer.go
+++ b/x/gravity/keeper/relayer.go
@@ -84,10 +84,19 @@ func (k Keeper) SetLastTotalPower(ctx sdk.Context) {
 	relayers := k.GetAllRelayers(ctx, true)
 	totalPower := sdkmath.ZeroInt()
 	for _, relayer := range relayers {
-		totalPower = totalPower.Add(relayer.GetPower())
+		totalPower = totalPower.Add(k.GetRelayerEffectivePower(ctx, relayer))
 	}
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.LastTotalPowerKey, k.cdc.MustMarshal(&sdk.IntProto{Int: totalPower}))
+}
+
+func (k Keeper) GetRelayerEffectivePower(ctx sdk.Context, relayer types.Relayer) sdkmath.Int {
+	slashAmount := relayer.GetSlashAmount(k.GetSlashFraction(ctx)).Amount
+	effectiveAmount := relayer.DelegateAmount.Sub(slashAmount)
+	if !effectiveAmount.IsPositive() {
+		return sdkmath.ZeroInt()
+	}
+	return effectiveAmount.Quo(sdk.DefaultPowerReduction)
 }
 
 // --- RELAYERS --- //
@@ -177,6 +186,7 @@ func (k Keeper) SlashRelayer(ctx sdk.Context, relayerAddrStr string) error {
 		relayer.Online = false
 	}
 	k.SetRelayer(ctx, relayerAddr, relayer)
+	k.SetLastTotalPower(ctx)
 	k.SetLastRelayerSlashBlockHeight(ctx, uint64(ctx.BlockHeight()))
 	return nil
 }

--- a/x/gravity/keeper/relayer_set.go
+++ b/x/gravity/keeper/relayer_set.go
@@ -29,7 +29,7 @@ func (k Keeper) GetCurrentRelayerSet(ctx sdk.Context) *types.RelayerSet {
 	var totalPower uint64
 
 	for _, relayer := range allRelayers {
-		power := relayer.GetPower()
+		power := k.GetRelayerEffectivePower(ctx, relayer)
 		if power.LTE(sdkmath.ZeroInt()) {
 			continue
 		}


### PR DESCRIPTION
## Summary
- compute Gravity relayer voting power from `DelegateAmount - slash debt`
- refresh `LastTotalPower` when `SlashRelayer` updates relayer state
- prevent offline relayers from voting through direct `Attest` calls and skip offline votes in quorum calculation
- add GRAV-381 regression tests for stale total power and offline direct attestation

## Bounty
- Refs #381
- Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestGrav381' -count=1 -v`\n- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(Grav381|MsgAddDelegate|SlashRelayer|AttestationAfterRelayerUpdate)' -count=1 -v`\n- `git diff --check`\n\n## Baseline note\n- This PR intentionally does not address #580 / PR #769, which re-enables EndBlocker slashing.\n- `go test ./x/gravity/keeper -count=1 -v` still fails on this branch due to existing unrelated baseline failures: GRAV-004 pending in #812, `TestMsgBondedRelayer` error-string expectations, and `TestRelayerSetSlash` pending in PR #769.\n