### PR TITLE
fix(wnft): paginate owner nft queries

### DIFF
--- a/proto/metaearth/wnft/query.proto
+++ b/proto/metaearth/wnft/query.proto
@@ -30,6 +30,8 @@ message QueryClassAddressRequest {
   string class_id = 1;
 
   string address = 2;
+
+  cosmos.base.query.v1beta1.PageRequest pagination = 3;
 }
 
 // QueryClassesResponse is the response type for the Query/Classes RPC method
@@ -39,6 +41,8 @@ message QueryClassAddressResponse {
   uint64 total_supply = 2;
 
   repeated string nfts = 3;
+
+  cosmos.base.query.v1beta1.PageResponse pagination = 4;
 }
 
 // QueryNftFilterResponse is the request type for the Query/NftFilter RPC method
@@ -48,12 +52,16 @@ message QueryNftFilterRequest {
   string class_id = 2;
 
   string token_id = 3;
+
+  cosmos.base.query.v1beta1.PageRequest pagination = 4;
 }
 
 // QueryNftFilterResponse is the response type for the Query/NftFilter RPC
 // method
 message QueryNftFilterResponse {
   repeated NftList nfts = 1;
+
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
 message NftList {

--- a/x/wnft/client/cli/query.go
+++ b/x/wnft/client/cli/query.go
@@ -60,6 +60,11 @@ func GetCmdQueryClassAddress() *cobra.Command {
 			}
 			queryClient := types.NewQueryClient(clientCtx)
 
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
 			owner := args[1]
 
 			if len(owner) > 0 {
@@ -69,8 +74,9 @@ func GetCmdQueryClassAddress() *cobra.Command {
 			}
 
 			res, err := queryClient.ClassAddress(cmd.Context(), &types.QueryClassAddressRequest{
-				ClassId: args[0],
-				Address: owner,
+				ClassId:    args[0],
+				Address:    owner,
+				Pagination: pageReq,
 			})
 			if err != nil {
 				return err
@@ -78,6 +84,7 @@ func GetCmdQueryClassAddress() *cobra.Command {
 			return clientCtx.PrintProto(res)
 		},
 	}
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 	flags.AddQueryFlagsToCmd(cmd)
 	return cmd
 }
@@ -95,7 +102,15 @@ func GetCmdQueryNftFilter() *cobra.Command {
 			}
 			queryClient := types.NewQueryClient(clientCtx)
 
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
 			owner, err := cmd.Flags().GetString(FlagOwner)
+			if err != nil {
+				return err
+			}
 
 			if len(owner) > 0 {
 				if _, err := sdk.AccAddressFromBech32(owner); err != nil {
@@ -103,14 +118,21 @@ func GetCmdQueryNftFilter() *cobra.Command {
 				}
 			}
 
-			classId, _ := cmd.Flags().GetString(FlagClassID)
+			classId, err := cmd.Flags().GetString(FlagClassID)
+			if err != nil {
+				return err
+			}
 
-			tokenId, _ := cmd.Flags().GetString(FlagTokenId)
+			tokenId, err := cmd.Flags().GetString(FlagTokenId)
+			if err != nil {
+				return err
+			}
 
 			res, err := queryClient.NftFilter(cmd.Context(), &types.QueryNftFilterRequest{
-				Owner:   owner,
-				ClassId: classId,
-				TokenId: tokenId,
+				Owner:      owner,
+				ClassId:    classId,
+				TokenId:    tokenId,
+				Pagination: pageReq,
 			})
 			if err != nil {
 				return err
@@ -122,6 +144,7 @@ func GetCmdQueryNftFilter() *cobra.Command {
 	cmd.Flags().String(FlagOwner, "", "The owner of the nft")
 	cmd.Flags().String(FlagClassID, "", "The class-id of the nft")
 	cmd.Flags().String(FlagTokenId, "", "nft token id")
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 
 	return cmd
 }

--- a/x/wnft/keeper/grpc_query.go
+++ b/x/wnft/keeper/grpc_query.go
@@ -31,21 +31,24 @@ func (k Keeper) ClassAddress(goCtx context.Context, r *types.QueryClassAddressRe
 		return nil, err
 	}
 
-	nfts := k.GetNFTsOfClassByOwner(ctx, r.ClassId, address)
-
-	var tokenIds []string
-	for _, nft := range nfts {
-		tokenIds = append(tokenIds, nft.Id)
+	tokenIds, pageRes, err := k.paginateNFTIDsOfClassByOwner(ctx, r.ClassId, address, r.Pagination)
+	if err != nil {
+		return nil, err
 	}
 
 	return &types.QueryClassAddressResponse{
 		Exists:      true,
 		TotalSupply: class.TotalSupply,
 		Nfts:        tokenIds,
+		Pagination:  pageRes,
 	}, nil
 }
 
 func (k Keeper) NftFilter(goCtx context.Context, r *types.QueryNftFilterRequest) (*types.QueryNftFilterResponse, error) {
+	if r == nil {
+		return nil, sdkerrors.ErrInvalidRequest.Wrap("empty request")
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	var list []*types.NftList
@@ -82,9 +85,15 @@ func (k Keeper) NftFilter(goCtx context.Context, r *types.QueryNftFilterRequest)
 		if !has {
 			return nil, nil
 		}
-		address, _ := sdk.AccAddressFromBech32(r.Owner)
+		address, err := sdk.AccAddressFromBech32(r.Owner)
+		if err != nil {
+			return nil, err
+		}
 
-		nftInfos := k.GetNFTsOfClassByOwner(ctx, r.ClassId, address)
+		nftInfos, pageRes, err := k.paginateNFTsOfClassByOwner(ctx, r.ClassId, address, r.Pagination)
+		if err != nil {
+			return nil, err
+		}
 		for _, nftInfo := range nftInfos {
 			list = append(list, &types.NftList{
 				ClassId: nftInfo.ClassId,
@@ -95,28 +104,34 @@ func (k Keeper) NftFilter(goCtx context.Context, r *types.QueryNftFilterRequest)
 		}
 
 		return &types.QueryNftFilterResponse{
-			Nfts: list,
+			Nfts:       list,
+			Pagination: pageRes,
 		}, nil
 
 	} else if r.Owner != "" && r.TokenId == "" && r.ClassId == "" {
 		// query the nft information held by the address
-		classes := k.GetClasses(ctx)
-		address, _ := sdk.AccAddressFromBech32(r.Owner)
-		for _, class := range classes {
-			nftInfos := k.GetNFTsOfClassByOwner(ctx, class.Id, address)
-			for _, nftInfo := range nftInfos {
-				owner := k.GetOwner(ctx, nftInfo.ClassId, nftInfo.Id)
-				list = append(list, &types.NftList{
-					ClassId: nftInfo.ClassId,
-					TokenId: nftInfo.Id,
-					Owner:   owner.String(),
-					Uri:     nftInfo.Uri,
-				})
-			}
+		address, err := sdk.AccAddressFromBech32(r.Owner)
+		if err != nil {
+			return nil, err
+		}
+
+		nftInfos, pageRes, err := k.paginateNFTsByOwner(ctx, address, r.Pagination)
+		if err != nil {
+			return nil, err
+		}
+		for _, nftInfo := range nftInfos {
+			owner := k.GetOwner(ctx, nftInfo.ClassId, nftInfo.Id)
+			list = append(list, &types.NftList{
+				ClassId: nftInfo.ClassId,
+				TokenId: nftInfo.Id,
+				Owner:   owner.String(),
+				Uri:     nftInfo.Uri,
+			})
 		}
 
 		return &types.QueryNftFilterResponse{
-			Nfts: list,
+			Nfts:       list,
+			Pagination: pageRes,
 		}, nil
 
 	}

--- a/x/wnft/keeper/keeper.go
+++ b/x/wnft/keeper/keeper.go
@@ -11,7 +11,8 @@ import (
 
 type Keeper struct {
 	nftkeeper.Keeper
-	cdc codec.BinaryCodec
+	cdc      codec.BinaryCodec
+	storeKey storetypes.StoreKey
 }
 
 func NewKeeper(
@@ -21,8 +22,9 @@ func NewKeeper(
 	bk nft.BankKeeper,
 ) *Keeper {
 	return &Keeper{
-		Keeper: nftkeeper.NewKeeper(storeKey, cdc, ak, bk),
-		cdc:    cdc,
+		Keeper:   nftkeeper.NewKeeper(storeKey, cdc, ak, bk),
+		cdc:      cdc,
+		storeKey: storeKey,
 	}
 }
 

--- a/x/wnft/keeper/query_pagination.go
+++ b/x/wnft/keeper/query_pagination.go
@@ -1,0 +1,133 @@
+package keeper
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/cosmos/cosmos-sdk/x/nft"
+)
+
+const maxWNFTQueryLimit uint64 = 100
+
+var (
+	wnftNFTOfClassByOwnerKey = []byte{0x03}
+	wnftDelimiter            = []byte{0x00}
+)
+
+func safeWNFTPageRequest(pageReq *query.PageRequest) *query.PageRequest {
+	if pageReq == nil {
+		return &query.PageRequest{Limit: maxWNFTQueryLimit}
+	}
+
+	safeReq := *pageReq
+	if safeReq.Limit == 0 || safeReq.Limit > maxWNFTQueryLimit {
+		safeReq.Limit = maxWNFTQueryLimit
+	}
+	safeReq.CountTotal = false
+
+	return &safeReq
+}
+
+func (k Keeper) paginateNFTIDsOfClassByOwner(
+	ctx sdk.Context,
+	classID string,
+	owner sdk.AccAddress,
+	pageReq *query.PageRequest,
+) ([]string, *query.PageResponse, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), nftOfClassByOwnerStoreKey(owner, classID))
+
+	var tokenIDs []string
+	pageRes, err := query.Paginate(store, safeWNFTPageRequest(pageReq), func(key []byte, _ []byte) error {
+		tokenIDs = append(tokenIDs, string(key))
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tokenIDs, pageRes, nil
+}
+
+func (k Keeper) paginateNFTsOfClassByOwner(
+	ctx sdk.Context,
+	classID string,
+	owner sdk.AccAddress,
+	pageReq *query.PageRequest,
+) ([]nft.NFT, *query.PageResponse, error) {
+	tokenIDs, pageRes, err := k.paginateNFTIDsOfClassByOwner(ctx, classID, owner, pageReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nfts := make([]nft.NFT, 0, len(tokenIDs))
+	for _, tokenID := range tokenIDs {
+		nftInfo, found := k.GetNFT(ctx, classID, tokenID)
+		if found {
+			nfts = append(nfts, nftInfo)
+		}
+	}
+
+	return nfts, pageRes, nil
+}
+
+func (k Keeper) paginateNFTsByOwner(
+	ctx sdk.Context,
+	owner sdk.AccAddress,
+	pageReq *query.PageRequest,
+) ([]nft.NFT, *query.PageResponse, error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), prefixNftOfClassByOwnerStoreKey(owner))
+
+	var nfts []nft.NFT
+	pageRes, err := query.Paginate(store, safeWNFTPageRequest(pageReq), func(key []byte, _ []byte) error {
+		classID, tokenID, err := parseNFTOfClassByOwnerKey(key)
+		if err != nil {
+			return err
+		}
+
+		nftInfo, found := k.GetNFT(ctx, classID, tokenID)
+		if found {
+			nfts = append(nfts, nftInfo)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nfts, pageRes, nil
+}
+
+func nftOfClassByOwnerStoreKey(owner sdk.AccAddress, classID string) []byte {
+	owner = address.MustLengthPrefix(owner)
+
+	key := make([]byte, 0, len(wnftNFTOfClassByOwnerKey)+len(owner)+len(wnftDelimiter)+len(classID)+len(wnftDelimiter))
+	key = append(key, wnftNFTOfClassByOwnerKey...)
+	key = append(key, owner...)
+	key = append(key, wnftDelimiter...)
+	key = append(key, []byte(classID)...)
+	key = append(key, wnftDelimiter...)
+	return key
+}
+
+func prefixNftOfClassByOwnerStoreKey(owner sdk.AccAddress) []byte {
+	owner = address.MustLengthPrefix(owner)
+
+	key := make([]byte, 0, len(wnftNFTOfClassByOwnerKey)+len(owner)+len(wnftDelimiter))
+	key = append(key, wnftNFTOfClassByOwnerKey...)
+	key = append(key, owner...)
+	key = append(key, wnftDelimiter...)
+	return key
+}
+
+func parseNFTOfClassByOwnerKey(key []byte) (string, string, error) {
+	classID, tokenID, found := bytes.Cut(key, wnftDelimiter)
+	if !found || len(classID) == 0 || len(tokenID) == 0 {
+		return "", "", fmt.Errorf("invalid nft owner index key")
+	}
+
+	return string(classID), string(tokenID), nil
+}

--- a/x/wnft/keeper/query_pagination_test.go
+++ b/x/wnft/keeper/query_pagination_test.go
@@ -1,0 +1,44 @@
+package keeper
+
+import (
+	"bytes"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeWNFTPageRequestCapsLimitAndDisablesTotal(t *testing.T) {
+	require.Equal(t, maxWNFTQueryLimit, safeWNFTPageRequest(nil).Limit)
+
+	req := &query.PageRequest{
+		Limit:      maxWNFTQueryLimit + 1,
+		CountTotal: true,
+	}
+	got := safeWNFTPageRequest(req)
+
+	require.Equal(t, maxWNFTQueryLimit, got.Limit)
+	require.False(t, got.CountTotal)
+	require.Equal(t, maxWNFTQueryLimit+1, req.Limit)
+	require.True(t, req.CountTotal)
+}
+
+func TestParseNFTOfClassByOwnerKey(t *testing.T) {
+	classID := "album"
+	tokenID := "nft-1"
+	gotClassID, gotTokenID, err := parseNFTOfClassByOwnerKey([]byte(classID + string(wnftDelimiter) + tokenID))
+
+	require.NoError(t, err)
+	require.Equal(t, classID, gotClassID)
+	require.Equal(t, tokenID, gotTokenID)
+}
+
+func TestNFTOfClassByOwnerStoreKeyUsesOwnerClassPrefix(t *testing.T) {
+	owner := sdk.AccAddress(bytes.Repeat([]byte{0x01}, 20))
+	key := nftOfClassByOwnerStoreKey(owner, "album")
+
+	require.True(t, bytes.HasPrefix(key, wnftNFTOfClassByOwnerKey))
+	require.True(t, bytes.HasSuffix(key, append([]byte("album"), wnftDelimiter...)))
+	require.True(t, bytes.HasPrefix(key, prefixNftOfClassByOwnerStoreKey(owner)))
+}

--- a/x/wnft/types/query.pb.go
+++ b/x/wnft/types/query.pb.go
@@ -7,7 +7,7 @@ import (
 	context "context"
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
-	_ "github.com/cosmos/cosmos-sdk/types/query"
+	query "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 	proto "github.com/cosmos/gogoproto/proto"
@@ -34,8 +34,9 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // QueryClassRequest is the request type for the Query/Class RPC method
 type QueryClassAddressRequest struct {
 	// class_id associated with the nft
-	ClassId string `protobuf:"bytes,1,opt,name=class_id,json=classId,proto3" json:"class_id,omitempty"`
-	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	ClassId    string             `protobuf:"bytes,1,opt,name=class_id,json=classId,proto3" json:"class_id,omitempty"`
+	Address    string             `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	Pagination *query.PageRequest `protobuf:"bytes,3,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
 
 func (m *QueryClassAddressRequest) Reset()         { *m = QueryClassAddressRequest{} }
@@ -85,11 +86,19 @@ func (m *QueryClassAddressRequest) GetAddress() string {
 	return ""
 }
 
+func (m *QueryClassAddressRequest) GetPagination() *query.PageRequest {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
 // QueryClassesResponse is the response type for the Query/Classes RPC method
 type QueryClassAddressResponse struct {
-	Exists      bool     `protobuf:"varint,1,opt,name=exists,proto3" json:"exists,omitempty"`
-	TotalSupply uint64   `protobuf:"varint,2,opt,name=total_supply,json=totalSupply,proto3" json:"total_supply,omitempty"`
-	Nfts        []string `protobuf:"bytes,3,rep,name=nfts,proto3" json:"nfts,omitempty"`
+	Exists      bool                `protobuf:"varint,1,opt,name=exists,proto3" json:"exists,omitempty"`
+	TotalSupply uint64              `protobuf:"varint,2,opt,name=total_supply,json=totalSupply,proto3" json:"total_supply,omitempty"`
+	Nfts        []string            `protobuf:"bytes,3,rep,name=nfts,proto3" json:"nfts,omitempty"`
+	Pagination  *query.PageResponse `protobuf:"bytes,4,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
 
 func (m *QueryClassAddressResponse) Reset()         { *m = QueryClassAddressResponse{} }
@@ -146,11 +155,19 @@ func (m *QueryClassAddressResponse) GetNfts() []string {
 	return nil
 }
 
+func (m *QueryClassAddressResponse) GetPagination() *query.PageResponse {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
 // QueryNftFilterResponse is the request type for the Query/NftFilter RPC method
 type QueryNftFilterRequest struct {
-	Owner   string `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
-	ClassId string `protobuf:"bytes,2,opt,name=class_id,json=classId,proto3" json:"class_id,omitempty"`
-	TokenId string `protobuf:"bytes,3,opt,name=token_id,json=tokenId,proto3" json:"token_id,omitempty"`
+	Owner      string             `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
+	ClassId    string             `protobuf:"bytes,2,opt,name=class_id,json=classId,proto3" json:"class_id,omitempty"`
+	TokenId    string             `protobuf:"bytes,3,opt,name=token_id,json=tokenId,proto3" json:"token_id,omitempty"`
+	Pagination *query.PageRequest `protobuf:"bytes,4,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
 
 func (m *QueryNftFilterRequest) Reset()         { *m = QueryNftFilterRequest{} }
@@ -207,10 +224,18 @@ func (m *QueryNftFilterRequest) GetTokenId() string {
 	return ""
 }
 
+func (m *QueryNftFilterRequest) GetPagination() *query.PageRequest {
+	if m != nil {
+		return m.Pagination
+	}
+	return nil
+}
+
 // QueryNftFilterResponse is the response type for the Query/NftFilter RPC
 // method
 type QueryNftFilterResponse struct {
-	Nfts []*NftList `protobuf:"bytes,1,rep,name=nfts,proto3" json:"nfts,omitempty"`
+	Nfts       []*NftList          `protobuf:"bytes,1,rep,name=nfts,proto3" json:"nfts,omitempty"`
+	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
 
 func (m *QueryNftFilterResponse) Reset()         { *m = QueryNftFilterResponse{} }
@@ -249,6 +274,13 @@ var xxx_messageInfo_QueryNftFilterResponse proto.InternalMessageInfo
 func (m *QueryNftFilterResponse) GetNfts() []*NftList {
 	if m != nil {
 		return m.Nfts
+	}
+	return nil
+}
+
+func (m *QueryNftFilterResponse) GetPagination() *query.PageResponse {
+	if m != nil {
+		return m.Pagination
 	}
 	return nil
 }
@@ -508,6 +540,18 @@ func (m *QueryClassAddressRequest) MarshalToSizedBuffer(dAtA []byte) (int, error
 	_ = i
 	var l int
 	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.Address) > 0 {
 		i -= len(m.Address)
 		copy(dAtA[i:], m.Address)
@@ -545,6 +589,18 @@ func (m *QueryClassAddressResponse) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	_ = i
 	var l int
 	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
 	if len(m.Nfts) > 0 {
 		for iNdEx := len(m.Nfts) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.Nfts[iNdEx])
@@ -592,6 +648,18 @@ func (m *QueryNftFilterRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
 	if len(m.TokenId) > 0 {
 		i -= len(m.TokenId)
 		copy(dAtA[i:], m.TokenId)
@@ -636,6 +704,18 @@ func (m *QueryNftFilterResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	_ = i
 	var l int
 	_ = l
+	if m.Pagination != nil {
+		{
+			size, err := m.Pagination.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.Nfts) > 0 {
 		for iNdEx := len(m.Nfts) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -729,6 +809,10 @@ func (m *QueryClassAddressRequest) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovQuery(uint64(l))
 	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
 	return n
 }
 
@@ -749,6 +833,10 @@ func (m *QueryClassAddressResponse) Size() (n int) {
 			l = len(s)
 			n += 1 + l + sovQuery(uint64(l))
 		}
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
 }
@@ -771,6 +859,10 @@ func (m *QueryNftFilterRequest) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovQuery(uint64(l))
 	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
+	}
 	return n
 }
 
@@ -785,6 +877,10 @@ func (m *QueryNftFilterResponse) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.Size()
+		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
 }
@@ -913,6 +1009,42 @@ func (m *QueryClassAddressRequest) Unmarshal(dAtA []byte) error {
 			}
 			m.Address = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageRequest{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipQuery(dAtA[iNdEx:])
@@ -1033,6 +1165,42 @@ func (m *QueryClassAddressResponse) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Nfts = append(m.Nfts, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageResponse{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -1180,6 +1348,42 @@ func (m *QueryNftFilterRequest) Unmarshal(dAtA []byte) error {
 			}
 			m.TokenId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageRequest{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipQuery(dAtA[iNdEx:])
@@ -1261,6 +1465,42 @@ func (m *QueryNftFilterResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Nfts = append(m.Nfts, &NftList{})
 			if err := m.Nfts[len(m.Nfts)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &query.PageResponse{}
+			}
+			if err := m.Pagination.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/wnft/types/query.pb.gw.go
+++ b/x/wnft/types/query.pb.gw.go
@@ -66,6 +66,12 @@ func request_Query_ClassAddress_0(ctx context.Context, marshaler runtime.Marshal
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "class_id", err)
 	}
 
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_ClassAddress_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
 	msg, err := client.ClassAddress(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -104,10 +110,20 @@ func local_request_Query_ClassAddress_0(ctx context.Context, marshaler runtime.M
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "class_id", err)
 	}
 
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_ClassAddress_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
 	msg, err := server.ClassAddress(ctx, &protoReq)
 	return msg, metadata, err
 
 }
+
+var (
+	filter_Query_ClassAddress_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0, "class_id": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+)
 
 func request_Query_NftFilter_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryNftFilterRequest


### PR DESCRIPTION
## Summary
- add pagination fields and CLI pagination flags for `ClassAddress` and `NftFilter`
- read owner NFT indexes through bounded prefix-store pagination instead of loading all classes/NFTs into memory
- cap wnft query pages at 100 items and disable expensive total counting for these public owner queries
- return an error for invalid owner bech32 addresses instead of silently using an empty address
- add unit coverage for the pagination safety helpers and owner-index key parsing

## Bounty
Refs #799

Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./x/wnft/... -count=1 -v`
- `git diff --check`
