### PR TITLE
fix(wstaking): stop rewards after mint cap

### DIFF
--- a/x/wstaking/keeper/alias_functions.go
+++ b/x/wstaking/keeper/alias_functions.go
@@ -23,17 +23,24 @@ func (k Keeper) CalculateInterest(ctx sdk.Context, totalStaking cmath.Int, heigh
 
 // getRewardsByHeight Get coins through the block height range
 func (k Keeper) getRewardsByHeight(fromHeight int64, toHeight int64) (coin sdk.Dec) {
+	capHeight := mintCapRewardEndHeight()
+	if fromHeight >= capHeight {
+		return sdk.ZeroDec()
+	}
+	if toHeight > capHeight {
+		toHeight = capHeight
+	}
+	if fromHeight >= toHeight {
+		return sdk.ZeroDec()
+	}
+
 	totalCoins := sdk.ZeroInt()
 
 	lowMul := (fromHeight - 1) / mintTypes.OneYearTotalBlocks
 	highMul := (toHeight - 1) / mintTypes.OneYearTotalBlocks
 
 	for i := lowMul; i <= highMul; i++ {
-		halvingDivisor := sdk.NewDecFromBigInt(new(big.Int).Lsh(big.NewInt(1), uint(i)))
-		amountDec := sdk.NewDec(int64(mintTypes.InitOneYearMintAmount)).
-			Quo(sdk.NewDec(int64(mintTypes.OneYearTotalBlocks))).
-			Quo(halvingDivisor)
-		mintUMECAmount := wmint.RoundUpToFourDecimalsDec(amountDec).MulInt64(100_000_000).TruncateInt()
+		mintUMECAmount := mintUMECAmountByPeriod(i)
 
 		var blockCount int64
 		// If the range of from and to are in the same reduction period
@@ -55,6 +62,43 @@ func (k Keeper) getRewardsByHeight(fromHeight int64, toHeight int64) (coin sdk.D
 
 	coin = sdk.NewDecFromInt(totalCoins)
 	return
+}
+
+func mintCapRewardEndHeight() int64 {
+	totalCap := sdk.NewInt(mintTypes.TotalMintCoinsAmount)
+	totalCoins := sdk.ZeroInt()
+	blocksPerPeriod := int64(mintTypes.OneYearTotalBlocks)
+
+	for i := int64(0); ; i++ {
+		mintUMECAmount := mintUMECAmountByPeriod(i)
+		if !mintUMECAmount.IsPositive() {
+			return i * blocksPerPeriod
+		}
+
+		periodCoins := mintUMECAmount.MulRaw(blocksPerPeriod)
+		if totalCoins.Add(periodCoins).GTE(totalCap) {
+			remaining := totalCap.Sub(totalCoins)
+			blocksToCap := ceilDivInt64(remaining, mintUMECAmount)
+			return i*blocksPerPeriod + blocksToCap
+		}
+
+		totalCoins = totalCoins.Add(periodCoins)
+	}
+}
+
+func mintUMECAmountByPeriod(period int64) sdk.Int {
+	halvingDivisor := sdk.NewDecFromBigInt(new(big.Int).Lsh(big.NewInt(1), uint(period)))
+	amountDec := sdk.NewDec(int64(mintTypes.InitOneYearMintAmount)).
+		Quo(sdk.NewDec(int64(mintTypes.OneYearTotalBlocks))).
+		Quo(halvingDivisor)
+	return wmint.RoundUpToFourDecimalsDec(amountDec).MulInt64(100_000_000).TruncateInt()
+}
+
+func ceilDivInt64(numerator sdk.Int, denominator sdk.Int) int64 {
+	adjusted := new(big.Int).Sub(numerator.BigInt(), big.NewInt(1))
+	adjusted.Div(adjusted, denominator.BigInt())
+	adjusted.Add(adjusted, big.NewInt(1))
+	return adjusted.Int64()
 }
 
 // Calculate computes the per-block staking reward for a given amount of staked tokens.

--- a/x/wstaking/keeper/alias_functions_test.go
+++ b/x/wstaking/keeper/alias_functions_test.go
@@ -3,8 +3,11 @@ package keeper
 import (
 	"testing"
 
+	"github.com/cometbft/cometbft/libs/log"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	mintTypes "github.com/openmetaearth/me-hub/x/wmint/types"
+	stakingTypes "github.com/openmetaearth/me-hub/x/wstaking/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,4 +125,15 @@ func TestGetRewardsByHeight(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestCalculateInterestAfterMintCapReturnsZero(t *testing.T) {
+	k := newTestKeeper()
+
+	const capReachedHeight int64 = 132_444_800
+	ctx := sdk.NewContext(nil, tmproto.Header{Height: capReachedHeight + 100}, false, log.NewNopLogger())
+
+	rewards, err := k.CalculateInterest(ctx, sdk.NewInt(stakingTypes.CaclTotalSupply), capReachedHeight)
+	require.NoError(t, err)
+	require.True(t, rewards.IsZero(), "post-cap staking rewards should be zero, got %s", rewards)
 }


### PR DESCRIPTION
## Summary
- clamp theoretical staking reward calculation at the wmint total supply cap height
- reuse the same rounded per-period mint amount used by wmint
- add a regression test proving post-cap staking rewards are zero

## Bounty
Refs #292

Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./x/wstaking/keeper -run TestCalculateInterestAfterMintCapReturnsZero -count=1 -v`
- `go test ./x/wstaking/keeper -run 'Test(GetRewardsByHeight|CalculateInterestAfterMintCapReturnsZero)$' -count=1 -v`\n- `git diff --check`\n\n## Note\n`go test ./x/wstaking/keeper -count=1 -v` currently fails in existing suite tests outside this cap calculation path, including `TestDelegate/un_did_delegate`, several KYC reward accounting assertions, region authorization assertions, and stake/unstake balance expectations. The focused reward calculation tests above pass.