### PR TITLE
fix(sequencer): rotate proposer by bond denom deterministically

### DIFF
--- a/x/sequencer/keeper/sequencer.go
+++ b/x/sequencer/keeper/sequencer.go
@@ -57,8 +57,16 @@ func (k Keeper) RotateProposer(ctx sdk.Context, rollappId string) {
 	}
 
 	// take the next bonded sequencer to be the proposer. sorted by bond
+	bondDenom := k.GetParams(ctx).MinBond.Denom
 	sort.SliceStable(seqs, func(i, j int) bool {
-		return seqs[i].Tokens.IsAllGT(seqs[j].Tokens)
+		if bondDenom != "" {
+			iAmount := seqs[i].Tokens.AmountOf(bondDenom)
+			jAmount := seqs[j].Tokens.AmountOf(bondDenom)
+			if !iAmount.Equal(jAmount) {
+				return iAmount.GT(jAmount)
+			}
+		}
+		return seqs[i].SequencerAddress < seqs[j].SequencerAddress
 	})
 
 	seq := seqs[0]

--- a/x/sequencer/keeper/sequencer_test.go
+++ b/x/sequencer/keeper/sequencer_test.go
@@ -71,17 +71,24 @@ func TestSequencersByRollappGet(t *testing.T) {
 func (suite *SequencerTestSuite) TestRotatingSequencerByBond() {
 	suite.SetupTest()
 	rollappId := suite.CreateDefaultRollapp()
+	params := suite.App.SequencerKeeper.GetParams(suite.Ctx)
+	params.MinBond = sdk.NewCoin(bond.Denom, sdk.NewInt(100))
+	suite.App.SequencerKeeper.SetParams(suite.Ctx, params)
 
 	numOfSequencers := 5
 
 	// create sequencers
 	seqAddrs := make([]string, numOfSequencers)
 	for j := 0; j < len(seqAddrs)-1; j++ {
-		seqAddrs[j] = suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+		seqAddrs[j] = suite.CreateSequencerWithBond(suite.Ctx, rollappId, params.MinBond)
 	}
 	// last one with high bond is the expected new proposer
-	seqAddrs[len(seqAddrs)-1] = suite.CreateSequencerWithBond(suite.Ctx, rollappId, sdk.NewCoin(bond.Denom, bond.Amount.MulRaw(2)))
-	expecetedProposer := seqAddrs[len(seqAddrs)-1]
+	seqAddrs[len(seqAddrs)-1] = suite.CreateSequencerWithBond(
+		suite.Ctx,
+		rollappId,
+		sdk.NewCoin(params.MinBond.Denom, params.MinBond.Amount.MulRaw(2)),
+	)
+	expectedProposer := seqAddrs[len(seqAddrs)-1]
 
 	// check starting proposer and unbond
 	sequencer, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, seqAddrs[0])
@@ -91,7 +98,57 @@ func (suite *SequencerTestSuite) TestRotatingSequencerByBond() {
 	suite.App.SequencerKeeper.RotateProposer(suite.Ctx, rollappId)
 
 	// check proposer rotation
-	newProposer, _ := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, expecetedProposer)
+	newProposer, _ := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, expectedProposer)
 	suite.Equal(types.Bonded, newProposer.Status)
 	suite.True(newProposer.Proposer)
+}
+
+func (suite *SequencerTestSuite) TestRotateProposerUsesMinBondDenom() {
+	suite.SetupTest()
+	rollappId := suite.CreateDefaultRollapp()
+
+	bondDenom := bond.Denom
+	otherDenom := "otherdenom"
+	if otherDenom == bondDenom {
+		otherDenom = "otherdenom2"
+	}
+
+	lowMinBondWithLargeOtherDenom := types.Sequencer{
+		SequencerAddress: "a-low-min-bond",
+		RollappId:        rollappId,
+		Status:           types.Bonded,
+		Tokens: sdk.NewCoins(
+			sdk.NewCoin(bondDenom, sdk.NewInt(90)),
+			sdk.NewCoin(otherDenom, sdk.NewInt(1000)),
+		),
+	}
+	expectedProposer := types.Sequencer{
+		SequencerAddress: "b-high-min-bond",
+		RollappId:        rollappId,
+		Status:           types.Bonded,
+		Tokens: sdk.NewCoins(
+			sdk.NewCoin(bondDenom, sdk.NewInt(100)),
+			sdk.NewCoin(otherDenom, sdk.NewInt(1)),
+		),
+	}
+	lowerBond := types.Sequencer{
+		SequencerAddress: "c-lower-bond",
+		RollappId:        rollappId,
+		Status:           types.Bonded,
+		Tokens:           sdk.NewCoins(sdk.NewCoin(bondDenom, sdk.NewInt(80))),
+	}
+
+	suite.App.SequencerKeeper.SetSequencer(suite.Ctx, lowMinBondWithLargeOtherDenom)
+	suite.App.SequencerKeeper.SetSequencer(suite.Ctx, expectedProposer)
+	suite.App.SequencerKeeper.SetSequencer(suite.Ctx, lowerBond)
+
+	suite.App.SequencerKeeper.RotateProposer(suite.Ctx, rollappId)
+
+	selected, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, expectedProposer.SequencerAddress)
+	suite.Require().True(found)
+	suite.True(selected.Proposer)
+
+	lowBond, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, lowMinBondWithLargeOtherDenom.SequencerAddress)
+	suite.Require().True(found)
+	suite.False(lowBond.Proposer)
 }


### PR DESCRIPTION
Fixes #97

## Summary
- Order RotateProposer candidates by the current MinBond denom amount instead of sdk.Coins.IsAllGT.
- Add deterministic address tie-breaks for equal bond amounts.
- Add a regression test with multi-denom balances where the old comparator selected the lower MinBond-denom sequencer.
- Update the existing proposer rotation test to use a real nonzero MinBond.

## Tests
- go test ./x/sequencer/keeper -run 'TestSequencerKeeperTestSuite/TestRotateProposerUsesMinBondDenom$' -count=1 -v
- go test ./x/sequencer/keeper -run 'TestSequencerKeeperTestSuite/Test(RotateProposerUsesMinBondDenom|RotatingSequencerByBond)$' -count=1 -v
- go test ./x/sequencer/keeper -run '^$' -count=1
- go test ./x/sequencer/types -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Bounty wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099