### PR TITLE
fix(rollapp): preserve frozen client height order

### DIFF
--- a/x/rollapp/keeper/fraud_handler.go
+++ b/x/rollapp/keeper/fraud_handler.go
@@ -97,10 +97,14 @@ func (k Keeper) freezeClientState(ctx sdk.Context, clientId string) error {
 		return errorsmod.Wrapf(types.ErrInvalidClientState, "client state with ID %s is not a tendermint client state", clientId)
 	}
 
-	tmClientState.FrozenHeight = clienttypes.NewHeight(tmClientState.GetLatestHeight().GetRevisionHeight(), tmClientState.GetLatestHeight().GetRevisionNumber())
+	tmClientState.FrozenHeight = frozenHeightFromLatest(tmClientState)
 	k.ibcClientKeeper.SetClientState(ctx, clientId, tmClientState)
 
 	return nil
+}
+
+func frozenHeightFromLatest(tmClientState *cometbfttypes.ClientState) clienttypes.Height {
+	return tmClientState.LatestHeight
 }
 
 // revert all pending states of a rollapp

--- a/x/rollapp/keeper/fraud_handler_internal_test.go
+++ b/x/rollapp/keeper/fraud_handler_internal_test.go
@@ -1,0 +1,20 @@
+package keeper
+
+import (
+	"testing"
+
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	cometbfttypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrozenHeightFromLatestPreservesRevisionOrder(t *testing.T) {
+	latest := clienttypes.NewHeight(2, 1234)
+	clientState := &cometbfttypes.ClientState{LatestHeight: latest}
+
+	frozen := frozenHeightFromLatest(clientState)
+
+	require.Equal(t, latest, frozen)
+	require.Equal(t, uint64(2), frozen.RevisionNumber)
+	require.Equal(t, uint64(1234), frozen.RevisionHeight)
+}


### PR DESCRIPTION
## Summary
- Set Tendermint client `FrozenHeight` directly from `LatestHeight` during rollapp fraud handling.
- Avoid rebuilding the height with swapped `revisionNumber` / `revisionHeight` arguments.
- Add regression coverage for preserving the revision order.

## Why
`clienttypes.NewHeight` expects `(revisionNumber, revisionHeight)`, but `freezeClientState` passed the values in the opposite order. That stored nonsensical frozen heights after fraud handling, such as revision number 1234 and revision height 2 instead of 2/1234.

## Tests
- go test ./x/rollapp/keeper -run TestFrozenHeightFromLatestPreservesRevisionOrder -count=1 -v
- go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestHandleFraud$' -count=1 -v\n- git diff --check\n\nFixes #520\n\nBounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099