### PR TITLE
fix(kyc): require approve pubkey to match address

### DIFF
--- a/x/kyc/keeper/msg_server.go
+++ b/x/kyc/keeper/msg_server.go
@@ -62,6 +62,14 @@ func (m msgServer) Approve(goCtx context.Context, msg *types.MsgApprove) (*types
 
 	// check holder address and pubkey
 	address := sdk.MustAccAddressFromBech32(msg.Address)
+	pubkeyAddress, err := m.MustAccAddressFromPubkeyString(msg.Pubkey)
+	if err != nil {
+		return &types.MsgApproveResponse{}, sdkerrors.Wrap(types.ErrInvalidPubkey, err.Error())
+	}
+	if !pubkeyAddress.Equals(address) {
+		return &types.MsgApproveResponse{}, sdkerrors.Wrap(types.ErrInvalidPubkey, "pubkey does not match address")
+	}
+
 	did, found := m.GetDID(ctx, address)
 	if found && did != msg.Did {
 		// notice: holder must have not DID

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -60,6 +60,33 @@ func (s *KeeperTestSuite) TestApprove() {
 	s.Require().Equal(msg.Hash, kyc.Hash)
 }
 
+func (s *KeeperTestSuite) TestApproveRejectsPubkeyAddressMismatch() {
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	did := "1111111111111111"
+	kycAccount, _ := s.NewAccount()
+	_, attackerPubkey := s.NewAccount()
+
+	_, err := s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: strings.ToLower(wstakingtypes.MeEarthRegionName),
+		Address:  kycAccount.String(),
+		Pubkey:   attackerPubkey,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "aaaa",
+		Level:    2,
+	})
+	s.Require().ErrorIs(err, types.ErrInvalidPubkey)
+
+	_, found := s.Keeper().GetDID(s.Ctx, kycAccount)
+	s.Require().False(found)
+	_, found = s.Keeper().GetDidInfo(s.Ctx, did)
+	s.Require().False(found)
+}
+
 func (s *KeeperTestSuite) TestRemove() {
 	s.SetupTest()
 


### PR DESCRIPTION
## Summary
- derive the account address from `MsgApprove.Pubkey` during KYC approval
- reject `Approve` when the derived pubkey address does not match `MsgApprove.Address`
- add a regression test that verifies no DID or DID info is written on mismatch

## Bounty
Refs #266

Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestApproveRejectsPubkeyAddressMismatch' -count=1 -v`\n- `go test ./x/kyc/keeper -run 'TestKeeperTestSuite/Test(Approve|Remove|Update)$' -count=1 -v`\n- `git diff --check`\n\n## Note\n`go test ./x/kyc/keeper -count=1 -v` still fails on existing query assertions in `grpc_query_test.go`: `TestDIDs`, `TestKYCs`, and `TestProtocol`. The new mismatch regression test passes.