### PR TITLE
fix(kyc): reject protocol region writes

### DIFF
--- a/x/kyc/keeper/grpc_query_test.go
+++ b/x/kyc/keeper/grpc_query_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/kyc/types"
@@ -32,6 +33,34 @@ func (s *KeeperTestSuite) TestProtocol() {
 	s.Require().Equal(len(res.Protocol.Service.Issuers), len(genesis.Issuers))
 	s.Require().Equal(res.Protocol.Service.Status, didtypes.SERVICE_STATUS_ACTIVE)
 	s.Require().Equal(len(res.Protocol.Regions), 0)
+}
+
+func (s *KeeperTestSuite) TestSetProtocolRejectsRegions() {
+	s.SetupTest()
+
+	svc := didtypes.Service{
+		Sid:  types.ModuleName,
+		Name: "updated-kyc",
+	}
+	err := s.Keeper().SetProtocol(s.Ctx, types.Protocol{Service: svc})
+	s.Require().NoError(err)
+
+	gotSvc, found := s.Keeper().GetService(s.Ctx)
+	s.Require().True(found)
+	s.Require().Equal("updated-kyc", gotSvc.Name)
+
+	err = s.Keeper().SetProtocol(s.Ctx, types.Protocol{
+		Service: didtypes.Service{
+			Sid:  types.ModuleName,
+			Name: "must-not-overwrite",
+		},
+		Regions: []types.Region{{Id: "custom", Name: "Custom"}},
+	})
+	s.Require().ErrorIs(err, sdkerrors.ErrInvalidRequest)
+
+	gotSvc, found = s.Keeper().GetService(s.Ctx)
+	s.Require().True(found)
+	s.Require().Equal("updated-kyc", gotSvc.Name)
 }
 
 func (s *KeeperTestSuite) TestDID() {

--- a/x/kyc/keeper/protocol.go
+++ b/x/kyc/keeper/protocol.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/kyc/types"
 )
@@ -43,6 +44,14 @@ func (k *Keeper) GetProtocol(ctx sdk.Context) (types.Protocol, bool) {
 	return types.Protocol{Service: svc, Regions: regions}, true
 }
 
-func (k *Keeper) SetProtocol(ctx sdk.Context, proto types.Protocol) {
+func (k *Keeper) SetProtocol(ctx sdk.Context, proto types.Protocol) error {
+	if len(proto.Regions) != 0 {
+		return sdkerrors.Wrap(
+			sdkerrors.ErrInvalidRequest,
+			"kyc protocol regions are derived from staking and cannot be set through SetProtocol",
+		)
+	}
+
 	k.SetService(ctx, proto.Service)
+	return nil
 }


### PR DESCRIPTION
## Summary
- Make `SetProtocol` return an error instead of silently discarding non-empty `Regions`.
- Keep the existing service update path for protocols with no regions.
- Add a regression test proving rejected region writes do not overwrite the stored service.

## Why
KYC protocol regions are derived from the staking module. The previous `SetProtocol(ctx, Protocol)` API accepted `Regions` but ignored them with no error, which made callers believe region updates had been persisted.

## Tests
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestSetProtocolRejectsRegions' -count=1 -v\n- go test ./x/kyc/keeper -run '^$' -count=1\n- git diff --check\n\n## Baseline note\nRunning `go test ./x/kyc/keeper -run 'TestKeeperTestSuite/Test(Protocol|SetProtocolRejectsRegions)$' -count=1 -v` still fails in the existing `TestProtocol` issuer-count assertion: expected 1, actual 0. The new SetProtocol regression test passes.\n\nFixes #243\n\nBounty payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099