### PR TITLE
fix(dao): preserve free gas accounts in genesis

### DIFF
--- a/proto/metaearth/dao/genesis.proto
+++ b/proto/metaearth/dao/genesis.proto
@@ -9,4 +9,5 @@ option go_package = "github.com/openmetaearth/me-hub/x/dao/types";
 // GenesisState defines the sudo module's genesis state.
 message GenesisState {
   DaoAddresses dao_addresses = 1 [(gogoproto.nullable) = false];
+  repeated string free_gas_accounts = 2;
 }

--- a/x/dao/genesis.go
+++ b/x/dao/genesis.go
@@ -10,11 +10,15 @@ import (
 // state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
 	k.SetDaoAddresses(ctx, genState.DaoAddresses)
+	for _, address := range genState.FreeGasAccounts {
+		k.SetFreeGasAccount(ctx, address)
+	}
 }
 
 // ExportGenesis returns the capability module's exported genesis.
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 	genesis.DaoAddresses, _ = k.GetDaoAddresses(ctx)
+	genesis.FreeGasAccounts = k.GetAllFreeGasAccounts(ctx)
 	return genesis
 }

--- a/x/dao/genesis_free_gas_test.go
+++ b/x/dao/genesis_free_gas_test.go
@@ -1,0 +1,62 @@
+package dao_test
+
+import (
+	"testing"
+
+	"github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	"github.com/openmetaearth/me-hub/x/dao"
+	daotypes "github.com/openmetaearth/me-hub/x/dao/types"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestAddress() string {
+	privKey := secp256k1.GenPrivKey()
+	return sdk.AccAddress(privKey.PubKey().Address()).String()
+}
+
+func TestExportImportMustPreserveFreeGasAccounts(t *testing.T) {
+	sourceApp := apptesting.Setup(t, false)
+	sourceCtx := sourceApp.GetBaseApp().NewContext(false, types.Header{})
+
+	daoAddresses := daotypes.DaoAddresses{
+		GlobalDao:      newTestAddress(),
+		MeidDao:        newTestAddress(),
+		DevOperator:    newTestAddress(),
+		AirdropAddress: newTestAddress(),
+	}
+	freeGasAccounts := []string{
+		newTestAddress(),
+		newTestAddress(),
+	}
+
+	sourceApp.DaoKeeper.SetDaoAddresses(sourceCtx, daoAddresses)
+	for _, address := range freeGasAccounts {
+		sourceApp.DaoKeeper.SetFreeGasAccount(sourceCtx, address)
+		require.True(t, sourceApp.DaoKeeper.CheckFreeGasAccount(sourceCtx, address))
+	}
+
+	exported := dao.ExportGenesis(sourceCtx, sourceApp.DaoKeeper)
+	require.Equal(t, daoAddresses, exported.DaoAddresses)
+	require.ElementsMatch(t, freeGasAccounts, exported.FreeGasAccounts)
+	require.NoError(t, exported.Validate())
+
+	exportedJSON := sourceApp.AppCodec().MustMarshalJSON(exported)
+	require.Contains(t, string(exportedJSON), "free_gas_accounts")
+	var decoded daotypes.GenesisState
+	sourceApp.AppCodec().MustUnmarshalJSON(exportedJSON, &decoded)
+	require.ElementsMatch(t, freeGasAccounts, decoded.FreeGasAccounts)
+
+	importedApp := apptesting.Setup(t, false)
+	importedCtx := importedApp.GetBaseApp().NewContext(false, types.Header{})
+	dao.InitGenesis(importedCtx, importedApp.DaoKeeper, *exported)
+
+	imported := dao.ExportGenesis(importedCtx, importedApp.DaoKeeper)
+	require.Equal(t, daoAddresses, imported.DaoAddresses)
+	require.ElementsMatch(t, freeGasAccounts, imported.FreeGasAccounts)
+	for _, address := range freeGasAccounts {
+		require.True(t, importedApp.DaoKeeper.CheckFreeGasAccount(importedCtx, address))
+	}
+}

--- a/x/dao/keeper/fee_gas_account.go
+++ b/x/dao/keeper/fee_gas_account.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/x/dao/types"
 )
