### PR TITLE
fix(gravity): preserve higher fee live batches

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -27,11 +27,9 @@ func (k Keeper) BuildOutgoingTxBatch(ctx sdk.Context, contractAddress, feeReceiv
 		return nil, errorsmod.Wrapf(types.ErrInvalid, "batch timeout height %d less than 0", batchTimeout)
 	}
 
-	// if there is a more profitable batch for this token type do not create a new batch
-	if lastBatch := k.GetLastOutgoingBatchByTokenType(ctx, contractAddress); lastBatch != nil {
-		if lastBatch.BatchTimeout < projectedCurrentExternalHeight {
-			return nil, errorsmod.Wrap(types.ErrInvalid, "existing unexecuted batch, and the batch not timeout")
-		}
+	var liveBatch *types.OutgoingTxBatch
+	if lastBatch := k.GetLastOutgoingBatchByTokenType(ctx, contractAddress); lastBatch != nil && lastBatch.BatchTimeout >= projectedCurrentExternalHeight {
+		liveBatch = lastBatch
 	}
 	selectedTx, err := k.pickUnBatchedTx(ctx, contractAddress, maxElements, baseFee)
 	if err != nil {
@@ -42,6 +40,28 @@ func (k Keeper) BuildOutgoingTxBatch(ctx sdk.Context, contractAddress, feeReceiv
 	}
 	if types.OutgoingTransferTxs(selectedTx).TotalFee().LT(minimumFee) {
 		return nil, errorsmod.Wrap(types.ErrInvalid, "total fee less than minimum fee")
+	}
+	if liveBatch != nil {
+		selectedFee := types.OutgoingTransferTxs(selectedTx).TotalFee()
+		liveBatchFee := types.OutgoingTransferTxs(liveBatch.Transactions).TotalFee()
+		if selectedFee.LTE(liveBatchFee) {
+			for _, tx := range selectedTx {
+				if restoreErr := k.AddUnbatchedTx(ctx, tx); restoreErr != nil {
+					return nil, errorsmod.Wrapf(restoreErr, "restore selected tx %d after live batch fee check", tx.Id)
+				}
+			}
+			return nil, errorsmod.Wrapf(types.ErrInvalid,
+				"existing live batch fee (%s) is greater than or equal to selected batch fee (%s)",
+				liveBatchFee.String(), selectedFee.String())
+		}
+		if err = k.CancelOutgoingTxBatch(ctx, contractAddress, liveBatch.BatchNonce); err != nil {
+			for _, tx := range selectedTx {
+				if restoreErr := k.AddUnbatchedTx(ctx, tx); restoreErr != nil {
+					return nil, errorsmod.Wrapf(restoreErr, "restore selected tx %d after live batch cancel failure", tx.Id)
+				}
+			}
+			return nil, errorsmod.Wrapf(err, "cancel less profitable live batch %d", liveBatch.BatchNonce)
+		}
 	}
 
 	nextID := k.AutoIncrementID(ctx, types.KeyLastOutgoingBatchID)

--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -70,6 +70,77 @@ func (suite *KeeperTestSuite) TestLastPendingBatchRequestByAddr() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestLiveLowFeeBatchDoesNotSupersedeHigherFeePendingBatch() {
+	tokenContract := helpers.GenerateAddress().Hex()
+	feeReceive := helpers.GenerateAddress().Hex()
+
+	makeTx := func(id uint64, fee int64) *types.OutgoingTransferTx {
+		return &types.OutgoingTransferTx{
+			Id:          id,
+			Sender:      sdk.AccAddress(helpers.GenerateAddress().Bytes()).String(),
+			DestAddress: helpers.GenerateAddress().Hex(),
+			Token: types.ERC20Token{
+				Contract: tokenContract,
+				Amount:   sdkmath.NewInt(100),
+			},
+			Fee: types.ERC20Token{
+				Contract: tokenContract,
+				Amount:   sdkmath.NewInt(fee),
+			},
+		}
+	}
+
+	suite.NoError(suite.Keeper().AddUnbatchedTx(suite.Ctx, makeTx(1, 1_000)))
+
+	suite.Ctx = suite.Ctx.WithBlockHeight(20)
+	suite.Keeper().SetLastObservedBlockHeight(suite.Ctx, 10, 10)
+	firstBatch, err := suite.Keeper().BuildOutgoingTxBatch(
+		suite.Ctx,
+		tokenContract,
+		feeReceive,
+		100,
+		sdkmath.NewInt(1),
+		sdkmath.ZeroInt(),
+	)
+	suite.Require().NoError(err)
+	suite.Require().Equal(sdkmath.NewInt(1_000), types.OutgoingTransferTxs(firstBatch.Transactions).TotalFee())
+
+	lowFeeTx := makeTx(2, 1)
+	suite.NoError(suite.Keeper().AddUnbatchedTx(suite.Ctx, lowFeeTx))
+
+	suite.Ctx = suite.Ctx.WithBlockHeight(21)
+	secondBatch, err := suite.Keeper().BuildOutgoingTxBatch(
+		suite.Ctx,
+		tokenContract,
+		feeReceive,
+		100,
+		sdkmath.NewInt(1),
+		sdkmath.ZeroInt(),
+	)
+	suite.Require().Error(err)
+	suite.Require().Nil(secondBatch)
+
+	restoredTx, err := suite.Keeper().GetUnbatchedTxByFeeAndId(suite.Ctx, lowFeeTx.Fee, lowFeeTx.Id)
+	suite.Require().NoError(err)
+	suite.Require().Equal(lowFeeTx.Id, restoredTx.Id)
+
+	relayer := types.Relayer{
+		RelayerAddress: suite.relayerAddrs[0].String(),
+		StartHeight:    0,
+	}
+	suite.Keeper().SetRelayer(suite.Ctx, suite.relayerAddrs[0], relayer)
+
+	response, err := suite.QueryClient().LastPendingBatchRequestByAddr(
+		sdk.WrapSDKContext(suite.Ctx),
+		&types.QueryLastPendingBatchRequestByAddrRequest{
+			RelayerAddress: relayer.RelayerAddress,
+		},
+	)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(response.Batch)
+	suite.Require().Equal(firstBatch.BatchNonce, response.Batch.BatchNonce)
+}
+
 func (suite *KeeperTestSuite) TestKeeper_DeleteBatchConfirm() {
 	tokenContract := helpers.GenerateAddress().Hex()
 	batch := &types.OutgoingTxBatch{


### PR DESCRIPTION
Fixes #286

## Summary
- Treat the latest same-token batch as live only while its timeout is still at or above the projected external height.
- Reject a candidate batch when an existing live batch has a greater or equal total fee.
- Restore selected transactions to the unbatched pool when the candidate is rejected, so the rejected low-fee attempt does not silently remove withdrawals from the pool.
- Cancel a less-profitable live batch before storing a higher-fee replacement.

## Why
`BuildOutgoingTxBatch` previously allowed a newer low-fee batch to be created while a higher-fee same-token batch was still live. Because relayer queries iterate batches in reverse order, the lower-fee newer batch could supersede the higher-fee pending batch in `LastPendingBatchRequestByAddr`.

## Verification
- Red before fix: `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestLiveLowFeeBatchDoesNotSupersedeHigherFeePendingBatch$' -count=1 -v` failed with `An error is expected but got nil`.
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestLiveLowFeeBatchDoesNotSupersedeHigherFeePendingBatch$' -count=1 -v`
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(LastPendingBatchRequestByAddr|LiveLowFeeBatchDoesNotSupersedeHigherFeePendingBatch|Keeper_DeleteBatchConfirm|Keeper_IterateBatch)$' -count=1 -v`
- `go test ./x/gravity/keeper -run '^$' -count=1`
- `go test ./x/gravity/types -run '^$' -count=1`
- `go test ./app -run '^$' -count=1`
- `git diff --check`

## Reward address
`0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`
