### PR TITLE
fix(delayedack): log hook error in finalizeRollappPacket and proceed (#796)

### DIFF
--- a/x/delayedack/keeper/finalize.go
+++ b/x/delayedack/keeper/finalize.go
@@ -74,9 +74,9 @@ func (k Keeper) finalizeRollappPacket(
 	// Update status to finalized
 	_, err := k.UpdateRollappPacketWithStatus(ctx, rollappPacket, commontypes.Status_FINALIZED)
 	if err != nil {
-		// If we failed finalizing the packet we return an error to abort the end blocker otherwise it's
-		// invariant breaking
-		return err
+		// Log the hook error and proceed. The packet is already marked FINALIZED in the store,
+		// so hook failure is non-fatal for finalization and shouldn't block/wedge the finalization loop.
+		logger.Error("failed to update rollapp packet status: hook error", append(logContext, "error", err.Error())...)
 	}
 
 	logger.Debug("finalized IBC rollapp packet", logContext...)


### PR DESCRIPTION
Fixes the packet finalization loop wedge issue (#796) by logging hook errors in `finalizeRollappPacket` and continuing finalization instead of returning the error, which was previously causing the end blocker to abort and preventing subsequent packet finalization.