@@ -31,4 +32,16 @@ func (k Keeper) CheckFreeGasAccount(ctx sdk.Context, address string) bool {
 		return false
 	}
 	return true
+}
+
+func (k Keeper) GetAllFreeGasAccounts(ctx sdk.Context) (list []string) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.FreeGasAddressePrefix)
+	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+	defer iterator.Close() // nolint: errcheck
+
+	for ; iterator.Valid(); iterator.Next() {
+		list = append(list, string(iterator.Value()))
+	}
+
+	return list
 }

--- a/x/dao/types/genesis.go
+++ b/x/dao/types/genesis.go
@@ -19,6 +19,7 @@ func DefaultGenesis() *GenesisState {
 			DevOperator:    "",
 			AirdropAddress: "",
 		},
+		FreeGasAccounts: []string{},
 	}
 }
 
@@ -43,6 +44,17 @@ func (gs GenesisState) Validate() error {
 	_, err = sdk.AccAddressFromBech32(gs.DaoAddresses.AirdropAddress)
 	if err != nil {
 		return fmt.Errorf("invalid airdrop address %s", gs.DaoAddresses.AirdropAddress)
+	}
+
+	freeGasAccounts := make(map[string]struct{})
+	for _, address := range gs.FreeGasAccounts {
+		if _, err = sdk.AccAddressFromBech32(address); err != nil {
+			return fmt.Errorf("invalid free gas account address %s", address)
+		}
+		if _, ok := freeGasAccounts[address]; ok {
+			return fmt.Errorf("duplicated free gas account address %s", address)
+		}
+		freeGasAccounts[address] = struct{}{}
 	}
 
 	return nil

--- a/x/dao/types/genesis.pb.go
+++ b/x/dao/types/genesis.pb.go
@@ -25,7 +25,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // GenesisState defines the sudo module's genesis state.
 type GenesisState struct {
-	DaoAddresses DaoAddresses `protobuf:"bytes,1,opt,name=dao_addresses,json=daoAddresses,proto3" json:"dao_addresses"`
+	DaoAddresses    DaoAddresses `protobuf:"bytes,1,opt,name=dao_addresses,json=daoAddresses,proto3" json:"dao_addresses"`
+	FreeGasAccounts []string     `protobuf:"bytes,2,rep,name=free_gas_accounts,json=freeGasAccounts,proto3" json:"free_gas_accounts,omitempty"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -66,6 +67,13 @@ func (m *GenesisState) GetDaoAddresses() DaoAddresses {
 		return m.DaoAddresses
 	}
 	return DaoAddresses{}
+}
+
+func (m *GenesisState) GetFreeGasAccounts() []string {
+	if m != nil {
+		return m.FreeGasAccounts
+	}
+	return nil
 }
 
 func init() {
@@ -111,6 +119,15 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.FreeGasAccounts) > 0 {
+		for iNdEx := len(m.FreeGasAccounts) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.FreeGasAccounts[iNdEx])
+			copy(dAtA[i:], m.FreeGasAccounts[iNdEx])
+			i = encodeVarintGenesis(dAtA, i, uint64(len(m.FreeGasAccounts[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
 	{
 		size, err := m.DaoAddresses.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
@@ -143,6 +160,12 @@ func (m *GenesisState) Size() (n int) {
 	_ = l
 	l = m.DaoAddresses.Size()
 	n += 1 + l + sovGenesis(uint64(l))
+	if len(m.FreeGasAccounts) > 0 {
+		for _, s := range m.FreeGasAccounts {
+			l = len(s)
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -213,6 +236,38 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			if err := m.DaoAddresses.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FreeGasAccounts", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.FreeGasAccounts = append(m.FreeGasAccounts, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
Fixes #357

## Summary
- Add free_gas_accounts to DAO genesis state.
- Export every stored free-gas account and restore it during InitGenesis.
- Validate free-gas account addresses and reject duplicates.
- Add an export/import regression test that also verifies the field survives app JSON codec marshaling.

## Tests
- go test ./x/dao -run TestExportImportMustPreserveFreeGasAccounts -count=1 -v
- go test ./x/dao -count=1
- go test ./x/dao/types -run '^$' -count=1
- go test ./x/dao/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Bounty wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099