### PR TITLE
fix(wgov): fix governance tally bypass issue (#792)

### DIFF
--- a/x/wgov/keeper/tally.go
+++ b/x/wgov/keeper/tally.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 
 // Tally iterates over the votes and updates the tally of a proposal based on the voting power of the
@@ -32,6 +33,7 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 		return false
 	})
 
+	var votersToDelete []sdk.AccAddress
 	keeper.IterateVotes(ctx, proposal.Id, func(vote v1.Vote) bool {
 		// if validator, just record it in the map
 		voter := sdk.MustAccAddressFromBech32(vote.Voter)
@@ -43,32 +45,36 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 		}
 
 		// iterate over all delegations from voter, deduct from any delegated-to validators
-		//keeper.stakingKeeper.IterateStakes(ctx, voter, func(index int64, stake wstakingtypes.Stake) (stop bool) {
-		//	valAddrStr := stake.GetValidatorAddr().String()
-		//
-		//	if val, ok := currValidators[valAddrStr]; ok {
-		//		// There is no need to handle the special case that validator address equal to voter address.
-		//		// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
-		//		val.DelegatorDeductions = val.DelegatorDeductions.Add(stake.GetShares())
-		//		currValidators[valAddrStr] = val
-		//
-		//		// delegation shares * bonded / total shares
-		//		votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
-		//
-		//		for _, option := range vote.Options {
-		//			weight, _ := sdk.NewDecFromStr(option.Weight)
-		//			subPower := votingPower.Mul(weight)
-		//			results[option.Option] = results[option.Option].Add(subPower)
-		//		}
-		//		totalVotingPower = totalVotingPower.Add(votingPower)
-		//	}
-		//
-		//	return false
-		//})
+		keeper.stakingKeeper.IterateStakes(ctx, voter, func(index int64, stake wstakingtypes.Stake) (stop bool) {
+			valAddrStr := stake.GetValidatorAddr().String()
 
-		keeper.DeleteVote(ctx, vote.ProposalId, voter)
+			if val, ok := currValidators[valAddrStr]; ok {
+				// There is no need to handle the special case that validator address equal to voter address.
+				// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
+				val.DelegatorDeductions = val.DelegatorDeductions.Add(stake.GetShares())
+				currValidators[valAddrStr] = val
+
+				// delegation shares * bonded / total shares
+				votingPower := stake.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+
+				for _, option := range vote.Options {
+					weight, _ := sdk.NewDecFromStr(option.Weight)
+					subPower := votingPower.Mul(weight)
+					results[option.Option] = results[option.Option].Add(subPower)
+				}
+				totalVotingPower = totalVotingPower.Add(votingPower)
+			}
+
+			return false
+		})
+
+		votersToDelete = append(votersToDelete, voter)
 		return false
 	})
+
+	for _, voter := range votersToDelete {
+		keeper.DeleteVote(ctx, proposal.Id, voter)
+	}
 
 	// iterate over the validators again to tally their voting power
 	for _, val := range currValidators {
@@ -76,9 +82,8 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 			continue
 		}
 
-		//sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
-		//votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
-		votingPower := sdk.NewDec(1)
+		sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
+		votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
 
 		for _, option := range val.Vote {
 			weight, _ := sdk.NewDecFromStr(option.Weight)
@@ -91,16 +96,13 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 	params := keeper.GetParams(ctx)
 	tallyResults = v1.NewTallyResultFromMap(results)
 
-	// TODO: Upgrade the spec to cover all of these cases & remove pseudocode.
 	// If there is no staked coins, the proposal fails
-	//if keeper.stakingKeeper.TotalBondedStakePool(ctx).IsZero() {
-	//	return false, false, tallyResults
-	//}
-	totalValidatorNumber := len(currValidators)
+	if keeper.stakingKeeper.TotalBondedStakePool(ctx).IsZero() {
+		return false, false, tallyResults
+	}
 
 	// If there is not enough quorum of votes, the proposal fails
-	//percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(keeper.stakingKeeper.TotalBondedStakePool(ctx)))
-	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(sdk.NewInt(int64(totalValidatorNumber))))
+	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(keeper.stakingKeeper.TotalBondedStakePool(ctx)))
 	quorum, _ := sdk.NewDecFromStr(params.Quorum)
 	if percentVoting.LT(quorum) {
 		return false, params.BurnVoteQuorum, tallyResults


### PR DESCRIPTION
This PR fixes the governance tally bypass issue by:
1. Collecting voter addresses in a slice and deleting votes after the IterateVotes loop completes to avoid modifying state during iteration.
2. Calculating voting power using delegation shares/stake instead of hardcoded sdk.NewDec(1).
3. Restoring original quorum calculation based on TotalBondedStakePool instead of validator count.