### PR TITLE
fix(did): revoke KYC-derived state when disabling DID

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -451,6 +451,7 @@ func (a *AppKeepers) InitKeepers(
 		a.KycKeeper,
 	)
 	a.StakingKeeper.SetGroupKeeper(a.GroupKeeper)
+	a.DidKeeper.SetHooks(didtypes.NewMultiDidHooks(a.KycKeeper))
 
 	a.BscKeeper = gravitykeeper.NewKeeper(
 		bsctypes.ModuleName,

--- a/x/did/keeper/keeper.go
+++ b/x/did/keeper/keeper.go
@@ -14,6 +14,7 @@ type Keeper struct {
 	cdc       codec.Codec
 	storeKey  storetypes.StoreKey
 	daoKeeper types.DaoKeeper
+	hooks     types.DidHooks
 }
 
 func NewKeeper(
@@ -26,6 +27,20 @@ func NewKeeper(
 		storeKey:  storeKey,
 		daoKeeper: daoKeeper,
 	}
+}
+
+func (k *Keeper) SetHooks(hooks types.DidHooks) {
+	if k.hooks != nil {
+		panic("did hooks already set")
+	}
+	k.hooks = hooks
+}
+
+func (k Keeper) Hooks() types.DidHooks {
+	if k.hooks == nil {
+		return types.MultiDidHooks{}
+	}
+	return k.hooks
 }
 
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {

--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -46,6 +46,9 @@ func (m msgServer) UpdateDidStatus(goCtx context.Context, msg *types.MsgUpdateDi
 	m.SetDidInfo(ctx, info.Did, info)
 
 	ctx.EventManager().EmitEvent(types.NewDidEvent(types.EventTypeUpdateDidStatus, info.Did, info.Address, info.Status.String()))
+	if err := m.Hooks().AfterDidStatusUpdated(ctx, info); err != nil {
+		return &types.MsgUpdateDidStatusResponse{}, errors.Wrap(types.ErrHooks, err.Error())
+	}
 	return &types.MsgUpdateDidStatusResponse{}, nil
 }
 

--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -14,6 +14,7 @@ var (
 	ErrDidNotFound   = errors.Register(ModuleName, 111, "DID not found")
 	ErrDidNotActive  = errors.Register(ModuleName, 112, "DID not active")
 	ErrSameDidStatus = errors.Register(ModuleName, 113, "same DID status")
+	ErrHooks         = errors.Register(ModuleName, 114, "hooks error")
 
 	ErrServiceExists     = errors.Register(ModuleName, 120, "credential service already exists")
 	ErrServiceNotFound   = errors.Register(ModuleName, 121, "credential service not found")

--- a/x/did/types/hooks.go
+++ b/x/did/types/hooks.go
@@ -1,0 +1,22 @@
+package types
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+type DidHooks interface {
+	AfterDidStatusUpdated(ctx sdk.Context, info DidInfo) error
+}
+
+type MultiDidHooks []DidHooks
+
+func NewMultiDidHooks(hooks ...DidHooks) MultiDidHooks {
+	return hooks
+}
+
+func (h MultiDidHooks) AfterDidStatusUpdated(ctx sdk.Context, info DidInfo) error {
+	for i := range h {
+		if err := h[i].AfterDidStatusUpdated(ctx, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/x/kyc/keeper/did_hooks.go
+++ b/x/kyc/keeper/did_hooks.go
@@ -1,0 +1,58 @@
+package keeper
+
+import (
+	"cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	"github.com/openmetaearth/me-hub/x/kyc/types"
+)
+
+func (k Keeper) AfterDidStatusUpdated(ctx sdk.Context, info didtypes.DidInfo) error {
+	if info.Status != didtypes.DID_STATUS_INACTIVE {
+		return nil
+	}
+	return k.revokeKycForDid(ctx, info)
+}
+
+func (k Keeper) revokeKycForDid(ctx sdk.Context, didInfo didtypes.DidInfo) error {
+	kyc, found := k.GetKYC(ctx, didInfo.Did)
+	regionID := didInfo.RegionId
+	if found && len(kyc.Data) > 0 {
+		regionID = string(kyc.Data)
+	}
+
+	didInfo.RegionId = ""
+	didInfo.KycLevel = didtypes.KYC_LEVEL_NONE
+	didInfo.Status = didtypes.DID_STATUS_INACTIVE
+	k.SetDidInfo(ctx, didInfo.Did, didInfo)
+
+	if !found {
+		return nil
+	}
+
+	k.DeleteKYC(ctx, didInfo.Did)
+
+	filters, _ := k.GetFilters(ctx, didInfo.Did)
+	if len(filters) > 0 {
+		k.DeleteFilters(ctx, didInfo.Did, filters)
+	}
+
+	if didInfo.Address != "" && regionID != "" {
+		if err := k.DeleteApproveReward(ctx, didInfo.Address, regionID); err != nil {
+			return errors.Wrap(err, "delete reward failed")
+		}
+	}
+
+	event := sdk.NewEvent(
+		types.EventTypeRemove,
+		sdk.NewAttribute(types.AttributeKeyAddress, didInfo.Address),
+		sdk.NewAttribute(types.AttributeKeyRegionId, regionID),
+	)
+	ctx.EventManager().EmitEvent(event)
+
+	return k.handlerReg.HandleEvent(sdk.WrapSDKContext(ctx), types.EventTypeRemove, event)
+}
+
+var _ interface {
+	AfterDidStatusUpdated(sdk.Context, didtypes.DidInfo) error
+} = Keeper{}

--- a/x/kyc/keeper/msg_server.go
+++ b/x/kyc/keeper/msg_server.go
@@ -219,26 +219,11 @@ func (m msgServer) Remove(goCtx context.Context, msg *types.MsgRemove) (*types.M
 	if !found {
 		return &types.MsgRemoveResponse{}, didtypes.ErrHolderNotFound
 	}
-	didInfo.RegionId = ""
-	didInfo.KycLevel = 0
-	didInfo.Status = didtypes.DID_STATUS_INACTIVE
-	m.SetDidInfo(ctx, msg.Did, didInfo)
-
-	// delete KYC
-	kyc, found := m.GetKYC(ctx, msg.Did)
-	if !found {
+	if !m.HasKYC(ctx, msg.Did) {
 		return &types.MsgRemoveResponse{}, didtypes.ErrCredentialNotFound
 	}
-	m.DeleteKYC(ctx, msg.Did)
-
-	// delete KYC region filter
-	filters, _ := m.GetFilters(ctx, msg.Did)
-	m.DeleteFilters(ctx, msg.Did, filters)
-
-	// cancel reward
-	address := sdk.MustAccAddressFromBech32(didInfo.Address)
-	if err := m.DeleteApproveReward(ctx, address.String(), string(kyc.Data)); err != nil {
-		return &types.MsgRemoveResponse{}, errors.Wrap(err, "delete reward failed")
+	if err := m.revokeKycForDid(ctx, didInfo); err != nil {
+		return &types.MsgRemoveResponse{}, err
 	}
 
 	return &types.MsgRemoveResponse{}, nil

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -6,7 +6,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	"github.com/openmetaearth/me-hub/app/params"
+	didkeeper "github.com/openmetaearth/me-hub/x/did/keeper"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/kyc/types"
+	groupkeeper "github.com/openmetaearth/me-hub/x/megroup/keeper"
+	megrouptypes "github.com/openmetaearth/me-hub/x/megroup/types"
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
 	wmintTypes "github.com/openmetaearth/me-hub/x/wmint/types"
@@ -112,6 +116,72 @@ func (s *KeeperTestSuite) TestRemove() {
 	// check kyc
 	_, f = s.Keeper().GetKYC(s.Ctx, did)
 	s.Require().False(f)
+}
+
+func (s *KeeperTestSuite) TestUpdateDidStatusInactiveClearsKycDerivedGroupState() {
+	s.SetupTest()
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	kycAccount, newUserPubkey := s.NewAccount()
+	did := "did-status-inactive-member"
+	regionID := strings.ToLower(wstakingtypes.MeEarthRegionName)
+	inviter, _ := s.NewAccount()
+
+	_, err := s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: regionID,
+		Address:  kycAccount.String(),
+		Pubkey:   newUserPubkey,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "aaaa",
+		Inviter:  inviter.String(),
+		Level:    didtypes.KYC_LEVEL_TWO,
+	})
+	s.Require().NoError(err)
+
+	groupID, found := s.App.GroupKeeper.GetGroupIdByRegion(s.Ctx, regionID)
+	s.Require().True(found)
+	groupMsgServer := groupkeeper.NewMsgServerImpl(*s.App.GroupKeeper)
+	_, err = groupMsgServer.JoinGroup(s.Ctx, &megrouptypes.MsgJoinGroup{
+		Creator:          kycAccount.String(),
+		GroupId:          groupID,
+		ApplicantAddress: kycAccount.String(),
+	})
+	s.Require().NoError(err)
+
+	joined, found := s.App.GroupKeeper.GetMemberJoined(s.Ctx, kycAccount.String())
+	s.Require().True(found)
+	s.Require().Equal(groupID, joined.GroupId)
+
+	didMsgServer := didkeeper.NewMsgServerImpl(s.App.DidKeeper)
+	_, err = didMsgServer.UpdateDidStatus(s.Ctx, didtypes.NewMsgUpdateDidStatus(
+		s.Dao.GlobalDao,
+		did,
+		didtypes.DID_STATUS_INACTIVE,
+	))
+	s.Require().NoError(err)
+
+	info, found := s.App.DidKeeper.GetDidInfo(s.Ctx, did)
+	s.Require().True(found)
+	s.Require().Equal(didtypes.DID_STATUS_INACTIVE, info.Status)
+	s.Require().Empty(info.RegionId)
+	s.Require().Equal(didtypes.KYC_LEVEL_NONE, info.KycLevel)
+
+	_, found = s.Keeper().GetKYC(s.Ctx, did)
+	s.Require().False(found)
+	s.Require().NotEqual(regionID, s.App.StakingKeeper.GetRegionIdByAccount(s.Ctx, kycAccount))
+
+	joined, found = s.App.GroupKeeper.GetMemberJoined(s.Ctx, kycAccount.String())
+	s.Require().True(found)
+	s.Require().Zero(joined.GroupId)
+
+	groupCount, found := s.App.GroupKeeper.GetGroupMemberCount(s.Ctx, groupID)
+	s.Require().True(found)
+	s.Require().Zero(groupCount)
 }
 
 func (s *KeeperTestSuite) TestUpdate() {

--- a/x/megroup/keeper/keeper.go
+++ b/x/megroup/keeper/keeper.go
@@ -64,6 +64,7 @@ func NewKeeper(
 		kycKeeper:     kycKeeper,
 	}
 	keeperVal.kycKeeper.RegisterEventHandler(kycTypes.EventTypeUpdate, 0, types.ModuleName, keeperVal.KycStatusChanged)
+	keeperVal.kycKeeper.RegisterEventHandler(kycTypes.EventTypeRemove, 0, types.ModuleName, keeperVal.KycStatusChanged)
 	return keeperVal
 }
 
@@ -74,6 +75,21 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) KycStatusChanged(goCtx context.Context, msgType string, data interface{}) error {
 	//if eventType
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	if kycTypes.EventTypeRemove == msgType {
+		val, ok := data.(sdk.Event)
+		if !ok {
+			return fmt.Errorf("data's type is not sdk.Event.but msgType is remove")
+		}
+		attrRegion, found := val.GetAttribute(kycTypes.AttributeKeyRegionId)
+		if !found {
+			return fmt.Errorf("can not found AttributeKeyRegionId.but EventType is remove")
+		}
+		attrAddress, found := val.GetAttribute(kycTypes.AttributeKeyAddress)
+		if !found {
+			return fmt.Errorf("can not found AttributeKeyAddress.but EventType is remove")
+		}
+		return k.procKycRegionChange(ctx, attrAddress.Value, attrRegion.Value, "")
+	}
 	if kycTypes.EventTypeUpdate != msgType {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Fixes #301.

When a DID is switched to INACTIVE, the DID module now calls DID hooks. The KYC keeper handles that hook by revoking the linked KYC credential, clearing DID KYC fields, deleting KYC filters and approve rewards, and emitting the existing KYC remove event. The MEGroup keeper now listens for that remove event and clears the member's group assignment through the existing region-change path.

## Tests

- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestUpdateDidStatusInactiveClearsKycDerivedGroupState' -count=1 -v
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/Test(Remove|UpdateDidStatusInactiveClearsKycDerivedGroupState|Update)$' -count=1 -v
- go test ./x/did/keeper ./x/kyc/keeper ./x/megroup/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

## Bounty wallet

0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099