### PR TITLE
fix(dao): reject empty GlobalDao/MeidDao in MsgUpdateDao

### DIFF
--- a/x/dao/types/msg.go
+++ b/x/dao/types/msg.go
@@ -40,15 +40,20 @@ func (msg *MsgUpdateDao) GetSignBytes() []byte {
 }
 
 func (msg *MsgUpdateDao) ValidateBasic() error {
-	if len(msg.DaoAddresses.GlobalDao) > 0 {
-		if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.GlobalDao); err != nil {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.DaoAddresses.GlobalDao)
-		}
+	// GlobalDao and MeidDao are required: an empty value would permanently
+	// lock out all DAO-gated operations (IsGlobalDao/IsMeidDao can never match
+	// an empty address), bricking governance.
+	if len(msg.DaoAddresses.GlobalDao) == 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "GlobalDao address cannot be empty")
 	}
-	if len(msg.DaoAddresses.MeidDao) > 0 {
-		if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.MeidDao); err != nil {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.DaoAddresses.MeidDao)
-		}
+	if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.GlobalDao); err != nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.DaoAddresses.GlobalDao)
+	}
+	if len(msg.DaoAddresses.MeidDao) == 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "MeidDao address cannot be empty")
+	}
+	if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.MeidDao); err != nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.DaoAddresses.MeidDao)
 	}
 	if len(msg.DaoAddresses.DevOperator) > 0 {
 		if _, err := sdk.AccAddressFromBech32(msg.DaoAddresses.DevOperator); err != nil {


### PR DESCRIPTION
## Problem

`MsgUpdateDao.ValidateBasic()` skips address validation when `GlobalDao` or `MeidDao` is empty (len("") == 0). This allows a DAO admin to permanently brick chain governance by setting empty addresses, since `IsGlobalDao("")` can never be true.

**Fixes #851**

## Changes

- Require non-empty addresses for `GlobalDao` and `MeidDao` in `ValidateBasic()`
- Reject `MsgUpdateDao` with empty required fields

## Impact

Without this fix, submitting `MsgUpdateDao{GlobalDao: "", MeidDao: ""}` permanently locks out all DAO-gated operations:
- `UpdateDao` — cannot update DAO addresses again
- `FreeGasAccount` — cannot manage gas-free accounts
- `SkipDelayRollapp` — cannot skip rollapp delays
- Sequencer whitelist operations — permanently blocked

This effectively bricks chain governance, requiring a chain upgrade/fork to recover.
