### PR TITLE
fix(vfc): reject stale VFBC metadata updates

### DIFF
--- a/x/denommetadata/keeper/keeper.go
+++ b/x/denommetadata/keeper/keeper.go
@@ -51,11 +51,11 @@ func (k *Keeper) UpdateDenomMetadata(ctx sdk.Context, metadata banktypes.Metadat
 	if !found {
 		return gerrc.ErrNotFound
 	}
-	k.bankKeeper.SetDenomMetaData(ctx, metadata)
 	err := k.hooks.AfterDenomMetadataUpdate(ctx, metadata)
 	if err != nil {
 		return err
 	}
+	k.bankKeeper.SetDenomMetaData(ctx, metadata)
 	return nil
 }
 

--- a/x/denommetadata/keeper/keeper_test.go
+++ b/x/denommetadata/keeper/keeper_test.go
@@ -58,6 +58,28 @@ func (suite *KeeperTestSuite) TestUpdateDenom() {
 	suite.Require().EqualValues(denom.DenomUnits[1].Exponent, suite.getDymUpdateMetadata().DenomUnits[1].Exponent)
 }
 
+func (suite *KeeperTestSuite) TestUpdateIbcDenomWithExistingVFBCDoesNotMutateBankMetadata() {
+	keeper := suite.App.DenomMetadataKeeper
+	bankKeeper := suite.App.BankKeeper
+
+	metadata := suite.getIbcMetadata()
+	err := keeper.CreateDenomMetadata(suite.Ctx, metadata)
+	suite.Require().NoError(err)
+
+	denom, found := bankKeeper.GetDenomMetaData(suite.Ctx, metadata.Base)
+	suite.Require().True(found)
+	suite.Require().EqualValues(metadata.DenomUnits[1].Exponent, denom.DenomUnits[1].Exponent)
+
+	updatedMetadata := suite.getIbcUpdateMetadata()
+	err = keeper.UpdateDenomMetadata(suite.Ctx, updatedMetadata)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "existing virtual frontier bank contract")
+
+	denom, found = bankKeeper.GetDenomMetaData(suite.Ctx, metadata.Base)
+	suite.Require().True(found)
+	suite.Require().EqualValues(metadata.DenomUnits[1].Exponent, denom.DenomUnits[1].Exponent)
+}
+
 func (suite *KeeperTestSuite) TestCreateExistingDenom() {
 	keeper := suite.App.DenomMetadataKeeper
 	err := keeper.CreateDenomMetadata(suite.Ctx, suite.getDymMetadata())
@@ -99,5 +121,33 @@ func (suite *KeeperTestSuite) getDymUpdateMetadata() banktypes.Metadata {
 		},
 		Base:    "adym",
 		Display: "DYM",
+	}
+}
+
+func (suite *KeeperTestSuite) getIbcMetadata() banktypes.Metadata {
+	return banktypes.Metadata{
+		Name:        "Atom IBC token",
+		Symbol:      "ATOM",
+		Description: "Denom metadata for IBC ATOM.",
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: "ibc/uatom", Exponent: uint32(0), Aliases: []string{}},
+			{Denom: "ATOM", Exponent: uint32(6), Aliases: []string{}},
+		},
+		Base:    "ibc/uatom",
+		Display: "ATOM",
+	}
+}
+
+func (suite *KeeperTestSuite) getIbcUpdateMetadata() banktypes.Metadata {
+	return banktypes.Metadata{
+		Name:        "Atom IBC token",
+		Symbol:      "ATOM",
+		Description: "Updated denom metadata for IBC ATOM.",
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: "ibc/uatom", Exponent: uint32(0), Aliases: []string{}},
+			{Denom: "ATOM", Exponent: uint32(18), Aliases: []string{}},
+		},
+		Base:    "ibc/uatom",
+		Display: "ATOM",
 	}
 }

--- a/x/vfc/hooks/denom_metadata_hooks.go
+++ b/x/vfc/hooks/denom_metadata_hooks.go
@@ -37,7 +37,17 @@ func (v VirtualFrontierBankContractRegistrationHook) AfterDenomMetadataCreation(
 	return nil
 }
 
