### PR TITLE
fix(gravity): reject duplicate outgoing txs in genesis

### DIFF
--- a/x/gravity/types/genesis.go
+++ b/x/gravity/types/genesis.go
@@ -1,10 +1,46 @@
 package types
 
+import (
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+)
+
 // ValidateBasic validates genesis state by looping through the params and
 // calling their validation functions
 func (m *GenesisState) ValidateBasic() error {
 	if err := m.Params.ValidateBasic(); err != nil {
 		return err
 	}
+	if err := m.validateUniqueOutgoingTransferTxIDs(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *GenesisState) validateUniqueOutgoingTransferTxIDs() error {
+	seen := make(map[uint64]string, len(m.UnbatchedTransfers))
+
+	for i, tx := range m.UnbatchedTransfers {
+		location := fmt.Sprintf("unbatched transfer index %d", i)
+		if previous, found := seen[tx.Id]; found {
+			return errorsmod.Wrapf(ErrDuplicate, "outgoing transfer tx id %d appears in %s and %s", tx.Id, previous, location)
+		}
+		seen[tx.Id] = location
+	}
+
+	for batchIndex, batch := range m.Batches {
+		for txIndex, tx := range batch.Transactions {
+			if tx == nil {
+				return errorsmod.Wrapf(ErrInvalid, "nil outgoing transfer tx in batch index %d transaction index %d", batchIndex, txIndex)
+			}
+			location := fmt.Sprintf("batch index %d transaction index %d", batchIndex, txIndex)
+			if previous, found := seen[tx.Id]; found {
+				return errorsmod.Wrapf(ErrDuplicate, "outgoing transfer tx id %d appears in %s and %s", tx.Id, previous, location)
+			}
+			seen[tx.Id] = location
+		}
+	}
+
 	return nil
 }

--- a/x/gravity/types/genesis_test.go
+++ b/x/gravity/types/genesis_test.go
@@ -1,0 +1,108 @@
+package types
+
+import (
+	"testing"
+
+	errorsmod "cosmossdk.io/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisValidateBasicRejectsDuplicateOutgoingTransferTxIDs(t *testing.T) {
+	testCases := []struct {
+		name    string
+		genesis GenesisState
+	}{
+		{
+			name: "duplicate unbatched transfer ids",
+			genesis: GenesisState{
+				Params: DefaultParams(),
+				UnbatchedTransfers: []OutgoingTransferTx{
+					{Id: 7},
+					{Id: 7},
+				},
+			},
+		},
+		{
+			name: "duplicate ids across unbatched transfer and batch",
+			genesis: GenesisState{
+				Params: DefaultParams(),
+				UnbatchedTransfers: []OutgoingTransferTx{
+					{Id: 7},
+				},
+				Batches: []OutgoingTxBatch{
+					{
+						BatchNonce: 3,
+						Transactions: []*OutgoingTransferTx{
+							{Id: 7},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "duplicate ids across batches",
+			genesis: GenesisState{
+				Params: DefaultParams(),
+				Batches: []OutgoingTxBatch{
+					{
+						BatchNonce: 3,
+						Transactions: []*OutgoingTransferTx{
+							{Id: 7},
+						},
+					},
+					{
+						BatchNonce: 4,
+						Transactions: []*OutgoingTransferTx{
+							{Id: 7},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.genesis.ValidateBasic()
+
+			require.Error(t, err)
+			require.True(t, errorsmod.IsOf(err, ErrDuplicate), "expected ErrDuplicate, got %v", err)
+		})
+	}
+}
+
+func TestGenesisValidateBasicAcceptsUniqueOutgoingTransferTxIDs(t *testing.T) {
+	genesis := GenesisState{
+		Params: DefaultParams(),
+		UnbatchedTransfers: []OutgoingTransferTx{
+			{Id: 7},
+		},
+		Batches: []OutgoingTxBatch{
+			{
+				BatchNonce: 3,
+				Transactions: []*OutgoingTransferTx{
+					{Id: 8},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, genesis.ValidateBasic())
+}
+
+func TestGenesisValidateBasicRejectsNilBatchTransfer(t *testing.T) {
+	genesis := GenesisState{
+		Params: DefaultParams(),
+		Batches: []OutgoingTxBatch{
+			{
+				BatchNonce:   3,
+				Transactions: []*OutgoingTransferTx{nil},
+			},
+		},
+	}
+
+	err := genesis.ValidateBasic()
+
+	require.Error(t, err)
+	require.True(t, errorsmod.IsOf(err, ErrInvalid), "expected ErrInvalid, got %v", err)
+}


### PR DESCRIPTION
Fixes #399

## Summary
- reject duplicate outgoing transfer tx IDs during Gravity genesis validation
- cover duplicates within unbatched transfers, within batches, and across unbatched/batched lifecycle state
- reject nil batch transaction entries before genesis import can reach keeper state restoration

## Tests
- go test ./x/gravity/types -run 'TestGenesisValidateBasic' -count=1 -v
- go test ./x/gravity/types -count=1
- go test ./x/gravity/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099