### PR TITLE
fix(tron): avoid panics on invalid addresses

### DIFF
--- a/x/tron/types/address.go
+++ b/x/tron/types/address.go
@@ -22,7 +22,7 @@ func (b TronAddress) ValidateExternalAddr(addr string) error {
 func (b TronAddress) ExternalAddrToAccAddr(addr string) sdk.AccAddress {
 	tronAddr, err := tronaddress.Base58ToAddress(addr)
 	if err != nil {
-		panic(err)
+		return nil
 	}
 	return tronAddr.Bytes()[1:]
 }
@@ -30,7 +30,7 @@ func (b TronAddress) ExternalAddrToAccAddr(addr string) sdk.AccAddress {
 func (b TronAddress) ExternalAddrToHexAddr(addr string) gethcommon.Address {
 	tronAddr, err := tronaddress.Base58ToAddress(addr)
 	if err != nil {
-		panic(err)
+		return gethcommon.Address{}
 	}
 	return gethcommon.BytesToAddress(tronAddr.Bytes()[1:])
 }

--- a/x/tron/types/address_test.go
+++ b/x/tron/types/address_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/openmetaearth/me-hub/x/tron/types"
 	"github.com/stretchr/testify/require"
 )
@@ -61,4 +62,36 @@ func TestValidateTronAddress(t *testing.T) {
 			require.EqualValues(t, testCase.errStr, err.Error(), testCase.value)
 		})
 	}
+}
+
+func TestTronAddressExternalConversionsDoNotPanicOnInvalidInput(t *testing.T) {
+	tronAddr := types.TronAddress{}
+
+	testCases := []string{
+		"",
+		"invalid_address",
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				require.Nil(t, tronAddr.ExternalAddrToAccAddr(testCase))
+			})
+			require.NotPanics(t, func() {
+				require.Equal(t, gethcommon.Address{}, tronAddr.ExternalAddrToHexAddr(testCase))
+			})
+		})
+	}
+}
+
+func TestTronAddressExternalConversionsValidInput(t *testing.T) {
+	tronAddr := types.TronAddress{}
+	addr := "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+
+	accAddr := tronAddr.ExternalAddrToAccAddr(addr)
+	hexAddr := tronAddr.ExternalAddrToHexAddr(addr)
+
+	require.Len(t, accAddr, gethcommon.AddressLength)
+	require.NotEqual(t, gethcommon.Address{}, hexAddr)
+	require.Equal(t, []byte(accAddr), hexAddr.Bytes())
 }


### PR DESCRIPTION
## Summary
- Stop `TronAddress.ExternalAddrToAccAddr` from panicking on invalid Base58 input.
- Stop `TronAddress.ExternalAddrToHexAddr` from panicking on invalid Base58 input.
- Return zero values for invalid conversions while keeping `ValidateExternalAddr` as the validation path.
- Add regression tests for empty, malformed, and valid Tron addresses.

## Why
The gravity external address router can call these conversion methods after separate validation paths. A malformed Tron address should not be able to crash the process by reaching a conversion helper.

## Tests
- go test ./x/tron/types -count=1 -v
- git diff --check

Fixes #262

Bounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099