### PR TITLE
fix(kyc): clear stale DID address mappings on removal

### DIFF
--- a/x/kyc/keeper/did.go
+++ b/x/kyc/keeper/did.go
@@ -23,6 +23,10 @@ func (k *Keeper) SetDID(ctx sdk.Context, addr sdk.AccAddress, did string) {
 	k.didKeeper.SetDID(ctx, addr, did)
 }
 
+func (k *Keeper) DeleteDID(ctx sdk.Context, addr sdk.AccAddress) {
+	k.didKeeper.DeleteDID(ctx, addr)
+}
+
 func (k *Keeper) HasDidInfo(ctx sdk.Context, did string) bool {
 	return k.didKeeper.HasDidInfo(ctx, did)
 }

--- a/x/kyc/keeper/msg_server.go
+++ b/x/kyc/keeper/msg_server.go
@@ -69,6 +69,15 @@ func (m msgServer) Approve(goCtx context.Context, msg *types.MsgApprove) (*types
 	}
 
 	// create DID
+	if found && holderInfo.Address != "" && holderInfo.Address != msg.Address {
+		oldAddress, err := sdk.AccAddressFromBech32(holderInfo.Address)
+		if err != nil {
+			return &types.MsgApproveResponse{}, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, holderInfo.Address)
+		}
+		if oldDid, oldFound := m.GetDID(ctx, oldAddress); oldFound && oldDid == msg.Did {
+			m.DeleteDID(ctx, oldAddress)
+		}
+	}
 	m.SetDID(ctx, address, msg.Did)
 	m.SetDidInfo(ctx, msg.Did, didtypes.DidInfo{
 		Did:      msg.Did,
@@ -239,6 +248,9 @@ func (m msgServer) Remove(goCtx context.Context, msg *types.MsgRemove) (*types.M
 	address := sdk.MustAccAddressFromBech32(didInfo.Address)
 	if err := m.DeleteApproveReward(ctx, address.String(), string(kyc.Data)); err != nil {
 		return &types.MsgRemoveResponse{}, errors.Wrap(err, "delete reward failed")
+	}
+	if oldDid, found := m.GetDID(ctx, address); found && oldDid == msg.Did {
+		m.DeleteDID(ctx, address)
 	}
 
 	return &types.MsgRemoveResponse{}, nil

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	"github.com/openmetaearth/me-hub/app/params"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/kyc/types"
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
@@ -112,6 +113,62 @@ func (s *KeeperTestSuite) TestRemove() {
 	// check kyc
 	_, f = s.Keeper().GetKYC(s.Ctx, did)
 	s.Require().False(f)
+}
+
+func (s *KeeperTestSuite) TestRemoveThenReapproveDoesNotKeepOldAddressActive() {
+	s.SetupTest()
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	oldAddress, oldPubkey := s.NewAccount()
+	newAddress, newPubkey := s.NewAccount()
+	did := "1111111111111111"
+	regionID := strings.ToLower(wstakingtypes.MeEarthRegionName)
+
+	_, err := s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: regionID,
+		Address:  oldAddress.String(),
+		Pubkey:   oldPubkey,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "aaaa",
+		Level:    didtypes.KYC_LEVEL_TWO,
+	})
+	s.Require().NoError(err)
+
+	_, err = s.msgServer.Remove(s.Ctx, &types.MsgRemove{
+		Issuer: s.Dao.GlobalDao,
+		Did:    did,
+	})
+	s.Require().NoError(err)
+
+	_, err = s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: regionID,
+		Address:  newAddress.String(),
+		Pubkey:   newPubkey,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "aaaa",
+		Level:    didtypes.KYC_LEVEL_TWO,
+	})
+	s.Require().NoError(err)
+
+	_, found := s.Keeper().GetDID(s.Ctx, oldAddress)
+	s.Require().False(found)
+
+	newDid, found := s.Keeper().GetDID(s.Ctx, newAddress)
+	s.Require().True(found)
+	s.Require().Equal(did, newDid)
+
+	_, oldAddressActive := s.App.GroupKeeper.GetDidAndKycActive(s.Ctx, oldAddress, regionID)
+	s.Require().False(oldAddressActive)
+
+	_, newAddressActive := s.App.GroupKeeper.GetDidAndKycActive(s.Ctx, newAddress, regionID)
+	s.Require().True(newAddressActive)
 }
 
 func (s *KeeperTestSuite) TestUpdate() {

--- a/x/megroup/keeper/keeper.go
+++ b/x/megroup/keeper/keeper.go
@@ -254,6 +254,9 @@ func (k Keeper) GetDidAndKycActive(sdkCtx sdk.Context, address sdk.AccAddress, r
 	if !found {
 		return "", false
 	}
+	if didInfo.Address != address.String() {
+		return "", false
+	}
 	if didInfo.RegionId != regionID {
 		return "", false
 	}


### PR DESCRIPTION
Fixes #191.

Summary:
- Clear the previous address-to-DID index when an inactive DID is re-approved for a different address.
- Clear the removed holder address index after KYC removal succeeds.
- Harden MeGroup KYC checks so the active DID info must still point to the queried address.
- Add regression coverage for remove-then-reapprove account migration.

Tests:
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestRemoveThenReapproveDoesNotKeepOldAddressActive$' -count=1 -v
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/Test(Approve|Remove|RemoveThenReapproveDoesNotKeepOldAddressActive)$' -count=1 -v
- go test ./x/megroup/keeper -run '^$' -count=1
- go test ./x/kyc/types ./x/megroup/types -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Reward wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099
