### PR TITLE
fix(rollapp): restrict frozen eip155 recovery creator

### DIFF
--- a/x/rollapp/keeper/msg_server_create_rollapp.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp.go
@@ -15,7 +15,7 @@ func (k msgServer) CreateRollapp(goCtx context.Context, msg *types.MsgCreateRoll
 		return nil, types.ErrRollappsDisabled
 	}
 
-	err := k.checkIfRollappExists(ctx, msg.RollappId)
+	err := k.checkIfRollappExists(ctx, msg.RollappId, msg.Creator)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (k msgServer) CreateRollapp(goCtx context.Context, msg *types.MsgCreateRoll
 	return &types.MsgCreateRollappResponse{}, nil
 }
 
-func (k msgServer) checkIfRollappExists(ctx sdk.Context, RawRollappId string) error {
+func (k msgServer) checkIfRollappExists(ctx sdk.Context, RawRollappId string, creator string) error {
 	rollappId, err := types.NewChainID(RawRollappId)
 	if err != nil {
 		return err
@@ -64,6 +64,9 @@ func (k msgServer) checkIfRollappExists(ctx sdk.Context, RawRollappId string) er
 	}
 	if !existingRollapp.Frozen {
 		return types.ErrRollappExists
+	}
+	if existingRollapp.Creator != creator {
+		return errorsmod.Wrapf(types.ErrUnauthorizedRollappCreator, "only original creator %s can recover frozen EIP155 rollapp", existingRollapp.Creator)
 	}
 	existingRollappChainId, _ := types.NewChainID(existingRollapp.RollappId)
 

--- a/x/rollapp/keeper/msg_server_create_rollapp_test.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp_test.go
@@ -324,6 +324,53 @@ func (suite *RollappTestSuite) TestForkChainId() {
 	}
 }
 
+func (suite *RollappTestSuite) TestFrozenEIP155ForkRequiresOriginalCreator() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	originalRollapp := types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             "rollapp_1234-1",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{alice},
+	}
+	_, err := suite.msgServer.CreateRollapp(goCtx, &originalRollapp)
+	suite.Require().NoError(err)
+
+	rollapp, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, originalRollapp.RollappId)
+	suite.Require().True(found)
+	rollapp.Frozen = true
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	hijackRollapp := types.MsgCreateRollapp{
+		Creator:               bob,
+		RollappId:             "rollapp_1234-2",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{bob},
+	}
+	_, err = suite.msgServer.CreateRollapp(goCtx, &hijackRollapp)
+	suite.Require().ErrorIs(err, types.ErrUnauthorizedRollappCreator)
+
+	rollappByEIP155, found := suite.App.RollappKeeper.GetRollappByEIP155(suite.Ctx, uint64(1234))
+	suite.Require().True(found)
+	suite.Require().Equal(originalRollapp.RollappId, rollappByEIP155.RollappId)
+	suite.Require().Equal(alice, rollappByEIP155.Creator)
+
+	recoveryRollapp := types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             "rollapp_1234-2",
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{alice},
+	}
+	_, err = suite.msgServer.CreateRollapp(goCtx, &recoveryRollapp)
+	suite.Require().NoError(err)
+
+	rollappByEIP155, found = suite.App.RollappKeeper.GetRollappByEIP155(suite.Ctx, uint64(1234))
+	suite.Require().True(found)
+	suite.Require().Equal(recoveryRollapp.RollappId, rollappByEIP155.RollappId)
+	suite.Require().Equal(alice, rollappByEIP155.Creator)
+}
+
 func (suite *RollappTestSuite) TestOverwriteEIP155Key() {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Fixes #194.

## Summary
- Require frozen EIP155 RollApp recovery to be submitted by the original RollApp creator.
- Keep the existing frozen-recovery checks for same EIP155 name and next revision number.
- Add a regression test proving a different creator cannot hijack `rollapp_1234-2`, while the original creator can still recover it.

## Verification
- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestFrozenEIP155ForkRequiresOriginalCreator$' -count=1 -v`
- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/Test(ForkChainId|OverwriteEIP155Key|FrozenEIP155ForkRequiresOriginalCreator|CreateRollappAlreadyExists)$' -count=1 -v`
- `go test ./x/rollapp/keeper -run '^$' -count=1`
- `go test ./x/rollapp/types -run '^$' -count=1`
- `go test ./app -run '^$' -count=1`
- `git diff --check`

## Baseline note
A broader local run including `TestCreateRollappId` and `TestCreateRollappUnauthorizedRollappCreator` fails on clean `origin/main` at commit `c500bf3c` with the same failures. Those failures are pre-existing and unrelated to this patch.

## Reward wallet
`0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`
