### PR TITLE
fix(wstaking): preserve validator updates in genesis

### DIFF
--- a/app/export_validator_updates_test.go
+++ b/app/export_validator_updates_test.go
@@ -1,0 +1,31 @@
+package app_test
+
+import (
+	"testing"
+
+	cometbftproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportGenesisPreservesCommittedValidatorUpdates(t *testing.T) {
+	sourceApp := apptesting.Setup(t, false)
+	sourceCtx := sourceApp.NewContext(false, cometbftproto.Header{})
+	sourceStore := sourceCtx.KVStore(sourceApp.GetKey(types.StoreKey))
+
+	sourceValidatorUpdates := sourceStore.Get(types.ValidatorUpdatesKey)
+	require.NotEmpty(t, sourceValidatorUpdates)
+
+	exportedGenesis := sourceApp.StakingKeeper.ExportGenesis(sourceCtx)
+
+	importApp := apptesting.Setup(t, false)
+	importCtx := importApp.NewContext(false, cometbftproto.Header{})
+	importStore := importCtx.KVStore(importApp.GetKey(types.StoreKey))
+	importStore.Delete(types.ValidatorUpdatesKey)
+	require.Empty(t, importStore.Get(types.ValidatorUpdatesKey))
+
+	importApp.StakingKeeper.InitGenesis(importCtx, exportedGenesis)
+
+	require.Equal(t, sourceValidatorUpdates, importStore.Get(types.ValidatorUpdatesKey))
+}

--- a/x/wstaking/keeper/genesis.go
+++ b/x/wstaking/keeper/genesis.go
@@ -142,6 +142,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, data *wstakingtypes.GenesisState) (
 			update.Power = lv.Power // keep the next-val-set offset, use the last power for the first block
 			res = append(res, update)
 		}
+		k.SetValidatorUpdates(ctx, res)
 	} else {
 		var err error
 

--- a/x/wstaking/keeper/keeper.go
+++ b/x/wstaking/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"math/big"
 
+	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -11,6 +12,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 
@@ -88,6 +90,19 @@ func (k Keeper) GetProposerOwnerAddress(ctx sdk.Context) (string, error) {
 
 func (k Keeper) GetStoreKey() storetypes.StoreKey {
 	return k.storeKey
+}
+
+func (k Keeper) GetValidatorUpdates(ctx sdk.Context) []abci.ValidatorUpdate {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(stakingtypes.ValidatorUpdatesKey)
+	if bz == nil {
+		return nil
+	}
+
+	var valUpdates stakingtypes.ValidatorUpdates
+	k.cdc.MustUnmarshal(bz, &valUpdates)
+
+	return valUpdates.Updates
 }
 
 func (k Keeper) GetCdc() codec.BinaryCodec {


### PR DESCRIPTION
Fixes #373

## Summary
- restore the committed staking `ValidatorUpdatesKey` when importing an exported staking genesis
- write the same validator updates that `InitGenesis` returns to CometBFT, keeping exported import state consistent with the committed staking store
- harden the wrapper `GetValidatorUpdates` path to return an empty result when the committed key is absent instead of panicking
- add an app-level regression test that proves the raw committed key round-trips through export/import

## Tests
- go test ./app -run TestExportGenesisPreservesCommittedValidatorUpdates -count=1 -v
- go test ./app -run '^$' -count=1\n- go test ./x/wstaking/keeper -run '^$' -count=1\n- go test ./x/wstaking/types -run '^$' -count=1\n- git diff --check\n\n## Bounty reward address\n0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099