### PR TITLE
fix(rollapp): restrict skip-delay control to GlobalDao

### DIFF
--- a/x/rollapp/keeper/msg_server_skip_delay_rollapp.go
+++ b/x/rollapp/keeper/msg_server_skip_delay_rollapp.go
@@ -12,7 +12,7 @@ import (
 func (k msgServer) SkipDelayRollapp(goCtx context.Context, msg *types.MsgSkipDelayRollapp) (*types.MsgSkipDelayRollappResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if !k.daoKeeper.IsDao(ctx, msg.Creator) {
+	if !k.daoKeeper.IsGlobalDao(ctx, msg.Creator) {
 		return nil, types.ErrCheckGlobalDao
 	}
 

--- a/x/rollapp/keeper/msg_server_skip_delay_rollapp_test.go
+++ b/x/rollapp/keeper/msg_server_skip_delay_rollapp_test.go
@@ -1,0 +1,28 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+)
+
+func (suite *RollappTestSuite) TestSkipDelayRollappRequiresGlobalDao() {
+	suite.SetupTest()
+	suite.InitializeDao()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollapp := types.Rollapp{
+		RollappId:     "rollapp1",
+		Creator:       alice,
+		Version:       1,
+		MaxSequencers: 1,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	_, err := suite.msgServer.SkipDelayRollapp(goCtx, types.NewMsgSkipDelayRollapp(suite.Dao.MeidDao, rollapp.RollappId, true))
+	suite.Require().ErrorIs(err, types.ErrCheckGlobalDao)
+	suite.Require().False(suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollapp.RollappId))
+
+	_, err = suite.msgServer.SkipDelayRollapp(goCtx, types.NewMsgSkipDelayRollapp(suite.Dao.GlobalDao, rollapp.RollappId, true))
+	suite.Require().NoError(err)
+	suite.Require().True(suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollapp.RollappId))
+}

--- a/x/rollapp/types/expected_keepers.go
+++ b/x/rollapp/types/expected_keepers.go
@@ -16,4 +16,5 @@ type ChannelKeeper interface {
 
 type DaoKeeper interface {
 	IsDao(ctx sdk.Context, address string) bool
+	IsGlobalDao(ctx sdk.Context, address string) bool
 }


### PR DESCRIPTION
## Summary

Fixes #84.

SkipDelayRollapp is a dispute-period bypass control, so it now requires IsGlobalDao instead of the broader IsDao check. This keeps MeidDao from toggling skip-delay for arbitrary rollapps while preserving GlobalDao access.

## Tests

- go test ./x/rollapp/keeper -run TestRollappKeeperTestSuite/TestSkipDelayRollappRequiresGlobalDao -count=1 -v
- go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/Test(SkipDelayRollappRequiresGlobalDao|CreateRollapp|UpdateState)$' -count=1 -v
- go test ./x/rollapp/types -count=1
- go test ./x/rollapp/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

## Bounty wallet

0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099