-func (v VirtualFrontierBankContractRegistrationHook) AfterDenomMetadataUpdate(sdk.Context, banktypes.Metadata) error {
-	// do nothing
-	return nil
+func (v VirtualFrontierBankContractRegistrationHook) AfterDenomMetadataUpdate(ctx sdk.Context, updatedDenomMetadata banktypes.Metadata) error {
+	if !strings.HasPrefix(strings.ToLower(updatedDenomMetadata.Base), ibcDenomPrefix) {
+		return nil
+	}
+
+	_, found := v.evmKeeper.GetVirtualFrontierBankContractAddressByDenom(ctx, updatedDenomMetadata.Base)
+	if !found {
+		return nil
+	}
+
+	// Existing VFBC instances keep their constructor metadata, so allowing a
+	// bank metadata update here would make the two records disagree.
+	return fmt.Errorf("cannot update IBC denom metadata for %s with existing virtual frontier bank contract", updatedDenomMetadata.Base)
 }

--- a/x/vfc/hooks/denom_metadata_hooks_test.go
+++ b/x/vfc/hooks/denom_metadata_hooks_test.go
@@ -159,6 +159,37 @@ func (suite *HooksTestSuite) TestHookOperation_AfterDenomMetadataCreation() {
 	})
 }
 
+func (suite *HooksTestSuite) TestHookOperation_AfterDenomMetadataUpdateAllowsSafeUpdates() {
+	suite.SetupTest()
+
+	hooks := vfchooks.NewVirtualFrontierBankContractRegistrationHook(*suite.App.EvmKeeper.Keeper)
+
+	nonIbcDenom := createDenomMetadata("adym", "DYM", 18)
+	suite.Require().NoError(hooks.AfterDenomMetadataUpdate(suite.Ctx, nonIbcDenom))
+
+	ibcDenomWithoutVFBC := createDenomMetadata("ibc/not_deployed", "ATOM", 6)
+	suite.Require().NoError(hooks.AfterDenomMetadataUpdate(suite.Ctx, ibcDenomWithoutVFBC))
+}
+
+func (suite *HooksTestSuite) TestHookOperation_AfterDenomMetadataUpdateRejectsExistingVFBC() {
+	suite.SetupTest()
+
+	workingCtx := suite.Ctx.WithBlockHeight(0) // ignore invoking x/evm exec for contract deployment
+	hooks := vfchooks.NewVirtualFrontierBankContractRegistrationHook(*suite.App.EvmKeeper.Keeper)
+
+	ibcDenom := createDenomMetadata("ibc/uatom", "ATOM", 6)
+	suite.App.BankKeeper.SetDenomMetaData(workingCtx, ibcDenom)
+	suite.Require().NoError(hooks.AfterDenomMetadataCreation(workingCtx, ibcDenom))
+
+	_, found := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(workingCtx, ibcDenom.Base)
+	suite.Require().True(found, "VFBC must exist before update rejection is tested")
+
+	updatedIbcDenom := createDenomMetadata(ibcDenom.Base, ibcDenom.Display, 18)
+	err := hooks.AfterDenomMetadataUpdate(workingCtx, updatedIbcDenom)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "existing virtual frontier bank contract")
+}
+
 func createDenomMetadata(base, display string, decimals uint32) banktypes.Metadata {
 	return banktypes.Metadata{
 		Description: display,


### PR DESCRIPTION
Fixes #234

This PR prevents bank denom metadata from diverging from an already deployed Virtual Frontier Bank Contract.

What changed:
- reject IBC denom metadata updates when a VFBC already exists for that denom
- allow non-IBC updates and IBC updates before VFBC deployment
- run denommetadata update hooks before writing new bank metadata, so rejected updates do not mutate bank state
- add regression coverage for hook behavior and keeper-level atomicity

Why this path:
The current codebase has deployment and lookup support for VFBC, but no keeper method that updates metadata inside an existing VFBC. Rejecting unsafe updates is the conservative fix proposed by the issue until a real VFBC metadata migration/update path exists.

Local checks:
- go test ./x/vfc/hooks -run 'TestHooksTestSuite/TestHookOperation_AfterDenomMetadata(Update|Creation)' -count=1 -v
- go test ./x/denommetadata/keeper -count=1 -v
- go test ./x/vfc/hooks -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099