### PR TITLE
fix(gravity): remove BSC fallback from routed queries

### DIFF
--- a/x/gravity/keeper/grpc_query_router.go
+++ b/x/gravity/keeper/grpc_query_router.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	bsctypes "github.com/openmetaearth/me-hub/x/bsc/types"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -219,16 +218,12 @@ func (k RouterKeeper) ClaimsByEventNonce(c context.Context, req *types.QueryClai
 	}
 }
 
-func (k RouterKeeper) BridgeChainList(c context.Context, req *types.QueryBridgeChainListRequest) (*types.QueryBridgeChainListResponse, error) {
-	if queryServer, err := k.getQueryServerByChainName(bsctypes.ModuleName); err != nil {
-		return nil, err
-	} else {
-		return queryServer.BridgeChainList(c, req)
-	}
+func (k RouterKeeper) BridgeChainList(_ context.Context, _ *types.QueryBridgeChainListRequest) (*types.QueryBridgeChainListResponse, error) {
+	return &types.QueryBridgeChainListResponse{ChainNames: types.GetSupportChains()}, nil
 }
 
 func (k RouterKeeper) LastObservedRelayer(c context.Context, req *types.QueryLastObservedRelayer) (*types.QueryLastObservedRelayerResponse, error) {
-	if queryServer, err := k.getQueryServerByChainName(bsctypes.ModuleName); err != nil {
+	if queryServer, err := k.getQueryServerByChainName(req.ChainName); err != nil {
 		return nil, err
 	} else {
 		return queryServer.LastObservedRelayer(c, req)

--- a/x/gravity/keeper/grpc_query_router_test.go
+++ b/x/gravity/keeper/grpc_query_router_test.go
@@ -1,0 +1,68 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	bsctypes "github.com/openmetaearth/me-hub/x/bsc/types"
+	"github.com/openmetaearth/me-hub/x/gravity/keeper"
+	gravitytypes "github.com/openmetaearth/me-hub/x/gravity/types"
+	trontypes "github.com/openmetaearth/me-hub/x/tron/types"
+)
+
+type routerQueryServer struct {
+	gravitytypes.UnimplementedQueryServer
+
+	relayerSet *gravitytypes.RelayerSet
+	calls      int
+}
+
+func (s *routerQueryServer) LastObservedRelayer(
+	_ context.Context,
+	_ *gravitytypes.QueryLastObservedRelayer,
+) (*gravitytypes.QueryLastObservedRelayerResponse, error) {
+	s.calls++
+	return &gravitytypes.QueryLastObservedRelayerResponse{RelayerSet: s.relayerSet}, nil
+}
+
+func TestRouterKeeperBridgeChainListDoesNotRequireBscRoute(t *testing.T) {
+	rtr := keeper.NewRouter()
+	rtr.AddRoute(trontypes.ModuleName, &keeper.ModuleHandler{
+		QueryServer: &routerQueryServer{},
+	})
+
+	routerKeeper := keeper.NewRouterKeeper(rtr)
+	res, err := routerKeeper.BridgeChainList(context.Background(), &gravitytypes.QueryBridgeChainListRequest{})
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, gravitytypes.GetSupportChains(), res.ChainNames)
+}
+
+func TestRouterKeeperLastObservedRelayerRoutesByRequestChainName(t *testing.T) {
+	bscServer := &routerQueryServer{
+		relayerSet: &gravitytypes.RelayerSet{Nonce: 1},
+	}
+	tronServer := &routerQueryServer{
+		relayerSet: &gravitytypes.RelayerSet{Nonce: 2},
+	}
+	rtr := keeper.NewRouter()
+	rtr.AddRoute(bsctypes.ModuleName, &keeper.ModuleHandler{
+		QueryServer: bscServer,
+	})
+	rtr.AddRoute(trontypes.ModuleName, &keeper.ModuleHandler{
+		QueryServer: tronServer,
+	})
+
+	routerKeeper := keeper.NewRouterKeeper(rtr)
+	res, err := routerKeeper.LastObservedRelayer(
+		context.Background(),
+		&gravitytypes.QueryLastObservedRelayer{ChainName: trontypes.ModuleName},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), res.RelayerSet.Nonce)
+	require.Zero(t, bscServer.calls)
+	require.Equal(t, 1, tronServer.calls)
+}


### PR DESCRIPTION
Fixes #240.

## What changed
- `BridgeChainList` now returns the registered supported chains directly instead of resolving the BSC query server. This avoids failing or depending on BSC for a chain-agnostic request.
- `LastObservedRelayer` now resolves the backend query server with `req.ChainName`, matching the other routed gravity queries.
- Added focused router tests for the no-BSC `BridgeChainList` path and TRON `LastObservedRelayer` routing.

## Local tests
- `go test ./x/gravity/keeper -run 'TestRouterKeeper(BridgeChainListDoesNotRequireBscRoute|LastObservedRelayerRoutesByRequestChainName)' -count=1 -v`\n- `go test ./x/gravity/keeper -run '^$' -count=1`\n- `git diff --check`\n\nBug bounty wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`