### PR TITLE
fix(rollapp): preserve skip-delay policy in genesis

### DIFF
--- a/proto/metaearth/rollapp/genesis.proto
+++ b/proto/metaearth/rollapp/genesis.proto
@@ -18,5 +18,6 @@ message GenesisState {
   repeated StateInfoIndex latestStateInfoIndexList = 4 [(gogoproto.nullable) = false];
   repeated StateInfoIndex latestFinalizedStateIndexList = 5 [(gogoproto.nullable) = false];
   repeated BlockHeightToFinalizationQueue blockHeightToFinalizationQueueList = 6 [(gogoproto.nullable) = false];
+  repeated string skip_delay_rollapp_list = 7;
   // this line is used by starport scaffolding # genesis/proto/state
 }

--- a/x/rollapp/genesis.go
+++ b/x/rollapp/genesis.go
@@ -29,6 +29,9 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	for _, elem := range genState.BlockHeightToFinalizationQueueList {
 		k.SetBlockHeightToFinalizationQueue(ctx, elem)
 	}
+	for _, rollappID := range genState.SkipDelayRollappList {
+		k.SetSkipDelayRollapp(ctx, rollappID, true)
+	}
 	k.SetParams(ctx, genState.Params)
 	// this line is used by starport scaffolding # genesis/module/init
 }
@@ -43,6 +46,7 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis.LatestStateInfoIndexList = k.GetAllLatestStateInfoIndex(ctx)
 	genesis.LatestFinalizedStateIndexList = k.GetAllLatestFinalizedStateIndex(ctx)
 	genesis.BlockHeightToFinalizationQueueList = k.GetAllBlockHeightToFinalizationQueue(ctx)
+	genesis.SkipDelayRollappList = k.GetSkipDelayRollapps(ctx)
 
 	return genesis
 }

--- a/x/rollapp/genesis_skip_delay_test.go
+++ b/x/rollapp/genesis_skip_delay_test.go
@@ -1,0 +1,43 @@
+package rollapp_test
+
+import (
+	"testing"
+
+	cometbftproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	"github.com/openmetaearth/me-hub/x/rollapp"
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisExportImportPreservesSkipDelayRollapps(t *testing.T) {
+	sourceApp := apptesting.Setup(t, false)
+	sourceCtx := sourceApp.GetBaseApp().NewContext(false, cometbftproto.Header{})
+	rollappID := "rollapp_1234-1"
+	disabledRollappID := "rollapp_5678-1"
+
+	sourceApp.RollappKeeper.SetRollapp(sourceCtx, types.Rollapp{RollappId: rollappID})
+	sourceApp.RollappKeeper.SetRollapp(sourceCtx, types.Rollapp{RollappId: disabledRollappID})
+	sourceApp.RollappKeeper.SetSkipDelayRollapp(sourceCtx, rollappID, true)
+	sourceApp.RollappKeeper.SetSkipDelayRollapp(sourceCtx, disabledRollappID, false)
+	require.True(t, sourceApp.RollappKeeper.IsSkipDelayRollapp(sourceCtx, rollappID))
+	require.False(t, sourceApp.RollappKeeper.IsSkipDelayRollapp(sourceCtx, disabledRollappID))
+
+	exported := rollapp.ExportGenesis(sourceCtx, *sourceApp.RollappKeeper)
+	require.ElementsMatch(t, []string{rollappID}, exported.SkipDelayRollappList)
+	require.NoError(t, exported.Validate())
+
+	exportedJSON := sourceApp.AppCodec().MustMarshalJSON(exported)
+	require.Contains(t, string(exportedJSON), "skip_delay_rollapp_list")
+	var decoded types.GenesisState
+	sourceApp.AppCodec().MustUnmarshalJSON(exportedJSON, &decoded)
+	require.ElementsMatch(t, []string{rollappID}, decoded.SkipDelayRollappList)
+
+	importedApp := apptesting.Setup(t, false)
+	importedCtx := importedApp.GetBaseApp().NewContext(false, cometbftproto.Header{})
+	rollapp.InitGenesis(importedCtx, *importedApp.RollappKeeper, *exported)
+
+	require.True(t, importedApp.RollappKeeper.IsSkipDelayRollapp(importedCtx, rollappID))
+	require.False(t, importedApp.RollappKeeper.IsSkipDelayRollapp(importedCtx, disabledRollappID))
+	require.ElementsMatch(t, []string{rollappID}, importedApp.RollappKeeper.GetSkipDelayRollapps(importedCtx))
+}

--- a/x/rollapp/types/genesis.go
+++ b/x/rollapp/types/genesis.go
@@ -15,6 +15,7 @@ func DefaultGenesis() *GenesisState {
 		LatestStateInfoIndexList:           []StateInfoIndex{},
 		LatestFinalizedStateIndexList:      []StateInfoIndex{},
 		BlockHeightToFinalizationQueueList: []BlockHeightToFinalizationQueue{},
+		SkipDelayRollappList:               []string{},
 		// this line is used by starport scaffolding # genesis/types/default
 		Params: DefaultParams(),
 	}
@@ -32,6 +33,18 @@ func (gs GenesisState) Validate() error {
 			return errors.New("duplicated index for rollapp")
 		}
 		rollappIndexMap[index] = struct{}{}
+	}
+	// Check for duplicated or unknown skip-delay rollapps
+	skipDelayRollappIndexMap := make(map[string]struct{})
+	for _, rollappId := range gs.SkipDelayRollappList {
+		index := string(RollappKey(rollappId))
+		if _, ok := rollappIndexMap[index]; !ok {
+			return errors.New("skip-delay rollapp not found in rollapp list")
+		}
+		if _, ok := skipDelayRollappIndexMap[index]; ok {
+			return errors.New("duplicated index for skipDelayRollapp")
+		}
+		skipDelayRollappIndexMap[index] = struct{}{}
 	}
 	// Check for duplicated index in stateInfo
 	stateInfoIndexMap := make(map[string]struct{})

