### PR TITLE
fix(gravity): convert bridge fee increases to external units

### DIFF
--- a/x/gravity/keeper/batch_fee.go
+++ b/x/gravity/keeper/batch_fee.go
@@ -112,8 +112,10 @@ func (k Keeper) AddUnbatchedTxBridgeFee(ctx sdk.Context, txId uint64, sender sdk
 		return err
 	}
 
-	// add bridge fee amount
-	tx.Fee.Amount = tx.Fee.Amount.Add(addBridgeFee.Amount)
+	// addBridgeFee is paid in voucher units. Outgoing tx fees are stored in the
+	// external token units used by the target chain.
+	externalBridgeFee := types.GetExternalUnlockAmount(addBridgeFee.Amount, k.moduleName, bridgeToken)
+	tx.Fee.Amount = tx.Fee.Amount.Add(externalBridgeFee)
 	if err := k.AddUnbatchedTx(ctx, tx); err != nil {
 		return err
 	}

--- a/x/gravity/keeper/outgoing_tx_pool_test.go
+++ b/x/gravity/keeper/outgoing_tx_pool_test.go
@@ -39,3 +39,38 @@ func (s *KeeperTestSuite) TestKeeper_OutgoingAncCancel() {
 	s.Equal(s.App.BankKeeper.GetAllBalances(s.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 	s.Equal(sendAmount, s.App.BankKeeper.GetSupply(s.Ctx, denom))
 }
+
+func (s *KeeperTestSuite) TestAddUnbatchedTxBridgeFeeUsesExternalUnits() {
+	sender := helpers.GenerateAddress().Bytes()
+	receiver := helpers.GenerateAddress().Hex()
+	denom := "uusdt"
+	tokenContract := helpers.GenerateAddress().Hex()
+	bridgeToken := types.BridgeToken{
+		ContractAddress: tokenContract,
+		Denom:           denom,
+		Symbol:          "USDT",
+		Decimal:         18,
+		Supply:          sdkmath.NewInt(20_000_000),
+	}
+	initialBalance := sdk.NewCoin(denom, bridgeToken.Supply)
+
+	s.Require().NoError(s.App.BankKeeper.MintCoins(s.Ctx, s.chainName, sdk.NewCoins(initialBalance)))
+	s.Require().NoError(s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, s.chainName, sender, sdk.NewCoins(initialBalance)))
+	s.Keeper().SetBridgeToken(s.Ctx, &bridgeToken)
+
+	amount := sdk.NewCoin(denom, sdkmath.NewInt(5_000_000))
+	initialFee := sdk.NewCoin(denom, sdkmath.NewInt(1_000_000))
+	txID, err := s.Keeper().AddToOutgoingPool(s.Ctx, sender, receiver, amount, initialFee)
+	s.Require().NoError(err)
+
+	tx, err := s.Keeper().GetUnbatchedTxById(s.Ctx, txID)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewIntWithDecimal(1, 18).String(), tx.Fee.Amount.String())
+
+	addBridgeFee := sdk.NewCoin(denom, sdkmath.NewInt(2_000_000))
+	s.Require().NoError(s.Keeper().AddUnbatchedTxBridgeFee(s.Ctx, txID, sender, addBridgeFee))
+
+	tx, err = s.Keeper().GetUnbatchedTxById(s.Ctx, txID)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewIntWithDecimal(3, 18).String(), tx.Fee.Amount.String())
+}


### PR DESCRIPTION
Addresses GRAV-NEW-003 in #277.

## Summary
- convert additional bridge fees from voucher units into external token units before updating the outgoing tx fee
- keep non-BSC and non-USDT/USDC behavior unchanged through the existing GetExternalUnlockAmount helper
- add a BSC USDT regression test proving a 2 USDT fee increase becomes 2e18 external units on an 18-decimal bridge token

## Tests
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestAddUnbatchedTxBridgeFeeUsesExternalUnits' -count=1 -v
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(Keeper_OutgoingAncCancel|AddUnbatchedTxBridgeFeeUsesExternalUnits)$' -count=1 -v
- go test ./x/gravity/keeper -run '^$' -count=1
- go test ./x/gravity/types -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099