### PR TITLE
fix(did): persist partial filter logger deletions

### DIFF
--- a/x/did/keeper/filter.go
+++ b/x/did/keeper/filter.go
@@ -57,7 +57,10 @@ func (k Keeper) DeleteFilters(ctx sdk.Context, did, sid string, filters [][]byte
 	// delete empty FilterLogger
 	if len(flog.Filters) == 0 {
 		k.DeleteFilterLogger(ctx, did, sid)
+		return
 	}
+
+	k.SetFilterLogger(ctx, did, sid, flog)
 }
 
 /*

--- a/x/did/keeper/filter_test.go
+++ b/x/did/keeper/filter_test.go
@@ -47,3 +47,36 @@ func TestKeeper_Filter(t *testing.T) {
 	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f2, &pr)
 	assert.Equal(t, 0, len(vcs))
 }
+
+func TestKeeper_DeleteFiltersPersistsPartialLogger(t *testing.T) {
+	k, ctx := keeper.DidKeeper(t)
+
+	did := "1000000000000001"
+	sid := "test"
+	vc := didtypes.Credential{
+		Did:  did,
+		Sid:  sid,
+		Hash: "FF000000000000000000",
+		Uri:  "https://www.example.com",
+		Data: []byte("this is test data"),
+	}
+
+	f1 := []byte("fs1")
+	f2 := []byte("fs2")
+	f3 := []byte("fs3")
+	k.AddFilters(ctx, did, sid, [][]byte{f1, f2, f3}, vc)
+
+	k.DeleteFilters(ctx, did, sid, [][]byte{f2})
+
+	fs, found := k.GetFilters(ctx, did, sid)
+	assert.True(t, found)
+	assert.Equal(t, [][]byte{f1, f3}, fs)
+
+	pr := query.PageRequest{}
+	vcs, _, _ := k.GetCredentialsByFilter(ctx, sid, f1, &pr)
+	assert.Equal(t, 1, len(vcs))
+	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f2, &pr)
+	assert.Equal(t, 0, len(vcs))
+	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f3, &pr)
+	assert.Equal(t, 1, len(vcs))
+}


### PR DESCRIPTION
## Summary
- Persist the updated `FilterLogger` when `DeleteFilters` removes only part of the tracked filters.
- Keep deleting the logger when all filters are removed.
- Add a regression test proving partial deletion removes the selected filter index while retaining the remaining logger entries.

## Why
`DeleteFilters` updated the logger in memory but only deleted it when empty. Partial deletions were not written back to store, leaving stale logger entries after the actual filter index was removed.

## Tests
- go test ./x/did/keeper -run 'TestKeeper_(Filter|DeleteFiltersPersistsPartialLogger)' -count=1 -v\n- go test ./x/did/keeper -count=1 -v\n- git diff --check\n\nFixes #670\n\nBounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099