### PR TITLE
fix(eibc): prevent self-fulfillment of demand orders

### DIFF
--- a/x/eibc/keeper/msg_server.go
+++ b/x/eibc/keeper/msg_server.go
@@ -38,6 +38,10 @@ func (m msgServer) FulfillOrder(goCtx context.Context, msg *types.MsgFulfillOrde
 		return nil, err
 	}
 
+	if msg.FulfillerAddress == demandOrder.Recipient {
+		return nil, types.ErrSelfFulfillment
+	}
+
 	// Check that the fulfiller expected fee is equal to the demand order fee
 	expectedFee, _ := sdk.NewIntFromString(msg.ExpectedFee)
 	orderFee := demandOrder.GetFeeAmount()

--- a/x/eibc/keeper/msg_server_test.go
+++ b/x/eibc/keeper/msg_server_test.go
@@ -313,3 +313,23 @@ func (suite *KeeperTestSuite) TestUpdateDemandOrderOnAckOrTimeout() {
 	suite.Assert().Equal(updatedDemandOrder.Fee.AmountOf(denom), newFee)
 	suite.Assert().Equal(updatedDemandOrder.Price.AmountOf(denom), expectedNewPrice)
 }
+
+func (suite *KeeperTestSuite) TestMsgFulfillOrderSelfFulfillment() {
+	// Create and fund the account
+	testAddresses := apptesting.AddTestAddrs(suite.App, suite.Ctx, 1, sdk.NewInt(1000))
+	addr := testAddresses[0]
+
+	// Set the rollapp packet
+	suite.App.DelayedAckKeeper.SetRollappPacket(suite.Ctx, *rollappPacket)
+
+	// Create new demand order where the recipient is addr
+	demandOrder := types.NewDemandOrder(*rollappPacket, math.NewIntFromUint64(150), math.NewIntFromUint64(50), sdk.DefaultBondDenom, addr.String())
+	err := suite.App.EIBCKeeper.SetDemandOrder(suite.Ctx, demandOrder)
+	suite.Require().NoError(err)
+
+	// try to fulfill the demand order using the same address (addr) as the fulfiller
+	msg := types.NewMsgFulfillOrder(addr.String(), demandOrder.Id, "50")
+	_, err = suite.msgServer.FulfillOrder(suite.Ctx, msg)
+	suite.Require().ErrorIs(err, types.ErrSelfFulfillment)
+}
+

--- a/x/eibc/types/errors.go
+++ b/x/eibc/types/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrFeeTooHigh                   = errorsmod.Register(ModuleName, 11, "Fee must be less than or equal to the total amount")
 	ErrExpectedFeeNotMet            = errorsmod.Register(ModuleName, 12, "Expected fee not met")
 	ErrNegativeFee                  = errorsmod.Register(ModuleName, 13, "Fee must be greater than or equal to 0")
+	ErrSelfFulfillment              = errorsmod.Register(ModuleName, 14, "Fulfiller cannot be the order recipient")
 	ErrMultipleDenoms               = errorsmod.Register(ModuleName, 15, "Multiple denoms not allowed")
 	ErrEmptyPrice                   = errorsmod.Register(ModuleName, 16, "Price must be greater than 0")
 )


### PR DESCRIPTION
### Description
Addresses Issue #710.

Enforces that `msg.FulfillerAddress != demandOrder.Recipient` at the start of `FulfillOrder` in `x/eibc/keeper/msg_server.go` to prevent self-fulfillment by order recipients. Returns `types.ErrSelfFulfillment` if they are equal.

Also registers the new sentinel error `ErrSelfFulfillment` (ID 14) in `x/eibc/types/errors.go` and adds a unit test verifying the guard clause in `x/eibc/keeper/msg_server_test.go`.
