### PR TITLE
fix(megroup): remove members after kyc downgrade

### DIFF
--- a/x/megroup/keeper/keeper.go
+++ b/x/megroup/keeper/keeper.go
@@ -80,6 +80,10 @@ func (k Keeper) KycStatusChanged(goCtx context.Context, msgType string, data int
 	if val, ok := data.(sdk.Event); !ok {
 		return fmt.Errorf("data's type is not sdk.Event.but msgType is update")
 	} else {
+		attrAddress, found := val.GetAttribute(kycTypes.AttributeKeyAddress)
+		if !found {
+			return fmt.Errorf("can not found AttributeKeyAddress.but EventType is update")
+		}
 		attrPreRegion, found := val.GetAttribute(kycTypes.AttributeKeyRegionId)
 		if !found {
 			return fmt.Errorf("can not found AttributeKeyRegionId.but EventType is update")
@@ -88,15 +92,19 @@ func (k Keeper) KycStatusChanged(goCtx context.Context, msgType string, data int
 		if !found {
 			return fmt.Errorf("can not found AttributeKeyRegionIdChanged.but EventType is update")
 		}
+		attrNewLevel, found := val.GetAttribute(kycTypes.AttributeKeyLevelChanged)
+		if !found {
+			return fmt.Errorf("can not found AttributeKeyLevelChanged.but EventType is update")
+		}
+		if attrNewLevel.Value != didTypes.KYC_LEVEL_TWO.String() {
+			_, err := k.removeJoinedMember(ctx, attrAddress.Value)
+			return err
+		}
 		if attrPreRegion.Value == attrNewRegion.Value { //if region not changed,return
 			k.Logger(ctx).Info("regionID was not changed in KycStatusChanged!!!")
 			return nil
 		}
 		k.Logger(ctx).Info("start to proc KycStatusChanged!!!")
-		attrAddress, found := val.GetAttribute(kycTypes.AttributeKeyAddress)
-		if !found {
-			return fmt.Errorf("can not found AttributeKeyAddress.but EventType is update")
-		}
 
 		if err := k.procKycRegionChange(ctx, attrAddress.Value, attrPreRegion.Value, attrNewRegion.Value); err != nil {
 			return err
@@ -106,6 +114,40 @@ func (k Keeper) KycStatusChanged(goCtx context.Context, msgType string, data int
 
 	return nil
 
+}
+
+func (k Keeper) removeJoinedMember(sdkCtx sdk.Context, address string) (uint64, error) {
+	joined, found := k.GetMemberJoined(sdkCtx, address)
+	if !found || joined.GroupId == 0 {
+		return 0, nil
+	}
+
+	groupInfo, found := k.GetGroupInfo(sdkCtx, joined.GroupId)
+	if !found {
+		return 0, errors.Wrapf(types.ErrGroupNotExist, "can not found joined group.groupID = %d", joined.GroupId)
+	}
+	if address == groupInfo.Admin {
+		return 0, errors.Wrapf(types.ErrExecute, "admin of group can not leave")
+	}
+
+	groupNumber, found := k.GetGroupMemberCount(sdkCtx, joined.GroupId)
+	if !found {
+		return 0, fmt.Errorf("can not found group number count while removing KYC-ineligible member")
+	}
+	if groupNumber == 0 {
+		return 0, fmt.Errorf("group number is 0 while removing KYC-ineligible member")
+	}
+
+	if err := k.deleteMemberFormGroup(sdkCtx, joined.GroupId, address); err != nil {
+		return 0, err
+	}
+	k.SetGroupMemberCount(sdkCtx, joined.GroupId, groupNumber-1)
+	k.SetMemberJoined(sdkCtx, types.MemberJoined{
+		Address: address,
+		GroupId: 0,
+	})
+
+	return joined.GroupId, nil
 }
 
 func (k Keeper) procKycRegionChange(sdkCtx sdk.Context, address, preRegionID, nowRegionID string) error {

--- a/x/megroup/keeper/keeper_test.go
+++ b/x/megroup/keeper/keeper_test.go
@@ -1,0 +1,192 @@
+package keeper_test
+
+import (
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	kyckeeper "github.com/openmetaearth/me-hub/x/kyc/keeper"
+	kyctypes "github.com/openmetaearth/me-hub/x/kyc/types"
+	"github.com/openmetaearth/me-hub/x/megroup/keeper"
+	"github.com/openmetaearth/me-hub/x/megroup/types"
+	"github.com/openmetaearth/me-hub/x/wdistri"
+	"github.com/openmetaearth/me-hub/x/wmint"
+	wminttypes "github.com/openmetaearth/me-hub/x/wmint/types"
+	wstakingkeeper "github.com/openmetaearth/me-hub/x/wstaking/keeper"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+type KeeperTestSuite struct {
+	apptesting.KeeperTestHelper
+
+	groupMsgServer types.MsgServer
+	kycMsgServer   kyctypes.MsgServer
+	queryClient    types.QueryClient
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (s *KeeperTestSuite) SetupTest() {
+	app := apptesting.Setup(s.T(), false)
+	ctx := app.GetBaseApp().NewContext(false, tmproto.Header{})
+
+	queryHelper := baseapp.NewQueryServerTestHelper(ctx, app.InterfaceRegistry())
+	types.RegisterQueryServer(queryHelper, *app.GroupKeeper)
+
+	s.App = app
+	s.Ctx = ctx
+	s.groupMsgServer = keeper.NewMsgServerImpl(*app.GroupKeeper)
+	s.kycMsgServer = kyckeeper.NewMsgServerImpl(*app.KycKeeper)
+	s.queryClient = types.NewQueryClient(queryHelper)
+
+	s.InitializeDao()
+
+	stakingMsgServer := wstakingkeeper.NewMsgServerImpl(
+		app.StakingKeeper,
+		app.TransferKeeper,
+		stakingkeeper.NewMsgServerImpl(app.StakingKeeper.Keeper),
+	)
+	validators := app.StakingKeeper.GetValidators(ctx, 10)
+	s.Require().GreaterOrEqual(len(validators), 3)
+	_, err := stakingMsgServer.NewRegion(ctx, &wstakingtypes.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            wstakingtypes.ExperienceRegionName,
+		OperatorAddress: validators[1].OperatorAddress,
+	})
+	s.Require().NoError(err)
+	_, err = stakingMsgServer.NewRegion(ctx, &wstakingtypes.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            "USA",
+		OperatorAddress: validators[2].OperatorAddress,
+	})
+	s.Require().NoError(err)
+	_, err = stakingMsgServer.NewRegion(ctx, &wstakingtypes.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            wstakingtypes.MeEarthRegionName,
+		OperatorAddress: validators[0].OperatorAddress,
+	})
+	s.Require().NoError(err)
+}
+
+func (s *KeeperTestSuite) TestKycLevelDowngradeRemovesJoinedMember() {
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).
+		WithBlockHeight(wminttypes.OneDayTotalBlocks).
+		WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	member, pubKey := s.NewAccount()
+	const did = "did-kyc-downgrade"
+	regionID := wstakingtypes.MeEarthRegionId
+
+	_, err := s.kycMsgServer.Approve(s.Ctx, &kyctypes.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: regionID,
+		Address:  member.String(),
+		Pubkey:   pubKey,
+		Uri:      "http://127.0.0.1/kyc",
+		Hash:     "hash-before-downgrade",
+		Level:    didtypes.KYC_LEVEL_TWO,
+	})
+	s.Require().NoError(err)
+
+	groupID, found := s.App.GroupKeeper.GetGroupIdByRegion(s.Ctx, regionID)
+	s.Require().True(found)
+	_, err = s.groupMsgServer.JoinGroup(s.Ctx, &types.MsgJoinGroup{
+		Creator:          member.String(),
+		GroupId:          groupID,
+		ApplicantAddress: member.String(),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.kycMsgServer.Update(s.Ctx, &kyctypes.MsgUpdate{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: regionID,
+		Uri:      "http://127.0.0.1/kyc",
+		Hash:     "hash-after-downgrade",
+		Level:    didtypes.KYC_LEVEL_ONE,
+	})
+	s.Require().NoError(err)
+
+	joined, found := s.App.GroupKeeper.GetMemberJoined(s.Ctx, member.String())
+	s.Require().True(found)
+	s.Require().Zero(joined.GroupId)
+
+	count, found := s.App.GroupKeeper.GetGroupMemberCount(s.Ctx, groupID)
+	s.Require().True(found)
+	s.Require().Zero(count)
+
+	_, err = s.App.GroupKeeper.GroupMember(s.Ctx, &types.QueryGetGroupMemberRequest{
+		Address: member.String(),
+	})
+	s.Require().Error(err)
+}
+
+func (s *KeeperTestSuite) TestKycRegionUpdateDoesNotMigrateDowngradedMember() {
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).
+		WithBlockHeight(wminttypes.OneDayTotalBlocks).
+		WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	member, pubKey := s.NewAccount()
+	const did = "did-kyc-region-downgrade"
+	regionID := wstakingtypes.MeEarthRegionId
+	newRegionID := "usa"
+
+	_, err := s.kycMsgServer.Approve(s.Ctx, &kyctypes.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: regionID,
+		Address:  member.String(),
+		Pubkey:   pubKey,
+		Uri:      "http://127.0.0.1/kyc",
+		Hash:     "hash-before-region-downgrade",
+		Level:    didtypes.KYC_LEVEL_TWO,
+	})
+	s.Require().NoError(err)
+
+	oldGroupID, found := s.App.GroupKeeper.GetGroupIdByRegion(s.Ctx, regionID)
+	s.Require().True(found)
+	newGroupID, found := s.App.GroupKeeper.GetGroupIdByRegion(s.Ctx, newRegionID)
+	s.Require().True(found)
+
+	_, err = s.groupMsgServer.JoinGroup(s.Ctx, &types.MsgJoinGroup{
+		Creator:          member.String(),
+		GroupId:          oldGroupID,
+		ApplicantAddress: member.String(),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.kycMsgServer.Update(s.Ctx, &kyctypes.MsgUpdate{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: newRegionID,
+		Uri:      "http://127.0.0.1/kyc",
+		Hash:     "hash-after-region-downgrade",
+		Level:    didtypes.KYC_LEVEL_ONE,
+	})
+	s.Require().NoError(err)
+
+	joined, found := s.App.GroupKeeper.GetMemberJoined(s.Ctx, member.String())
+	s.Require().True(found)
+	s.Require().Zero(joined.GroupId)
+
+	oldCount, found := s.App.GroupKeeper.GetGroupMemberCount(s.Ctx, oldGroupID)
+	s.Require().True(found)
+	s.Require().Zero(oldCount)
+
+	newCount, found := s.App.GroupKeeper.GetGroupMemberCount(s.Ctx, newGroupID)
+	s.Require().True(found)
+	s.Require().Zero(newCount)
+}


### PR DESCRIPTION
## Summary
- make the MEGroup KYC update hook enforce the final KYC level, not only region changes
- remove joined members when KYC update leaves them below `KYC_LEVEL_TWO`
- prevent region-change updates from migrating downgraded users into a new group
- add keeper tests for same-region downgrade and region-change downgrade

## Bounty
Refs #207

Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./x/megroup/keeper -run 'TestKeeperTestSuite/TestKyc(LevelDowngradeRemovesJoinedMember|RegionUpdateDoesNotMigrateDowngradedMember)' -count=1 -v`\n- `go test ./x/megroup/keeper -count=1 -v`\n- `git diff --check`