### PR TITLE
fix(wstaking): ignore inactive unused fixed-deposit configs

### DIFF
--- a/x/wstaking/keeper/kyc_region_test.go
+++ b/x/wstaking/keeper/kyc_region_test.go
@@ -4,6 +4,7 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	mintypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	"github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/x/wdistri"
@@ -67,4 +68,93 @@ func (s *KeeperTestSuite) TestTransferKycRegion() {
 	s.Require().Equal(delegation.Unmovable.String(), types.Bonus.String())
 	s.Require().Equal(delegation.ValidatorAddress, s.usaValidator.OperatorAddress)
 	s.Require().EqualValues(delegation.StartHeight, wmintTypes.OneDayTotalBlocks+1)
+}
+
+func (s *KeeperTestSuite) TestTransferKycRegionIgnoresInactiveUnusedFixedDepositCfg() {
+	s.SetupTest()
+
+	sourceRegionID := strings.ToLower(types.MeEarthRegionName)
+	targetRegionID := "usa"
+
+	newRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            types.MeEarthRegionName,
+		OperatorAddress: s.meEarthValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	newRegion = types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            "USA",
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	}
+	_, err = s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	for _, msg := range []types.MsgNewFixedDepositCfg{
+		{
+			Dao:      s.Dao.GlobalDao,
+			RegionId: sourceRegionID,
+			Term:     30,
+			Rate:     sdk.MustNewDecFromStr("0.1"),
+		},
+		{
+			Dao:      s.Dao.GlobalDao,
+			RegionId: targetRegionID,
+			Term:     30,
+			Rate:     sdk.MustNewDecFromStr("0.1"),
+		},
+		{
+			Dao:      s.Dao.GlobalDao,
+			RegionId: targetRegionID,
+			Term:     365,
+			Rate:     sdk.MustNewDecFromStr("0.12"),
+		},
+	} {
+		_, err = s.msgServer.NewFixedDepositCfg(s.Ctx, &msg)
+		s.Require().NoError(err)
+	}
+
+	_, err = s.msgServer.SetFixedDepositCfgStatus(s.Ctx, &types.MsgSetFixedDepositCfgStatus{
+		Admin:    s.Dao.GlobalDao,
+		RegionId: targetRegionID,
+		Term:     365,
+		Status:   types.RegionFixedDepositCfgStatusInactive,
+	})
+	s.Require().NoError(err)
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	userAccount, _ := s.NewAccount()
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx,
+		mintypes.ModuleName,
+		userAccount,
+		sdk.Coins{sdk.NewInt64Coin(params.BaseDenom, 10000000000)},
+	)
+	s.Require().NoError(err)
+
+	s.InitKyc(userAccount, "1111111111111192", sourceRegionID)
+	err = s.Keeper().KycReward(s.Ctx, userAccount, sourceRegionID, s.Dao.GlobalDao)
+	s.Require().NoError(err)
+
+	_, err = s.msgServer.DoFixedDeposit(s.Ctx, &types.MsgDoFixedDeposit{
+		Account:   userAccount.String(),
+		Principal: sdk.NewCoin(params.BaseDenom, sdk.NewInt(100000000)),
+		Term:      30,
+	})
+	s.Require().NoError(err)
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks + 1).WithChainID(apptesting.TestChainID)
+	err = s.Keeper().TransferKycRegion(s.Ctx, userAccount, s.Dao.GlobalDao, sourceRegionID, targetRegionID)
+	s.Require().NoError(err)
+
+	delegation, found := s.Keeper().GetDelegation(s.Ctx, userAccount, sdk.ValAddress{})
+	s.Require().True(found)
+	s.Require().Equal(s.usaValidator.OperatorAddress, delegation.ValidatorAddress)
+	s.Require().Equal(uint64(0), s.Keeper().GetFixedDepositCountOfCfg(s.Ctx, sourceRegionID, 30))
+	s.Require().Equal(uint64(1), s.Keeper().GetFixedDepositCountOfCfg(s.Ctx, targetRegionID, 30))
+	s.Require().Equal(uint64(0), s.Keeper().GetFixedDepositCountOfCfg(s.Ctx, targetRegionID, 365))
 }

--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -296,8 +296,8 @@ func (k Keeper) transferDeposit(ctx sdk.Context, fromRegion, toRegion *types.Reg
 	depositConfig := k.GetAllFixedDepositCfg(ctx, toRegion.RegionId)
 	depositConfigMap := make(map[int64]sdk.Dec)
 	for _, cfg := range depositConfig {
-		if cfg.Status == types.RegionFixedDepositCfgStatusInactive {
-			return errors.New("fixed deposit cfg status is inactive")
+		if cfg.Status != types.RegionFixedDepositCfgStatusActive {
+			continue
 		}
 		depositConfigMap[cfg.Term] = cfg.Rate
 	}


### PR DESCRIPTION
## Summary

Fixes #92.

`transferDeposit` now builds the target fixed-deposit config map from active configs only. An inactive config for an unrelated term no longer blocks a KYC region transfer when the user's actual fixed-deposit terms have matching active configs in the target region.

If the user's own term has no active target config, the existing per-deposit validation still rejects the transfer.

## Tests

- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestTransferKycRegionIgnoresInactiveUnusedFixedDepositCfg$' -count=1 -v
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/Test(NewFixedDepositCfg|SetFixedDepositCfgRateRejectsInvalidRates)$' -count=1 -v
- go test ./x/wstaking/types -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Baseline note: `go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestTransferKycRegion$' -count=1 -v` currently fails on clean `origin/main` at `kyc_region_test.go:48` with the invite-reward balance expectation. That baseline failure is unrelated to this fixed-deposit config change.

## Bounty wallet

0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099
