### PR TITLE
fix(delayedack): record timeout-on-close proof height

### DIFF
--- a/x/delayedack/proof_height_ante.go
+++ b/x/delayedack/proof_height_ante.go
@@ -49,6 +49,15 @@ func (rrd IBCProofHeightDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 				msg.Packet.SourceChannel,
 				msg.Packet.Sequence,
 			)
+
+		case *channeltypes.MsgTimeoutOnClose:
+			height = msg.ProofHeight
+			packetId = commontypes.NewPacketUID(
+				commontypes.RollappPacket_ON_TIMEOUT,
+				msg.Packet.SourcePort,
+				msg.Packet.SourceChannel,
+				msg.Packet.Sequence,
+			)
 		default:
 			continue
 		}

--- a/x/delayedack/proof_height_ante_test.go
+++ b/x/delayedack/proof_height_ante_test.go
@@ -1,0 +1,61 @@
+package delayedack
+
+import (
+	"testing"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+
+	commontypes "github.com/openmetaearth/me-hub/x/common/types"
+	delayedacktypes "github.com/openmetaearth/me-hub/x/delayedack/types"
+)
+
+type proofHeightTx struct {
+	msgs []sdk.Msg
+}
+
+func (tx proofHeightTx) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx proofHeightTx) ValidateBasic() error {
+	return nil
+}
+
+func TestIBCProofHeightDecoratorRecordsTimeoutOnClose(t *testing.T) {
+	decorator := NewIBCProofHeightDecorator()
+	ctx := sdk.NewContext(nil, tmproto.Header{}, false, nil)
+	proofHeight := clienttypes.NewHeight(7, 99)
+	packet := channeltypes.Packet{
+		Sequence:      1,
+		SourcePort:    "transfer",
+		SourceChannel: "channel-0",
+	}
+	packetID := commontypes.NewPacketUID(
+		commontypes.RollappPacket_ON_TIMEOUT,
+		packet.SourcePort,
+		packet.SourceChannel,
+		packet.Sequence,
+	)
+	tx := proofHeightTx{
+		msgs: []sdk.Msg{
+			&channeltypes.MsgTimeoutOnClose{
+				Packet:      packet,
+				ProofHeight: proofHeight,
+			},
+		},
+	}
+
+	_, err := decorator.AnteHandle(ctx, tx, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		got, ok := delayedacktypes.PacketProofHeightFromCtx(ctx, packetID)
+		require.True(t, ok)
+		require.Equal(t, proofHeight, got)
+		return ctx, nil
+	})
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- handle `MsgTimeoutOnClose` in `IBCProofHeightDecorator`
- store the timeout proof height under the same delayedack timeout packet id used by `MsgTimeout`
- add a regression test for timeout-on-close proof-height propagation

## Bounty
Refs #214

Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./x/delayedack -run TestIBCProofHeightDecoratorRecordsTimeoutOnClose -count=1 -v`
- `go test ./x/delayedack -count=1 -v`
- `git diff --check`