### PR TITLE
fix(wmint): skip zero mint after cap

### DIFF
--- a/x/wmint/abci.go
+++ b/x/wmint/abci.go
@@ -51,6 +51,14 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper, ic mintypes.InflationCalcula
 		mintingUMECAmount = sdk.ZeroInt()
 	}
 
+	if mintingUMECAmount.IsZero() {
+		perBlockMintAmount := k.GetPerBlockMintCoinAmount(ctx)
+		if perBlockMintAmount.Sign() != 0 {
+			k.SetPerBlockMintCoinAmount(ctx, *mintingUMECAmount.BigInt())
+		}
+		return
+	}
+
 	k.SetPerBlockMintCoinAmount(ctx, *mintingUMECAmount.BigInt())
 
 	mintedCoin := sdk.NewCoin(params.BaseDenom, mintingUMECAmount)

--- a/x/wmint/abci_test.go
+++ b/x/wmint/abci_test.go
@@ -176,6 +176,23 @@ func (suite *KeeperTestSuite) TestBeginBlocker() {
 		})
 	}
 }
+
+func (suite *KeeperTestSuite) TestBeginBlockerSkipsZeroMintAfterCap() {
+	ctx := suite.newContextWith(1)
+	suite.wmintKeeper.SetMintedCoinAmount(ctx, *big.NewInt(types.TotalMintCoinsAmount))
+	suite.wmintKeeper.SetPerBlockMintCoinAmount(ctx, *big.NewInt(123))
+
+	BeginBlocker(ctx, suite.wmintKeeper, nil)
+
+	minted := suite.wmintKeeper.GetMintedCoinAmount(ctx)
+	perBlock := suite.wmintKeeper.GetPerBlockMintCoinAmount(ctx)
+	require.Equal(suite.T(), int64(types.TotalMintCoinsAmount), minted.Int64())
+	require.Zero(suite.T(), perBlock.Sign())
+	require.Empty(suite.T(), ctx.EventManager().Events())
+	suite.bankKeeper.AssertNotCalled(suite.T(), "MintCoins")
+	suite.bankKeeper.AssertNotCalled(suite.T(), "SendCoinsFromModuleToModule")
+}
+
 func (suite *KeeperTestSuite) newContextWith(height int64) sdk.Context {
 	return sdk.NewContext(suite.ctx.MultiStore(), tmproto.Header{Time: tmtime.Now(), Height: height}, false, log.NewNopLogger())
 }


### PR DESCRIPTION
## Summary
- Fixes the wmint BeginBlocker zero-mint path after the total supply cap is reached.
- Stops calling MintCoins, SendCoinsToTreasury, mint event emission, and success logging when the computed mint amount is zero.
- Keeps the per-block mint query correct by resetting the stored per-block amount to zero when needed.

## Why
After the cap is reached, the module was still attempting to mint and transfer 0umec every block. That creates unnecessary module calls, events, and runtime work for the rest of chain lifetime.

## Tests
- go test ./x/wmint -run 'TestKeeperTestSuite/TestBeginBlockerSkipsZeroMintAfterCap' -count=1 -v\n- go test ./x/wmint -count=1 -v\n- git diff --check\n\nFixes #261\n\nBounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099