### PR TITLE
fix(sequencer): reject multiple genesis proposers

### DIFF
--- a/x/sequencer/types/genesis.go
+++ b/x/sequencer/types/genesis.go
@@ -15,6 +15,7 @@ func DefaultGenesis() *GenesisState {
 func (gs GenesisState) Validate() error {
 	// Check for duplicated index in sequencer
 	sequencerIndexMap := make(map[string]struct{})
+	bondedProposersByRollapp := make(map[string]string)
 
 	for _, elem := range gs.SequencerList {
 
@@ -25,9 +26,19 @@ func (gs GenesisState) Validate() error {
 			return fmt.Errorf("duplicated index for sequencer")
 		}
 		sequencerIndexMap[index] = struct{}{}
-	}
 
-	// FIXME: validate single PROPOSER per rollapp
+		if elem.Status == Bonded && elem.Proposer {
+			if existing, ok := bondedProposersByRollapp[elem.RollappId]; ok {
+				return fmt.Errorf(
+					"multiple bonded proposers for rollapp %s: %s and %s",
+					elem.RollappId,
+					existing,
+					elem.SequencerAddress,
+				)
+			}
+			bondedProposersByRollapp[elem.RollappId] = elem.SequencerAddress
+		}
+	}
 
 	return gs.Params.Validate()
 }

--- a/x/sequencer/types/genesis_test.go
+++ b/x/sequencer/types/genesis_test.go
@@ -19,6 +19,48 @@ func TestGenesisState_Validate(t *testing.T) {
 			genState: types.DefaultGenesis(),
 			valid:    true,
 		},
+		{
+			desc: "same rollapp cannot have multiple bonded proposers",
+			genState: &types.GenesisState{
+				SequencerList: []types.Sequencer{
+					{
+						SequencerAddress: "seq-1",
+						RollappId:        "rollapp-1",
+						Status:           types.Bonded,
+						Proposer:         true,
+					},
+					{
+						SequencerAddress: "seq-2",
+						RollappId:        "rollapp-1",
+						Status:           types.Bonded,
+						Proposer:         true,
+					},
+				},
+				Params: types.DefaultParams(),
+			},
+			valid: false,
+		},
+		{
+			desc: "different rollapps can each have a bonded proposer",
+			genState: &types.GenesisState{
+				SequencerList: []types.Sequencer{
+					{
+						SequencerAddress: "seq-1",
+						RollappId:        "rollapp-1",
+						Status:           types.Bonded,
+						Proposer:         true,
+					},
+					{
+						SequencerAddress: "seq-2",
+						RollappId:        "rollapp-2",
+						Status:           types.Bonded,
+						Proposer:         true,
+					},
+				},
+				Params: types.DefaultParams(),
+			},
+			valid: true,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := tc.genState.Validate()


### PR DESCRIPTION
Fixes #289

## Summary
- Reject genesis states with more than one bonded proposer for the same RollApp.
- Keep separate RollApps independent, so each RollApp can still have its own bonded proposer.
- Add regression coverage for the invalid same-RollApp multi-proposer state and the valid different-RollApp state.

## Tests
- go test ./x/sequencer/types -run 'TestGenesisState_Validate/same_rollapp_cannot_have_multiple_bonded_proposers$' -count=1 -v
- go test ./x/sequencer/types -run TestGenesisState_Validate -count=1 -v
- go test ./x/sequencer/types -run '^$' -count=1
- go test ./x/sequencer -run '^$' -count=1
- go test ./x/sequencer/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Bounty wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099