### PR TITLE
fix(sequencer): block unbond during proposer replacement

### DIFF
--- a/x/sequencer/keeper/msg_server_unbond.go
+++ b/x/sequencer/keeper/msg_server_unbond.go
@@ -37,6 +37,11 @@ func (k Keeper) setSequencerToUnbonding(ctx sdk.Context, seqAddr string) (time.T
 			seq.Status.String(),
 		)
 	}
+
+	if err := k.validateNoPendingReplaceProposerUnbond(ctx, seq); err != nil {
+		return time.Time{}, err
+	}
+
 	oldStatus := seq.Status
 	wasProposer := seq.Proposer
 
@@ -64,4 +69,26 @@ func (k Keeper) setSequencerToUnbonding(ctx sdk.Context, seqAddr string) (time.T
 	}
 
 	return completionTime, nil
+}
+
+func (k Keeper) validateNoPendingReplaceProposerUnbond(ctx sdk.Context, seq types.Sequencer) error {
+	pending, err := k.GetReplaceProposer(ctx, seq.RollappId)
+	if err != nil {
+		return err
+	}
+	if pending == nil {
+		return nil
+	}
+
+	replaceProposer := pending.ReplaceProposer
+	if seq.SequencerAddress != replaceProposer.OldProposer && seq.SequencerAddress != replaceProposer.NewProposer {
+		return nil
+	}
+
+	return errorsmod.Wrapf(
+		types.ErrInvalidRequest,
+		"sequencer %s cannot unbond while replace proposer is pending for rollapp %s",
+		seq.SequencerAddress,
+		seq.RollappId,
+	)
 }

--- a/x/sequencer/keeper/unbond_test.go
+++ b/x/sequencer/keeper/unbond_test.go
@@ -120,3 +120,53 @@ func (suite *SequencerTestSuite) TestTokensRefundOnUnbond() {
 	suite.Equal(types.Unbonding, sequencer2.Status)
 	suite.False(sequencer2.Tokens.IsZero())
 }
+
+func (suite *SequencerTestSuite) TestPendingReplaceProposerBlocksOldProposerUnbondBeforeActivation() {
+	suite.SetupTest()
+
+	rollappId := suite.CreateDefaultRollapp()
+	oldProposer := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	newProposer := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	err := suite.App.SequencerKeeper.SetReplaceProposer(suite.Ctx, &types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: oldProposer,
+		NewProposer: newProposer,
+		BlockHeight: 10,
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.msgServer.Unbond(suite.Ctx, &types.MsgUnbond{Creator: oldProposer})
+	suite.Require().Nil(resp)
+	suite.Require().ErrorIs(err, types.ErrInvalidRequest)
+
+	seq, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, oldProposer)
+	suite.Require().True(found)
+	suite.Require().Equal(types.Bonded, seq.Status)
+	suite.Require().True(seq.Proposer)
+}
+
+func (suite *SequencerTestSuite) TestPendingReplaceProposerBlocksNewProposerUnbondBeforeActivation() {
+	suite.SetupTest()
+
+	rollappId := suite.CreateDefaultRollapp()
+	oldProposer := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	newProposer := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	err := suite.App.SequencerKeeper.SetReplaceProposer(suite.Ctx, &types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: oldProposer,
+		NewProposer: newProposer,
+		BlockHeight: 10,
+	})
+	suite.Require().NoError(err)
+
+	resp, err := suite.msgServer.Unbond(suite.Ctx, &types.MsgUnbond{Creator: newProposer})
+	suite.Require().Nil(resp)
+	suite.Require().ErrorIs(err, types.ErrInvalidRequest)
+
+	seq, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, newProposer)
+	suite.Require().True(found)
+	suite.Require().Equal(types.Bonded, seq.Status)
+	suite.Require().False(seq.Proposer)
+}


### PR DESCRIPTION
Fixes #174

## Summary
- block unbonding for both old and new proposers while a ReplaceProposer request is pending
- keep the sequencer state unchanged when the guarded unbond is rejected
- add regression coverage for both pending replacement participants

## Tests
- go test ./x/sequencer/keeper -run 'TestSequencerKeeperTestSuite/TestPendingReplaceProposerBlocks(Old|New)ProposerUnbondBeforeActivation$' -count=1 -v\n- go test ./x/sequencer/keeper -run 'TestSequencerKeeperTestSuite/TestUnbondingMultiple$' -count=1 -v\n- go test ./x/sequencer/keeper -run '^$' -count=1\n- go test ./x/sequencer/types -run '^$' -count=1\n- go test ./app -run '^$' -count=1\n- git diff --check\n\n## Bounty reward address\n0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099\n\nNote: the pre-existing TestTokensRefundOnUnbond test currently fails independently on a zero-token assertion in this local environment, so I did not include it as evidence for this targeted fix.