### PR TITLE
fix(rollapp): add creator ownership check in UpdateRollapp

### DIFF
--- a/x/rollapp/keeper/msg_server_update_rollapp.go
+++ b/x/rollapp/keeper/msg_server_update_rollapp.go
@@ -22,6 +22,11 @@ func (k msgServer) UpdateRollapp(goCtx context.Context, msg *types.MsgUpdateRoll
 		return nil, types.ErrUnknownRollappID
 	}
 
+	// ensure only the rollapp creator can update it
+	if msg.Creator != rollapp.Creator {
+		return nil, types.ErrUnauthorizedRollappCreator
+	}
+
 	if msg.MaxSequencers != 0 {
 		rollapp.MaxSequencers = msg.MaxSequencers
 	}


### PR DESCRIPTION
## Problem

`MsgUpdateRollapp` lacks creator ownership verification. When `DeployerWhitelist` is empty (the default), any address can modify any rollapp's `ChannelId`, `PermissionedAddresses`, and `MaxSequencers`.

**Fixes #849**

## Changes

- Add `msg.Creator != rollapp.Creator` check in `UpdateRollapp` handler
- Returns `ErrUnauthorizedRollappCreator` if caller is not the rollapp creator

## Code Change

```go
// x/rollapp/keeper/msg_server_update_rollapp.go
rollapp, found := k.GetRollapp(ctx, msg.RollappId)
if !found {
    return nil, types.ErrUnknownRollappID
}

// NEW: ensure only the rollapp creator can update it
if msg.Creator != rollapp.Creator {
    return nil, types.ErrUnauthorizedRollappCreator
}
```

## Impact

Without this fix, any address can:
- Hijack a rollapp's IBC `ChannelId`
- Overwrite `PermissionedAddresses` to control the sequencer set
- Set `MaxSequencers` to DoS the rollapp
