### PR TITLE
fix(wstaking): price halving boundary rewards correctly

### DIFF
--- a/x/wstaking/keeper/alias_functions.go
+++ b/x/wstaking/keeper/alias_functions.go
@@ -35,19 +35,22 @@ func (k Keeper) getRewardsByHeight(fromHeight int64, toHeight int64) (coin sdk.D
 			Quo(halvingDivisor)
 		mintUMECAmount := wmint.RoundUpToFourDecimalsDec(amountDec).MulInt64(100_000_000).TruncateInt()
 
-		var blockCount int64
-		// If the range of from and to are in the same reduction period
-		if i == lowMul && lowMul == highMul {
-			blockCount = toHeight - fromHeight
-			// Calculate the number of tokens between fromHeight and its first halving boundary
-		} else if i == lowMul {
-			blockCount = int64(mintTypes.OneYearTotalBlocks)*(lowMul+1) - fromHeight + 1
-			// Calculate the number of tokens between the last halving boundary and toHeight
-		} else if i == highMul {
-			blockCount = toHeight - int64(mintTypes.OneYearTotalBlocks)*i - 1
-		} else {
-			// Calculate the number of tokens for each full halving interval
-			blockCount = int64(mintTypes.OneYearTotalBlocks)
+		periodStart := int64(mintTypes.OneYearTotalBlocks)*i + 1
+		periodEnd := int64(mintTypes.OneYearTotalBlocks) * (i + 1)
+
+		firstRewardHeight := fromHeight + 1
+		if firstRewardHeight < periodStart {
+			firstRewardHeight = periodStart
+		}
+
+		lastRewardHeight := toHeight
+		if lastRewardHeight > periodEnd {
+			lastRewardHeight = periodEnd
+		}
+
+		blockCount := int64(0)
+		if lastRewardHeight >= firstRewardHeight {
+			blockCount = lastRewardHeight - firstRewardHeight + 1
 		}
 
 		totalCoins = totalCoins.Add(mintUMECAmount.MulRaw(blockCount))

--- a/x/wstaking/keeper/alias_functions_test.go
+++ b/x/wstaking/keeper/alias_functions_test.go
@@ -77,36 +77,39 @@ func TestGetRewardsByHeight(t *testing.T) {
 			wantUMEC: perBlockUMEC[2] * 100,
 		},
 		{
+			name:       "halving boundary uses new year rate",
+			fromHeight: Y,
+			toHeight:   Y + 1,
+			// Rewarded interval is (Y, Y+1], so only block Y+1 is counted.
+			wantUMEC: perBlockUMEC[1],
+		},
+		{
 			// Cross-period: period 0 -> period 1
 			// fromHeight=Y-5, toHeight=Y+5
-			// i=0 (lowMul): blockCount = Y*1 - (Y-5) + 1 = 6  (includes fromHeight)
-			// i=1 (highMul): blockCount = (Y+5) - Y*1 - 1 = 4  (misses last block of period 1)
+			// rewarded heights are Y-4..Y+5, so each period gets 5 blocks.
 			name:       "cross-period year1 to year2",
 			fromHeight: Y - 5,
 			toHeight:   Y + 5,
-			wantUMEC:   perBlockUMEC[0]*6 + perBlockUMEC[1]*4,
+			wantUMEC:   perBlockUMEC[0]*5 + perBlockUMEC[1]*5,
 		},
 		{
 			// Cross-period: period 1 -> period 2
 			// fromHeight=2Y-3, toHeight=2Y+3
-			// i=1 (lowMul): blockCount = Y*2 - (2Y-3) + 1 = 4
-			// i=2 (highMul): blockCount = (2Y+3) - Y*2 - 1 = 2
+			// rewarded heights are 2Y-2..2Y+3, so each period gets 3 blocks.
 			name:       "cross-period year2 to year3",
 			fromHeight: 2*Y - 3,
 			toHeight:   2*Y + 3,
-			wantUMEC:   perBlockUMEC[1]*4 + perBlockUMEC[2]*2,
+			wantUMEC:   perBlockUMEC[1]*3 + perBlockUMEC[2]*3,
 		},
 		{
 			// Cross three periods: period 0 -> period 1 -> period 2
 			// fromHeight=Y-1, toHeight=2Y+1
 			// lowMul=0, highMul=2
-			// i=0: blockCount = Y*1 - (Y-1) + 1 = 2
-			// i=1: (full middle period) blockCount = Y
-			// i=2: blockCount = (2Y+1) - Y*2 - 1 = 0
+			// rewarded heights are Y..2Y+1.
 			name:       "cross three periods year1 to year3",
 			fromHeight: Y - 1,
 			toHeight:   2*Y + 1,
-			wantUMEC:   perBlockUMEC[0]*2 + perBlockUMEC[1]*Y + perBlockUMEC[2]*0,
+			wantUMEC:   perBlockUMEC[0] + perBlockUMEC[1]*Y + perBlockUMEC[2],
 		},
 	}
 


### PR DESCRIPTION
Fixes #296

## Summary
- Make `getRewardsByHeight(fromHeight, toHeight)` count the rewarded interval as `(fromHeight, toHeight]` for each halving period.
- Align the staking reward period mapping with `wmint.BeginBlocker`, where block `OneYearTotalBlocks + 1` already uses the next halved rate.
- Add explicit regression coverage for the first block after a halving boundary and update cross-period expectations.

## Why
The previous cross-period branch counted one boundary block in the previous period and skipped one block from the new period. For `fromHeight = Y` and `toHeight = Y + 1`, it charged the block at the year-1 rate instead of the year-2 halved rate.

## Verification
- `go test ./x/wstaking/keeper -run TestGetRewardsByHeight -count=1 -v`
- `go test ./x/wmint -run 'TestKeeperTestSuite/TestBeginBlocker$' -count=1 -v`
- `go test ./x/wstaking/keeper -run '^$' -count=1`
- `go test ./x/wmint -run '^$' -count=1`
- `go test ./app -run '^$' -count=1`
- `git diff --check`

## Reward address
`0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`
