### PR TITLE
fix(rollapp): freeze fraud client at latest height

### DIFF
--- a/x/rollapp/keeper/fraud_handler.go
+++ b/x/rollapp/keeper/fraud_handler.go
@@ -97,7 +97,8 @@ func (k Keeper) freezeClientState(ctx sdk.Context, clientId string) error {
 		return errorsmod.Wrapf(types.ErrInvalidClientState, "client state with ID %s is not a tendermint client state", clientId)
 	}
 
-	tmClientState.FrozenHeight = clienttypes.NewHeight(tmClientState.GetLatestHeight().GetRevisionHeight(), tmClientState.GetLatestHeight().GetRevisionNumber())
+	latestHeight := tmClientState.GetLatestHeight()
+	tmClientState.FrozenHeight = clienttypes.NewHeight(latestHeight.GetRevisionNumber(), latestHeight.GetRevisionHeight())
 	k.ibcClientKeeper.SetClientState(ctx, clientId, tmClientState)
 
 	return nil

--- a/x/rollapp/keeper/fraud_handler_test.go
+++ b/x/rollapp/keeper/fraud_handler_test.go
@@ -1,6 +1,12 @@
 package keeper_test
 
 import (
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	connectiontypes "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	commitmenttypes "github.com/cosmos/ibc-go/v7/modules/core/23-commitment/types"
+	tmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 	common "github.com/openmetaearth/me-hub/x/common/types"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
 )
@@ -173,7 +179,66 @@ func (suite *RollappTestSuite) TestHandleFraud_AlreadyFinalized() {
 	suite.Require().NotNil(err)
 }
 
-// TODO: test IBC freeze
+func (suite *RollappTestSuite) TestHandleFraudFreezesIBCClientAtLatestHeight() {
+	suite.SetupTest()
+	keeper := suite.App.RollappKeeper
+
+	rollappId := suite.CreateDefaultRollapp()
+	proposer := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	_, err := suite.PostStateUpdate(suite.Ctx, rollappId, proposer, 1, uint64(10))
+	suite.Require().NoError(err)
+
+	const (
+		clientId     = "07-tendermint-0"
+		connectionId = "connection-0"
+		channelId    = "channel-0"
+	)
+
+	latestHeight := clienttypes.NewHeight(7, 12345)
+	clientState := tmtypes.NewClientState(
+		"rollapp_1234-7",
+		tmtypes.DefaultTrustLevel,
+		ibctesting.TrustingPeriod,
+		ibctesting.UnbondingPeriod,
+		ibctesting.MaxClockDrift,
+		latestHeight,
+		commitmenttypes.GetSDKSpecs(),
+		ibctesting.UpgradePath,
+	)
+	suite.App.IBCKeeper.ClientKeeper.SetClientState(suite.Ctx, clientId, clientState)
+
+	connection := connectiontypes.NewConnectionEnd(
+		connectiontypes.OPEN,
+		clientId,
+		connectiontypes.NewCounterparty("counterparty-client-0", "connection-1", commitmenttypes.NewMerklePrefix([]byte("ibc"))),
+		[]*connectiontypes.Version{connectiontypes.DefaultIBCVersion},
+		0,
+	)
+	suite.App.IBCKeeper.ConnectionKeeper.SetConnection(suite.Ctx, connectionId, connection)
+
+	channel := channeltypes.NewChannel(
+		channeltypes.OPEN,
+		channeltypes.UNORDERED,
+		channeltypes.NewCounterparty("transfer", "channel-1"),
+		[]string{connectionId},
+		"ics20-1",
+	)
+	suite.App.IBCKeeper.ChannelKeeper.SetChannel(suite.Ctx, "transfer", channelId, channel)
+
+	rollapp, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, rollappId)
+	suite.Require().True(found)
+	rollapp.ChannelId = channelId
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	err = keeper.HandleFraud(suite.Ctx, rollappId, clientId, 2, proposer)
+	suite.Require().NoError(err)
+
+	storedClientState, found := suite.App.IBCKeeper.ClientKeeper.GetClientState(suite.Ctx, clientId)
+	suite.Require().True(found)
+	tmClientState, ok := storedClientState.(*tmtypes.ClientState)
+	suite.Require().True(ok)
+	suite.Require().Equal(latestHeight, tmClientState.FrozenHeight)
+}
 
 /* ---------------------------------- utils --------------------------------- */
 


### PR DESCRIPTION
Fixes #188

## Summary
- preserve IBC height field order when freezing a Tendermint client after fraud handling
- store `FrozenHeight` as the client latest height `(revision_number, revision_height)` instead of swapping the fields
- add an IBC-backed regression test that runs through `HandleFraud` and verifies the stored frozen height

## Tests
- go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestHandleFraudFreezesIBCClientAtLatestHeight$' -count=1 -v\n- go test ./x/rollapp/keeper -run 'TestRollappKeeperTestSuite/TestHandleFraud' -count=1 -v\n- go test ./x/rollapp/keeper -run '^$' -count=1\n- go test ./x/rollapp/types -run '^$' -count=1\n- go test ./app -run '^$' -count=1\n- git diff --check\n\n## Bounty reward address\n0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099