### PR TITLE
fix(wstaking): reject nil region queries

### DIFF
--- a/x/wstaking/keeper/grpc_query.go
+++ b/x/wstaking/keeper/grpc_query.go
@@ -21,6 +21,10 @@ type Querier struct {
 var _ types.QueryServer = Querier{}
 
 func (k Keeper) Region(goCtx context.Context, req *types.QueryRegionRequest) (*types.QueryRegionResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	region, found := k.GetRegion(ctx, req.RegionId)
 	if !found {
@@ -30,6 +34,10 @@ func (k Keeper) Region(goCtx context.Context, req *types.QueryRegionRequest) (*t
 }
 
 func (k Keeper) AllRegion(goCtx context.Context, req *types.QueryAllRegionRequest) (*types.QueryAllRegionResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
 	var regions []types.Region
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/wstaking/keeper/msg_server_region_test.go
+++ b/x/wstaking/keeper/msg_server_region_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/openmetaearth/me-hub/x/wmint"
 	wmintTypes "github.com/openmetaearth/me-hub/x/wmint/types"
 	"github.com/openmetaearth/me-hub/x/wstaking/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *KeeperTestSuite) TestNewRegion() {
@@ -120,6 +122,18 @@ func (s *KeeperTestSuite) TestRemoveRegion() {
 	// must error
 	_, err = s.queryClient.Region(s.Ctx, &types.QueryRegionRequest{RegionId: "usa"})
 	s.Require().ErrorIs(err, types.ErrRegionNotExist)
+}
+
+func (s *KeeperTestSuite) TestRegionQueriesRejectNilRequests() {
+	s.SetupTest()
+
+	_, err := s.App.StakingKeeper.Region(s.Ctx, nil)
+	s.Require().Error(err)
+	s.Require().Equal(codes.InvalidArgument, status.Code(err))
+
+	_, err = s.App.StakingKeeper.AllRegion(s.Ctx, nil)
+	s.Require().Error(err)
+	s.Require().Equal(codes.InvalidArgument, status.Code(err))
 }
 
 func (s *KeeperTestSuite) TestRemoveRegionThenCreateRegion() {


### PR DESCRIPTION
## Summary
- return `InvalidArgument` for nil `Region` query requests before reading `req.RegionId`
- return `InvalidArgument` for nil `AllRegion` query requests before reading `req.Pagination`
- add regression coverage for both nil request paths

## Bounty
Refs #263

Payout wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`

## Tests
- `go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestRegionQueriesRejectNilRequests' -count=1 -v`
- `git diff --check`

## Note
A broader local run of selected region tests still fails on existing error expectation mismatches unrelated to this nil-query guard:
- `TestRemoveRegion`
- `TestRemoveRegionThenCreateRegion`
- `TestWithdrawFromRegion/Dao_Permission`
