### PR TITLE
fix(rollapp): make fraud handling atomic

### DIFF
--- a/x/rollapp/keeper/fraud_handler.go
+++ b/x/rollapp/keeper/fraud_handler.go
@@ -16,6 +16,19 @@ import (
 
 // HandleFraud handles the fraud evidence submitted by the user.
 func (k Keeper) HandleFraud(ctx sdk.Context, rollappID, clientId string, fraudHeight uint64, seqAddr string) error {
+	cacheCtx, writeCache := ctx.CacheContext()
+	if err := k.handleFraud(cacheCtx, rollappID, clientId, fraudHeight, seqAddr); err != nil {
+		return err
+	}
+
+	events := cacheCtx.EventManager().Events()
+	writeCache()
+	ctx.EventManager().EmitEvents(events)
+
+	return nil
+}
+
+func (k Keeper) handleFraud(ctx sdk.Context, rollappID, clientId string, fraudHeight uint64, seqAddr string) error {
 	// Get the rollapp from the store
 	rollapp, found := k.GetRollapp(ctx, rollappID)
 	if !found {

--- a/x/rollapp/keeper/fraud_handler_test.go
+++ b/x/rollapp/keeper/fraud_handler_test.go
@@ -116,8 +116,28 @@ func (suite *RollappTestSuite) TestHandleFraud_WrongChannelID() {
 	_, err := suite.PostStateUpdate(*ctx, rollapp, proposer, 1, uint64(10))
 	suite.Require().Nil(err)
 
+	storedRollapp, found := keeper.GetRollapp(*ctx, rollapp)
+	suite.Require().True(found)
+	suite.Require().False(storedRollapp.Frozen)
+
+	stateInfo, err := keeper.FindStateInfoByHeight(*ctx, rollapp, 2)
+	suite.Require().Nil(err)
+	suite.Require().Equal(common.Status_PENDING, stateInfo.Status)
+
 	err = keeper.HandleFraud(*ctx, rollapp, "wrongChannelID", 2, proposer)
 	suite.Require().NotNil(err)
+
+	storedRollapp, found = keeper.GetRollapp(*ctx, rollapp)
+	suite.Require().True(found)
+	suite.Require().False(storedRollapp.Frozen)
+
+	stateInfo, err = keeper.FindStateInfoByHeight(*ctx, rollapp, 2)
+	suite.Require().Nil(err)
+	suite.Require().Equal(common.Status_PENDING, stateInfo.Status)
+
+	sequencers := suite.App.SequencerKeeper.GetSequencersByRollapp(*ctx, rollapp)
+	suite.Require().Len(sequencers, 1)
+	suite.Require().Equal(types.Bonded, sequencers[0].Status)
 }
 
 // Fail - Disputing already reverted state


### PR DESCRIPTION
Fixes #189

## Summary
- Run `HandleFraud` against a cached context and commit only after the full flow succeeds.
- Propagate emitted events back to the parent context after a successful cache write.
- Strengthen the wrong-clientID regression test to prove the error path leaves the rollapp unfrozen, the disputed state pending, and the sequencer bonded.

## Why
`HandleFraud` previously called hooks, froze the rollapp, and reverted pending states before validating the provided client ID. If the client ID was wrong, the function returned an error after persistent state had already changed.

The cached context makes the fraud path all-or-nothing: any error discards intermediate writes.

## Verification
- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestHandleFraud(_WrongChannelID)?$' -count=1 -v`
- `go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestHandleFraud' -count=1 -v`
- `go test ./x/rollapp/keeper -run '^$' -count=1`
- `go test ./x/rollapp/types -run '^$' -count=1`
- `go test ./app -run '^$' -count=1`
- `git diff --check`

## Reward address
`0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099`
