### PR TITLE
fix(kyc): avoid duplicate validator rewards on re-approval

### DIFF
--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -114,6 +114,58 @@ func (s *KeeperTestSuite) TestRemove() {
 	s.Require().False(f)
 }
 
+func (s *KeeperTestSuite) TestKycRewardsCannotBePaidTwiceByRemoveAndReapprove() {
+	s.SetupTest()
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	kycAccount, newUserPubkey := s.NewAccount()
+	did := "1111111111111111"
+	regionID := strings.ToLower(wstakingtypes.MeEarthRegionName)
+
+	region, found := s.App.StakingKeeper.GetRegion(s.Ctx, regionID)
+	s.Require().True(found)
+	valAddress, err := sdk.ValAddressFromBech32(region.OperatorAddress)
+	s.Require().NoError(err)
+	validator, found := s.App.StakingKeeper.GetValidator(s.Ctx, valAddress)
+	s.Require().True(found)
+
+	ownerAddress := sdk.MustAccAddressFromBech32(validator.OwnerAddress)
+	committeeAddress := sdk.MustAccAddressFromBech32(s.Dao.DevOperator)
+	ownerBefore := s.App.BankKeeper.GetBalance(s.Ctx, ownerAddress, params.BaseDenom).Amount
+	committeeBefore := s.App.BankKeeper.GetBalance(s.Ctx, committeeAddress, params.BaseDenom).Amount
+
+	approve := func() {
+		_, err = s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+			Issuer:   s.Dao.GlobalDao,
+			Did:      did,
+			RegionId: regionID,
+			Address:  kycAccount.String(),
+			Pubkey:   newUserPubkey,
+			Uri:      "http://127.0.0.1/8001",
+			Hash:     "aaaa",
+			Level:    2,
+		})
+		s.Require().NoError(err)
+	}
+
+	approve()
+	_, err = s.msgServer.Remove(s.Ctx, &types.MsgRemove{
+		Issuer: s.Dao.GlobalDao,
+		Did:    did,
+	})
+	s.Require().NoError(err)
+	approve()
+
+	ownerAfter := s.App.BankKeeper.GetBalance(s.Ctx, ownerAddress, params.BaseDenom).Amount
+	committeeAfter := s.App.BankKeeper.GetBalance(s.Ctx, committeeAddress, params.BaseDenom).Amount
+
+	s.Require().Equal(wstakingtypes.ValidatorReward.String(), ownerAfter.Sub(ownerBefore).String())
+	s.Require().Equal(wstakingtypes.CommitteeReward.String(), committeeAfter.Sub(committeeBefore).String())
+}
+
 func (s *KeeperTestSuite) TestUpdate() {
 	s.SetupTest()
 

--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -39,15 +39,23 @@ func (k Keeper) KycReward(ctx sdk.Context, account sdk.AccAddress, regionId, cre
 
 	validator.MeidAmount = validator.MeidAmount.Add(types.Bonus)
 
-	err = k.sendKycRewards(ctx, account, valAddr, validator, region)
+	payValidatorAndCommitteeRewards := !k.HasKycRewardPaid(ctx, account, region.RegionId)
+	err = k.sendKycRewards(ctx, account, valAddr, validator, region, payValidatorAndCommitteeRewards)
 	if err != nil {
 		return sdkerrors.Wrapf(types.ErrSendKycReward, err.Error())
+	}
+	if payValidatorAndCommitteeRewards {
+		k.SetKycRewardPaid(ctx, account, region.RegionId)
 	}
 
 	//validator rewards
 	ownerAddress := validator.OwnerAddress
 	if len(validator.OwnerAddress) <= 0 {
 		ownerAddress = k.daoKeeper.GetDevOperator(ctx)
+	}
+	validatorReward := sdk.ZeroInt()
+	if payValidatorAndCommitteeRewards {
+		validatorReward = types.ValidatorReward
 	}
 
 	ctx.EventManager().EmitEvent(
@@ -57,7 +65,7 @@ func (k Keeper) KycReward(ctx sdk.Context, account sdk.AccAddress, regionId, cre
 			sdk.NewAttribute(types.AttributeKeyCreator, creator),
 			sdk.NewAttribute(types.AttributeKeyKycRewardCommitteeAddress, k.daoKeeper.GetDevOperator(ctx)),
 			sdk.NewAttribute(types.AttributeKeyKycRewardNodeAddress, ownerAddress),
-			sdk.NewAttribute(types.AttributeKeyMeidNumAddReward, types.ValidatorReward.String()+params.BaseDenom),
+			sdk.NewAttribute(types.AttributeKeyMeidNumAddReward, validatorReward.String()+params.BaseDenom),
 		),
 	)
 	return nil
@@ -160,7 +168,7 @@ func (k Keeper) RemoveKycReward(ctx sdk.Context, account sdk.AccAddress, regionI
 }
 
 func (k Keeper) sendKycRewards(ctx sdk.Context, delAddr sdk.AccAddress, validatorAddr sdk.ValAddress,
-	validator stakingtypes.Validator, region types.Region) (err error) {
+	validator stakingtypes.Validator, region types.Region, payValidatorAndCommitteeRewards bool) (err error) {
 	experienceRegion, hasRegion := k.GetRegion(ctx, strings.ToLower(types.ExperienceRegionName))
 	if !hasRegion {
 		return types.ErrExpRegionNotExist
@@ -227,30 +235,32 @@ func (k Keeper) sendKycRewards(ctx sdk.Context, delAddr sdk.AccAddress, validato
 	delegation.ValidatorAddress = validator.OperatorAddress
 	treasureAddr := k.GetRegionAccount(ctx, types.RegionAccountTypeBase, region.RegionId)
 
-	// validator rewards
-	ownerAddress := validator.OwnerAddress
-	if len(ownerAddress) == 0 {
-		ownerAddress = k.daoKeeper.GetDevOperator(ctx)
-	}
-	err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
-		treasureAddr.GetAddress(),
-		sdk.MustAccAddressFromBech32(ownerAddress),
-		sdk.NewCoins(sdk.NewCoin(params.BaseDenom, types.ValidatorReward)),
-		fmt.Sprintf("ValidatorKycReward_%s", region.RegionId),
-	)
-	if err != nil {
-		return fmt.Errorf("send kyc reward to validator, %v", err)
-	}
+	if payValidatorAndCommitteeRewards {
+		// validator rewards
+		ownerAddress := validator.OwnerAddress
+		if len(ownerAddress) == 0 {
+			ownerAddress = k.daoKeeper.GetDevOperator(ctx)
+		}
+		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
+			treasureAddr.GetAddress(),
+			sdk.MustAccAddressFromBech32(ownerAddress),
+			sdk.NewCoins(sdk.NewCoin(params.BaseDenom, types.ValidatorReward)),
+			fmt.Sprintf("ValidatorKycReward_%s", region.RegionId),
+		)
+		if err != nil {
+			return fmt.Errorf("send kyc reward to validator, %v", err)
+		}
 
-	//committee rewards
-	err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
-		treasureAddr.GetAddress(),
-		sdk.MustAccAddressFromBech32(k.daoKeeper.GetDevOperator(ctx)),
-		sdk.NewCoins(sdk.NewCoin(params.BaseDenom, types.CommitteeReward)),
-		fmt.Sprintf("CommitteeKycReward_%s", region.RegionId),
-	)
-	if err != nil {
-		return fmt.Errorf("send kyc reward to committee, %v", err)
+		//committee rewards
+		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
+			treasureAddr.GetAddress(),
+			sdk.MustAccAddressFromBech32(k.daoKeeper.GetDevOperator(ctx)),
+			sdk.NewCoins(sdk.NewCoin(params.BaseDenom, types.CommitteeReward)),
+			fmt.Sprintf("CommitteeKycReward_%s", region.RegionId),
+		)
+		if err != nil {
+			return fmt.Errorf("send kyc reward to committee, %v", err)
+		}
 	}
 
 	delegation.Amount = delegation.Amount.Add(delegation.UnMeidAmount)

--- a/x/wstaking/keeper/kyc_reward_paid.go
+++ b/x/wstaking/keeper/kyc_reward_paid.go
@@ -1,0 +1,17 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (k Keeper) HasKycRewardPaid(ctx sdk.Context, account sdk.AccAddress, regionId string) bool {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.KycRewardPaidKeyPrefix))
+	return store.Has(types.KycRewardPaidKey(account, regionId))
+}
+
+func (k Keeper) SetKycRewardPaid(ctx sdk.Context, account sdk.AccAddress, regionId string) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.KycRewardPaidKeyPrefix))
+	store.Set(types.KycRewardPaidKey(account, regionId), []byte{1})
+}

