### PR TITLE
fix(rollapp): require success ack before opening transfers

### DIFF
--- a/x/rollapp/transfergenesis/ibc_module.go
+++ b/x/rollapp/transfergenesis/ibc_module.go
@@ -119,11 +119,11 @@ func (w IBCModule) OnRecvPacket(
 	memo, err := getMemo(transfer.GetMemo())
 	if errorsmod.IsOf(err, gerrc.ErrNotFound) {
 		// The first regular transfer marks the full opening of the bridge, more genesis transfers will not be allowed.
-		err := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
-		if err == nil && !ra.GenesisState.TransfersEnabled {
+		ack := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
+		if shouldEnableTransfersOnRecvAck(ack, ra.GenesisState.TransfersEnabled) {
 			w.rollappKeeper.EnableTransfers(ctx, ra.RollappId)
 		}
-		return err
+		return ack
 	}
 	if err != nil {
 		l.Error("Get memo.", "err", err)
@@ -152,6 +152,10 @@ func (w IBCModule) OnRecvPacket(
 
 	// we want to skip delayedack etc because we want the transfer to happen immediately
 	return w.IBCModule.OnRecvPacket(commontypes.SkipRollappMiddlewareContext(ctx), packet, relayer)
+}
+
+func shouldEnableTransfersOnRecvAck(ack exported.Acknowledgement, transfersEnabled bool) bool {
+	return ack != nil && ack.Success() && !transfersEnabled
 }
 
 func (w IBCModule) handleDRSViolation(ctx sdk.Context, rollappID string) error {

--- a/x/rollapp/transfergenesis/ibc_module_test.go
+++ b/x/rollapp/transfergenesis/ibc_module_test.go
@@ -1,0 +1,47 @@
+package transfergenesis
+
+import (
+	"errors"
+	"testing"
+
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldEnableTransfersOnRecvAck(t *testing.T) {
+	tests := []struct {
+		name             string
+		ack              exported.Acknowledgement
+		transfersEnabled bool
+		want             bool
+	}{
+		{
+			name: "pending nil ack does not enable transfers",
+			ack:  nil,
+			want: false,
+		},
+		{
+			name: "success ack enables transfers",
+			ack:  channeltypes.NewResultAcknowledgement([]byte{1}),
+			want: true,
+		},
+		{
+			name: "error ack does not enable transfers",
+			ack:  channeltypes.NewErrorAcknowledgement(errors.New("recv failed")),
+			want: false,
+		},
+		{
+			name:             "already enabled stays unchanged",
+			ack:              channeltypes.NewResultAcknowledgement([]byte{1}),
+			transfersEnabled: true,
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldEnableTransfersOnRecvAck(tt.ack, tt.transfersEnabled))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #287.

## What changed
- Treat `nil` OnRecvPacket acknowledgement as pending/asynchronous, not final success.
- Enable RollApp transfers only when the downstream acknowledgement is non-nil, successful, and transfers are not already enabled.
- Preserve the existing behavior for explicit success acknowledgements.

## Why
In ibc-go, `nil` acknowledgement can represent asynchronous acknowledgement handling. The transfer genesis middleware should not open regular transfers until the receive path has explicit successful acknowledgement.

## Local tests
- `go test ./x/rollapp/transfergenesis -run TestShouldEnableTransfersOnRecvAck -count=1 -v`
- `go test ./x/rollapp/transfergenesis -count=1 -v`
- `git diff --check`

Bug bounty wallet: `0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`