### PR TITLE
fix(wstaking): execute remove region message

### DIFF
--- a/x/wstaking/keeper/msg_server_region.go
+++ b/x/wstaking/keeper/msg_server_region.go
@@ -116,28 +116,35 @@ func (k MsgServer) NewRegion(goCtx context.Context, msg *types.MsgNewRegion) (*t
 }
 
 func (k MsgServer) RemoveRegion(goCtx context.Context, msg *types.MsgRemoveRegion) (*types.MsgRemoveRegionResponse, error) {
-	// ctx := sdk.UnwrapSDKContext(goCtx)
+	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	// if !k.daoKeeper.IsGlobalDao(ctx, msg.Creator) {
-	// 	return nil, types.ErrCheckGlobalDao
-	// }
+	if !k.daoKeeper.IsGlobalDao(ctx, msg.Creator) {
+		return nil, types.ErrCheckGlobalDao
+	}
 
-	// _, found := k.GetRegion(ctx, msg.RegionId)
-	// if !found {
-	// 	return nil, types.ErrRegionNotExist
-	// }
+	regionId := strings.ToLower(msg.RegionId)
+	if _, found := k.GetRegion(ctx, regionId); !found {
+		return nil, types.ErrRegionNotExist
+	}
 
-	// err := k.WstakingHooks().BeforeValidatorStakingModified(ctx, sdk.ValAddress{})
-	// if err != nil {
-	// 	return nil, sdkerrors.Wrapf(types.ErrHooks, "before remove region :error :%+v", err)
-	// }
-	// k.Keeper.RemoveRegion(ctx, msg.RegionId)
-	// ctx.EventManager().EmitEvent(
-	// 	sdk.NewEvent(
-	// 		types.EventTypeRemoveRegion,
-	// 		sdk.NewAttribute(types.AttributeKeyRegionId, msg.RegionId),
-	// 	),
-	// )
+	err := k.WstakingHooks().BeforeValidatorStakingModified(ctx, sdk.ValAddress{})
+	if err != nil {
+		return nil, sdkerrors.Wrapf(types.ErrHooks, "before remove region :error :%+v", err)
+	}
+
+	if groupId, found := k.groupKeeper.GetGroupIdByRegion(ctx, regionId); found {
+		k.groupKeeper.DeleteGroupAssociateWithRegion(ctx, regionId)
+		k.groupKeeper.RemoveGroup(ctx, groupId)
+		k.groupKeeper.RemoveGroupMemberCount(ctx, groupId)
+	}
+	k.Keeper.RemoveRegion(ctx, regionId)
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeRemoveRegion,
+			sdk.NewAttribute(types.AttributeKeyRegionId, regionId),
+		),
+	)
+
 	return &types.MsgRemoveRegionResponse{}, nil
 }
 

--- a/x/wstaking/keeper/msg_server_region_test.go
+++ b/x/wstaking/keeper/msg_server_region_test.go
@@ -109,6 +109,8 @@ func (s *KeeperTestSuite) TestRemoveRegion() {
 		RegionId: "usa",
 	})
 	s.Require().ErrorIs(err, types.ErrCheckGlobalDao)
+	_, found := s.App.StakingKeeper.GetRegion(s.Ctx, "usa")
+	s.Require().True(found)
 
 	// must no error
 	_, err = s.msgServer.RemoveRegion(s.Ctx, &types.MsgRemoveRegion{
@@ -116,6 +118,7 @@ func (s *KeeperTestSuite) TestRemoveRegion() {
 		RegionId: "usa",
 	})
 	s.Require().NoError(err)
+	s.Require().True(s.hasEvent(types.EventTypeRemoveRegion))
 
 	// must error
 	_, err = s.queryClient.Region(s.Ctx, &types.QueryRegionRequest{RegionId: "usa"})
@@ -401,4 +404,13 @@ func (s *KeeperTestSuite) TestRevokeRegionWithdraw() {
 			}
 		})
 	}
+}
+
+func (s *KeeperTestSuite) hasEvent(eventType string) bool {
+	for _, event := range s.Ctx.EventManager().Events() {
+		if event.Type == eventType {
+			return true
+		}
+	}
+	return false
 }

--- a/x/wstaking/types/expected_keepers.go
+++ b/x/wstaking/types/expected_keepers.go
@@ -70,4 +70,8 @@ type DidKeeper interface {
 type GroupKeeper interface {
 	CreateGroupByRegion(sdkCtx sdk.Context, regionInfo Region) (uint64, error)
 	UpdateGroupAdmin(ctx sdk.Context, regionID string, admin string)
+	GetGroupIdByRegion(ctx sdk.Context, regionID string) (uint64, bool)
+	DeleteGroupAssociateWithRegion(ctx sdk.Context, regionID string)
+	RemoveGroup(ctx sdk.Context, id uint64)
+	RemoveGroupMemberCount(ctx sdk.Context, groupId uint64)
 }


### PR DESCRIPTION
## Summary
- Restore `MsgRemoveRegion` authorization and existence checks.
- Remove the region from state instead of returning a misleading no-op success.
- Clean the region-created MEGroup mapping/group/count so the region can be recreated cleanly.
- Emit `remove_region` after successful removal.

## Why
`MsgRemoveRegion` had its business logic commented out and always returned success. That let non-DAO callers receive a successful response while leaving the region unchanged.

## Tests
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestRemoveRegion' -count=1 -v\n- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/Test(NewRegion|RemoveRegion|GrantRegionWithdraw|RevokeRegionWithdraw)' -count=1 -v\n- go test ./x/wstaking/keeper -run '^$' -count=1\n- git diff --check\n\n## Baseline note\nA broader run including `TestWithdrawFromRegion` still fails on an existing expectation mismatch: the current code returns generic `unauthorized` for a non-granted non-DAO withdrawer, while the test expects `ErrCheckGlobalDao`. This is outside the RemoveRegion handler path.\n\nFixes #294\n\nBounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099