--- a/x/wstaking/types/keys.go
+++ b/x/wstaking/types/keys.go
@@ -48,6 +48,7 @@ const (
 const (
 	FixedDepositCfgKeyPrefix        = "FixedDepositCfg/value/"
 	FixedDepositCountOfCfgKeyPrefix = "FixedDepositCountOfCfg/value/"
+	KycRewardPaidKeyPrefix          = "KycRewardPaid/value/"
 )
 
 const (
@@ -166,6 +167,15 @@ func MeidNFTKey(umeid string) []byte {
 func FixedDepositCfgKey(term int64) []byte {
 	var key = make([]byte, 8)
 	binary.BigEndian.PutUint64(key, uint64(term))
+	key = append(key, []byte("/")...)
+
+	return key
+}
+
+func KycRewardPaidKey(account sdk.AccAddress, regionId string) []byte {
+	var key []byte
+	key = append(key, address.MustLengthPrefix(account)...)
+	key = append(key, []byte(regionId)...)
 	key = append(key, []byte("/")...)
 
 	return key


### PR DESCRIPTION
Fixes #192.

Summary:
- Add a persistent per-account/per-region KYC reward-paid marker in wstaking.
- Keep normal KYC delegation restoration on re-approval, but skip duplicate validator and committee incentive transfers after a remove/re-approve cycle in the same region.
- Emit zero validator reward in the KYC event when the incentive leg is skipped.
- Add a regression test proving approve -> remove -> approve only pays validator and committee rewards once.

Tests:
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestKycRewardsCannotBePaidTwiceByRemoveAndReapprove$' -count=1 -v
- go test ./x/kyc/keeper -run 'TestKeeperTestSuite/Test(Approve|Remove|KycRewardsCannotBePaidTwiceByRemoveAndReapprove)$' -count=1 -v
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestKycReward_WithDelegation$' -count=1 -v
- go test ./x/wstaking/keeper -run '^$' -count=1
- go test ./x/kyc/types ./x/wstaking/types -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Baseline note:
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/Test(KycReward_WithDelegation|KycReward_WithoutDelegation|RemoveKycReward)$' -count=1 -v still fails on clean origin/main at kyc_reward_test.go:125 and kyc_reward_test.go:159 with expected 0 vs actual 10000000. This is pre-existing after #841 and not introduced by this patch.

Reward wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099
