### PR TITLE
fix(wstaking): validate global fee pool withdrawal amount

### DIFF
--- a/x/wstaking/types/msg_global_fee_pool_test.go
+++ b/x/wstaking/types/msg_global_fee_pool_test.go
@@ -1,0 +1,63 @@
+package types
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgWithdrawFromGlobalDaoFeePool_ValidateBasic(t *testing.T) {
+	validAddress := sample.AccAddress()
+
+	tests := []struct {
+		name string
+		msg  *MsgWithdrawFromGlobalDaoFeePool
+		err  error
+	}{
+		{
+			name: "valid withdrawal",
+			msg: NewMsgWithdrawFromGlobalDaoFeePool(
+				validAddress,
+				sdk.NewCoins(sdk.NewInt64Coin("adym", 1)),
+			),
+		},
+		{
+			name: "invalid withdrawer",
+			msg: NewMsgWithdrawFromGlobalDaoFeePool(
+				"invalid_address",
+				sdk.NewCoins(sdk.NewInt64Coin("adym", 1)),
+			),
+			err: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "empty amount",
+			msg: NewMsgWithdrawFromGlobalDaoFeePool(
+				validAddress,
+				sdk.Coins{},
+			),
+			err: sdkerrors.ErrInvalidCoins,
+		},
+		{
+			name: "zero amount",
+			msg: NewMsgWithdrawFromGlobalDaoFeePool(
+				validAddress,
+				sdk.Coins{sdk.NewInt64Coin("adym", 0)},
+			),
+			err: sdkerrors.ErrInvalidCoins,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/x/wstaking/types/msgs.go
+++ b/x/wstaking/types/msgs.go
@@ -394,6 +394,12 @@ func (msg *MsgWithdrawFromGlobalDaoFeePool) ValidateBasic() error {
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
 	}
+	if !msg.Amount.IsValid() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+	}
+	if !msg.Amount.IsAllPositive() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "amount must be positive")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #221

This PR makes MsgWithdrawFromGlobalDaoFeePool.ValidateBasic reject invalid, empty, and zero withdrawal amounts before the message reaches the handler.

What changed:
- require msg.Amount.IsValid()
- require msg.Amount.IsAllPositive()
- add regression coverage for valid, invalid-address, empty-amount, and zero-amount cases

Local checks:
- go test ./x/wstaking/types -run TestMsgWithdrawFromGlobalDaoFeePool_ValidateBasic -count=1 -v
- go test ./x/wstaking/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Baseline note:
- go test ./x/wstaking/types -count=1 currently fails on the existing TestMsgIbcTransferFromRegionTreasure_ValidateBasic test because that test constructs messages with empty IBC fields and hits invalid source port validation before the address assertion. This failure is outside this patch.

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099