### PR TITLE
fix(ante): unwrap authz wasm fee messages

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -95,6 +95,7 @@ func (suite *AnteTestSuite) TestCosmosAnteHandlerEip712() {
 	suite.mockDaoKeeper.EXPECT().GetGlobalDao(gomock.Any()).Return(devOperator.Address)
 	suite.mockDaoKeeper.EXPECT().GetMeidDao(gomock.Any()).Return(devOperator.Address)
 	suite.mockDaoKeeper.EXPECT().GetGlobalDaoFeePoolAddr(gomock.Any()).Return(devOperator.GetAddress())
+	suite.mockDaoKeeper.EXPECT().IsDao(gomock.Any(), addr.Address).Return(false)
 	suite.mockDaoKeeper.EXPECT().CheckFreeGasAccount(gomock.Any(), addr.Address).Return(false)
 
 	amt := sdk.NewInt(100)

--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -12,6 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	megrouptypes "github.com/openmetaearth/me-hub/x/megroup/types"
@@ -79,19 +80,27 @@ func (dfd DeductFeeDecorator) ParseWasmMsgContractCreator(ctx sdk.Context, tx sd
 	allwasm := true
 	var contract string
 	for _, msg := range tx.GetMsgs() {
-		switch msg := msg.(type) {
-		case *wasmtypes.MsgExecuteContract:
-			contract = msg.Contract
-		case *wasmtypes.MsgMigrateContract:
-			contract = msg.Contract
-		case *wasmtypes.MsgUpdateAdmin:
-			contract = msg.Contract
-		case *wasmtypes.MsgClearAdmin:
-			contract = msg.Contract
-		case *wasmtypes.MsgSudoContract:
-			contract = msg.Contract
-		default:
+		msgs, ok := unwrapAuthzExecMsgs(msg)
+		if !ok || len(msgs) == 0 {
 			allwasm = false
+			continue
+		}
+
+		for _, msg := range msgs {
+			switch msg := msg.(type) {
+			case *wasmtypes.MsgExecuteContract:
+				contract = msg.Contract
+			case *wasmtypes.MsgMigrateContract:
+				contract = msg.Contract
+			case *wasmtypes.MsgUpdateAdmin:
+				contract = msg.Contract
+			case *wasmtypes.MsgClearAdmin:
+				contract = msg.Contract
+			case *wasmtypes.MsgSudoContract:
+				contract = msg.Contract
+			default:
+				allwasm = false
+			}
 		}
 	}
 
@@ -108,6 +117,29 @@ func (dfd DeductFeeDecorator) ParseWasmMsgContractCreator(ctx sdk.Context, tx sd
 		return admin, true
 	}
 	return "", false
+}
+
+func unwrapAuthzExecMsgs(msg sdk.Msg) ([]sdk.Msg, bool) {
+	execMsg, ok := msg.(*authz.MsgExec)
+	if !ok {
+		return []sdk.Msg{msg}, true
+	}
+
+	msgs, err := execMsg.GetMessages()
+	if err != nil {
+		return nil, false
+	}
+
+	unwrapped := make([]sdk.Msg, 0, len(msgs))
+	for _, msg := range msgs {
+		nested, ok := unwrapAuthzExecMsgs(msg)
+		if !ok {
+			return nil, false
+		}
+		unwrapped = append(unwrapped, nested...)
+	}
+
+	return unwrapped, true
 }
 
 func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {

--- a/app/ante/fee_deduct_test.go
+++ b/app/ante/fee_deduct_test.go
@@ -1,10 +1,12 @@
 package ante_test
 
 import (
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authantetestutil "github.com/cosmos/cosmos-sdk/x/auth/ante/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/evmos/ethermint/crypto/ethsecp256k1"
@@ -390,4 +392,50 @@ func TestCheckFunds(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthzWrappedWasmExecParsesContractCreator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := sdk.Context{}
+	mockAccountKeeper := authantetestutil.NewMockAccountKeeper(ctrl)
+	mockBankKeeper := mock.NewMockBankKeeper(ctrl)
+	mockFeegrantKeeper := authantetestutil.NewMockFeegrantKeeper(ctrl)
+	mockDaoKeeper := mock.NewMockDaoKeeper(ctrl)
+	mockStakingKeeper := mock.NewMockStakingKeeper(ctrl)
+	mockKycKeeper := mock.NewMockKycKeeper(ctrl)
+	mockWasmKeeper := mock.NewMockWasmKeeper(ctrl)
+	decorator := ante.NewDeductFeeDecorator(
+		mockAccountKeeper,
+		mockBankKeeper,
+		mockFeegrantKeeper,
+		mockDaoKeeper,
+		mockStakingKeeper,
+		mockKycKeeper,
+		nil,
+		mockWasmKeeper,
+	)
+
+	grantee := NewAccount().GetAddress()
+	contract := NewAccount().GetAddress()
+	creator := NewAccount().GetAddress().String()
+	wasmMsg := &wasmtypes.MsgExecuteContract{
+		Sender:   grantee.String(),
+		Contract: contract.String(),
+		Msg:      []byte(`{}`),
+		Funds:    sdk.Coins{},
+	}
+	authzMsg := authz.NewMsgExec(grantee, []sdk.Msg{wasmMsg})
+
+	mockWasmKeeper.EXPECT().
+		GetContractInfo(ctx, contract).
+		Return(&wasmtypes.ContractInfo{Creator: creator})
+
+	gotCreator, ok := decorator.ParseWasmMsgContractCreator(ctx, &mock.MockTx{
+		Msgs: []sdk.Msg{&authzMsg},
+	})
+
+	require.True(t, ok)
+	require.Equal(t, creator, gotCreator)
 }

--- a/app/ante/mock/expected_keepers_mocks.go
+++ b/app/ante/mock/expected_keepers_mocks.go
@@ -122,6 +122,20 @@ func (mr *MockDaoKeeperMockRecorder) GetMeidDao(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeidDao", reflect.TypeOf((*MockDaoKeeper)(nil).GetMeidDao), ctx)
 }
 
+// IsDao mocks base method.
+func (m *MockDaoKeeper) IsDao(ctx types0.Context, addr string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDao", ctx, addr)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDao indicates an expected call of IsDao.
+func (mr *MockDaoKeeperMockRecorder) IsDao(ctx, addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDao", reflect.TypeOf((*MockDaoKeeper)(nil).IsDao), ctx, addr)
+}
+
 // MockBankKeeper is a mock of BankKeeper interface.
 type MockBankKeeper struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
## Summary
- unwrap `authz.MsgExec` messages before classifying wasm fee-share transactions
- preserve the existing all-wasm rule while allowing authz-wrapped wasm messages to pay creator fee share
- add regression coverage for authz-wrapped `MsgExecuteContract`
- refresh the stale DaoKeeper gomock with `IsDao` and update the existing ante test expectation

## Bounty
Refs #179

Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./app/ante -run TestAuthzWrappedWasmExecParsesContractCreator -count=1 -v`
- `go test ./app/ante -count=1 -v`
- `git diff --check`
