### PR TITLE
fix(rollapp): reject first state height gaps

### DIFF
--- a/x/rollapp/keeper/msg_server_update_state.go
+++ b/x/rollapp/keeper/msg_server_update_state.go
@@ -73,6 +73,10 @@ func (k msgServer) UpdateState(goCtx context.Context, msg *types.MsgUpdateState)
 
 		// bump state index
 		lastIndex = latestStateInfoIndex.Index
+	} else if msg.StartHeight != 1 {
+		return nil, errorsmod.Wrapf(types.ErrWrongBlockHeight,
+			"first state update must start at height 1, but received (%d)",
+			msg.StartHeight)
 	}
 	newIndex = lastIndex + 1
 

--- a/x/rollapp/keeper/msg_server_update_state_test.go
+++ b/x/rollapp/keeper/msg_server_update_state_test.go
@@ -324,7 +324,7 @@ func (suite *RollappTestSuite) TestUpdateStateErrLogicUnpermissioned() {
 	suite.ErrorIs(err, types.ErrLogic)
 }
 
-func (suite *RollappTestSuite) TestFirstUpdateStateGensisHightGreaterThanZero() {
+func (suite *RollappTestSuite) TestFirstUpdateStateRejectsGenesisHeightGreaterThanOne() {
 	suite.SetupTest()
 	goCtx := sdk.WrapSDKContext(suite.Ctx)
 
@@ -355,11 +355,14 @@ func (suite *RollappTestSuite) TestFirstUpdateStateGensisHightGreaterThanZero() 
 		NumBlocks:   3,
 		DAPath:      "",
 		Version:     3,
-		BDs:         types.BlockDescriptors{BD: []types.BlockDescriptor{{Height: 2}, {Height: 3}}},
+		BDs:         types.BlockDescriptors{BD: []types.BlockDescriptor{{Height: 2}, {Height: 3}, {Height: 4}}},
 	}
 
 	_, err := suite.msgServer.UpdateState(goCtx, &updateState)
-	suite.NoError(err)
+	suite.ErrorIs(err, types.ErrWrongBlockHeight)
+
+	_, found := suite.App.RollappKeeper.GetLatestStateInfoIndex(suite.Ctx, rollapp.GetRollappId())
+	suite.Require().False(found)
 }
 
 func (suite *RollappTestSuite) TestUpdateStateErrWrongBlockHeight() {


### PR DESCRIPTION
Fixes #353

## Summary
- Reject the first RollApp `MsgUpdateState` unless it starts at height `1`.
- Keep the existing continuity check for later state updates unchanged.
- Convert the previous permissive first-state test into a regression test that proves no latest state index is stored after rejection.

## Why
`DelayedAck` finalization assumes lower proof heights are covered once the latest finalized state end height advances. That assumption is unsafe if the first RollApp state can start above height `1`, because earlier proof heights may be finalized without any `StateInfo` / `StateRoot` coverage.

This PR makes the initial RollApp state history contiguous from height `1`, closing the first-state gap described in #353.

## Verification
- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestFirstUpdateStateRejectsGenesisHeightGreaterThanOne$' -count=1 -v`
- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/Test(FirstUpdateState|UpdateStateErrWrongBlockHeight|UpdateState)$' -count=1 -v`
- `go test ./x/rollapp/keeper -run '^$' -count=1`
- `go test ./x/rollapp/types -run '^$' -count=1`
- `go test ./app -run '^$' -count=1`
- `git diff --check`

## Reward address
`0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`
