### PR TITLE
fix(megroup): allow higher KYC levels to join groups

### DIFF
--- a/x/megroup/keeper/keeper.go
+++ b/x/megroup/keeper/keeper.go
@@ -257,7 +257,7 @@ func (k Keeper) GetDidAndKycActive(sdkCtx sdk.Context, address sdk.AccAddress, r
 	if didInfo.RegionId != regionID {
 		return "", false
 	}
-	if didInfo.KycLevel != didTypes.KYC_LEVEL_TWO {
+	if didInfo.KycLevel < didTypes.KYC_LEVEL_TWO {
 		return "", false
 	}
 	if didInfo.Status == didTypes.DID_STATUS_ACTIVE {

--- a/x/megroup/keeper/keeper_kyc_level_test.go
+++ b/x/megroup/keeper/keeper_kyc_level_test.go
@@ -1,0 +1,74 @@
+package keeper
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	"github.com/openmetaearth/me-hub/x/kyc/handler"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeKycKeeper struct {
+	dids     map[string]string
+	didInfos map[string]didtypes.DidInfo
+}
+
+func (f fakeKycKeeper) RegisterEventHandler(_ string, _ int, _ string, _ handler.HandlerFunc) {}
+
+func (f fakeKycKeeper) GetDID(_ sdk.Context, addr sdk.AccAddress) (string, bool) {
+	did, found := f.dids[string(addr)]
+	return did, found
+}
+
+func (f fakeKycKeeper) GetDidInfo(_ sdk.Context, did string) (didtypes.DidInfo, bool) {
+	info, found := f.didInfos[did]
+	return info, found
+}
+
+func TestGetDidAndKycActiveAcceptsLevelTwoAndHigher(t *testing.T) {
+	regionID := "me_earth"
+
+	testCases := []struct {
+		name   string
+		level  didtypes.KycLevel
+		active bool
+	}{
+		{name: "none", level: didtypes.KYC_LEVEL_NONE, active: false},
+		{name: "one", level: didtypes.KYC_LEVEL_ONE, active: false},
+		{name: "two", level: didtypes.KYC_LEVEL_TWO, active: true},
+		{name: "three", level: didtypes.KYC_LEVEL_THREE, active: true},
+		{name: "four", level: didtypes.KYC_LEVEL_FOUR, active: true},
+		{name: "five", level: didtypes.KYC_LEVEL_FIVE, active: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			addr := sdk.AccAddress([]byte(tc.name + "_address________"))
+			did := "did:" + tc.name
+			k := Keeper{
+				kycKeeper: fakeKycKeeper{
+					dids: map[string]string{
+						string(addr): did,
+					},
+					didInfos: map[string]didtypes.DidInfo{
+						did: {
+							RegionId: regionID,
+							KycLevel: tc.level,
+							Status:   didtypes.DID_STATUS_ACTIVE,
+						},
+					},
+				},
+			}
+
+			gotDid, ok := k.GetDidAndKycActive(sdk.Context{}, addr, regionID)
+
+			require.Equal(t, tc.active, ok)
+			if tc.active {
+				require.Equal(t, did, gotDid)
+			} else {
+				require.Empty(t, gotDid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #284

## Summary
- treat KYC level 2 as the minimum group-membership threshold instead of the only accepted level
- keep KYC none and level 1 rejected
- add a focused keeper regression test for levels none through five

## Tests
- go test ./x/megroup/keeper -run TestGetDidAndKycActiveAcceptsLevelTwoAndHigher -count=1 -v
- go test ./x/megroup/keeper -count=1
- go test ./x/megroup/keeper -run '^$' -count=1
- go test ./x/megroup/types -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

## Known unrelated failure
- go test ./x/megroup/types -count=1 currently panics in TestMsgCreateGroup_ValidateBasic on MsgCreateGroup.ValidateBasic with nil GroupInfo; this is outside this change.

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099