### PR TITLE
fix(rollapp): enable transfers on successful recv ack

### DIFF
--- a/x/rollapp/transfergenesis/ibc_module.go
+++ b/x/rollapp/transfergenesis/ibc_module.go
@@ -119,11 +119,11 @@ func (w IBCModule) OnRecvPacket(
 	memo, err := getMemo(transfer.GetMemo())
 	if errorsmod.IsOf(err, gerrc.ErrNotFound) {
 		// The first regular transfer marks the full opening of the bridge, more genesis transfers will not be allowed.
-		err := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
-		if err == nil && !ra.GenesisState.TransfersEnabled {
+		ack := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
+		if recvPacketSucceeded(ack) && !ra.GenesisState.TransfersEnabled {
 			w.rollappKeeper.EnableTransfers(ctx, ra.RollappId)
 		}
-		return err
+		return ack
 	}
 	if err != nil {
 		l.Error("Get memo.", "err", err)
@@ -152,6 +152,10 @@ func (w IBCModule) OnRecvPacket(
 
 	// we want to skip delayedack etc because we want the transfer to happen immediately
 	return w.IBCModule.OnRecvPacket(commontypes.SkipRollappMiddlewareContext(ctx), packet, relayer)
+}
+
+func recvPacketSucceeded(ack exported.Acknowledgement) bool {
+	return ack == nil || ack.Success()
 }
 
 func (w IBCModule) handleDRSViolation(ctx sdk.Context, rollappID string) error {

--- a/x/rollapp/transfergenesis/ibc_module_test.go
+++ b/x/rollapp/transfergenesis/ibc_module_test.go
@@ -1,0 +1,15 @@
+package transfergenesis
+
+import (
+	"errors"
+	"testing"
+
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecvPacketSucceeded(t *testing.T) {
+	require.True(t, recvPacketSucceeded(nil))
+	require.True(t, recvPacketSucceeded(channeltypes.NewResultAcknowledgement([]byte("ok"))))
+	require.False(t, recvPacketSucceeded(channeltypes.NewErrorAcknowledgement(errors.New("failed"))))
+}


### PR DESCRIPTION
## Summary
- Fixes transfergenesis `OnRecvPacket` so a successful IBC acknowledgement opens rollapp transfers.
- Treats both nil acknowledgements and `ack.Success()` acknowledgements as successful receive paths.
- Adds focused coverage for success/error acknowledgement classification.

## Why
The previous code checked `ack == nil` before calling `EnableTransfers`. Normal successful IBC receive handlers return a non-nil result acknowledgement, so a valid receive path could skip bridge opening and leave transfers disabled.

## Tests
- go test ./x/rollapp/transfergenesis -count=1 -v
- go test ./x/rollapp/... -run TestRecvPacketSucceeded -count=1 -v
- git diff --check

Fixes #673

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099