### PR TITLE
fix(kyc): reject zero-level updates

### DIFF
--- a/x/kyc/keeper/msg_server.go
+++ b/x/kyc/keeper/msg_server.go
@@ -146,10 +146,9 @@ func (m msgServer) Update(goCtx context.Context, msg *types.MsgUpdate) (*types.M
 		return &types.MsgUpdateResponse{}, stktypes.ErrRegionNotExist
 	}
 
-	// update KYC level
-	//if msg.Level == didtypes.KYC_LEVEL_NONE {
-	//	return &types.MsgUpdateResponse{}, errors.Wrap(didtypes.ErrParameter, "KYC level must be greater than 0")
-	//}
+	if msg.Level == didtypes.KYC_LEVEL_NONE {
+		return &types.MsgUpdateResponse{}, errors.Wrap(didtypes.ErrParameter, "KYC level must be greater than 0; use Remove to revoke KYC")
+	}
 
 	holderInfo.RegionId = msg.RegionId
 	holderInfo.KycLevel = msg.Level

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	"github.com/openmetaearth/me-hub/app/params"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/kyc/types"
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
@@ -157,6 +158,7 @@ func (s *KeeperTestSuite) TestUpdate() {
 		Issuer:   s.Dao.GlobalDao,
 		Did:      did,
 		RegionId: "usa",
+		Level:    didtypes.KYC_LEVEL_TWO,
 		Uri:      "http://127.0.0.1/8001",
 		Hash:     "aaaa",
 	})
@@ -167,4 +169,46 @@ func (s *KeeperTestSuite) TestUpdate() {
 	s.Require().Equal(delegation.Unmovable.String(), wstakingtypes.Bonus.String())
 	s.Require().Equal(s.usaValidator.OperatorAddress, delegation.ValidatorAddress)
 	s.Require().EqualValues(delegation.StartHeight, wmintTypes.OneDayTotalBlocks+1)
+}
+
+func (s *KeeperTestSuite) TestUpdateRejectsZeroKycLevel() {
+	s.SetupTest()
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	kycAccount, newUserPubkey := s.NewAccount()
+	did := "1111111111111111"
+	regionID := strings.ToLower(wstakingtypes.MeEarthRegionName)
+
+	_, err := s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: regionID,
+		Address:  kycAccount.String(),
+		Pubkey:   newUserPubkey,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "aaaa",
+		Level:    didtypes.KYC_LEVEL_TWO,
+	})
+	s.Require().NoError(err)
+
+	_, err = s.msgServer.Update(s.Ctx, &types.MsgUpdate{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: regionID,
+		Level:    didtypes.KYC_LEVEL_NONE,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "bbbb",
+	})
+	s.Require().ErrorIs(err, didtypes.ErrParameter)
+
+	didInfo, found := s.Keeper().GetDidInfo(s.Ctx, did)
+	s.Require().True(found)
+	s.Require().Equal(didtypes.KYC_LEVEL_TWO, didInfo.KycLevel)
+
+	region, found := s.App.StakingKeeper.GetRegion(s.Ctx, regionID)
+	s.Require().True(found)
+	s.Require().Equal(wstakingtypes.Bonus.String(), region.DelegateAmount.String())
 }


### PR DESCRIPTION
## Summary

Fixes #93.

The KYC update handler now rejects KYC_LEVEL_NONE. Level zero is an effective revocation, so callers must use the Remove flow, which performs the reward and staking cleanup that Update does not do.

This also updates the existing Update test to send an explicit valid level and adds a regression test proving a zero-level update is rejected without mutating the existing KYC level or region reward state.

## Tests

- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/Test(Update|UpdateRejectsZeroKycLevel)$' -count=1 -v
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/Test(Approve|Remove|Update|UpdateRejectsZeroKycLevel)$' -count=1 -v
- go test ./x/kyc/types -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

## Bounty wallet

0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099