--- a/x/rollapp/types/genesis.pb.go
+++ b/x/rollapp/types/genesis.pb.go
@@ -31,6 +31,7 @@ type GenesisState struct {
 	LatestStateInfoIndexList           []StateInfoIndex                 `protobuf:"bytes,4,rep,name=latestStateInfoIndexList,proto3" json:"latestStateInfoIndexList"`
 	LatestFinalizedStateIndexList      []StateInfoIndex                 `protobuf:"bytes,5,rep,name=latestFinalizedStateIndexList,proto3" json:"latestFinalizedStateIndexList"`
 	BlockHeightToFinalizationQueueList []BlockHeightToFinalizationQueue `protobuf:"bytes,6,rep,name=blockHeightToFinalizationQueueList,proto3" json:"blockHeightToFinalizationQueueList"`
+	SkipDelayRollappList               []string                         `protobuf:"bytes,7,rep,name=skip_delay_rollapp_list,json=skipDelayRollappList,proto3" json:"skip_delay_rollapp_list,omitempty"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -108,6 +109,13 @@ func (m *GenesisState) GetBlockHeightToFinalizationQueueList() []BlockHeightToFi
 	return nil
 }
 
+func (m *GenesisState) GetSkipDelayRollappList() []string {
+	if m != nil {
+		return m.SkipDelayRollappList
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*GenesisState)(nil), "metaearth.rollapp.GenesisState")
 }
@@ -162,6 +170,15 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.SkipDelayRollappList) > 0 {
+		for iNdEx := len(m.SkipDelayRollappList) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SkipDelayRollappList[iNdEx])
+			copy(dAtA[i:], m.SkipDelayRollappList[iNdEx])
+			i = encodeVarintGenesis(dAtA, i, uint64(len(m.SkipDelayRollappList[iNdEx])))
+			i--
+			dAtA[i] = 0x3a
+		}
+	}
 	if len(m.BlockHeightToFinalizationQueueList) > 0 {
 		for iNdEx := len(m.BlockHeightToFinalizationQueueList) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -291,6 +308,12 @@ func (m *GenesisState) Size() (n int) {
 	if len(m.BlockHeightToFinalizationQueueList) > 0 {
 		for _, e := range m.BlockHeightToFinalizationQueueList {
 			l = e.Size()
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
+	if len(m.SkipDelayRollappList) > 0 {
+		for _, s := range m.SkipDelayRollappList {
+			l = len(s)
 			n += 1 + l + sovGenesis(uint64(l))
 		}
 	}
@@ -534,6 +557,38 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			if err := m.BlockHeightToFinalizationQueueList[len(m.BlockHeightToFinalizationQueueList)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SkipDelayRollappList", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SkipDelayRollappList = append(m.SkipDelayRollappList, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
Fixes #361

## Summary
- Add skip_delay_rollapp_list to RollApp genesis state.
- Export enabled skip-delay RollApps and restore them during InitGenesis.
- Validate duplicate and unknown skip-delay RollApp IDs in genesis.
- Add a round-trip regression test that verifies keeper state and app JSON codec preservation.

## Tests
- go test ./x/rollapp -run TestGenesisExportImportPreservesSkipDelayRollapps -count=1 -v
- go test ./x/rollapp -count=1
- go test ./x/rollapp/types -run '^$' -count=1
- go test ./x/rollapp/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Bounty wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099