### PR TITLE
fix(wstaking): preserve downtime state on pubkey rotation

### DIFF
--- a/x/wstaking/keeper/replace_consensus_pubkey_downtime_test.go
+++ b/x/wstaking/keeper/replace_consensus_pubkey_downtime_test.go
@@ -1,0 +1,61 @@
+package keeper_test
+
+import (
+	"time"
+
+	ed25519 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestUpdateValidatorPubKeyPreservesDowntimeSigningInfo() {
+	s.SetupTest()
+
+	ctx := s.Ctx.WithBlockHeight(111)
+	validator := s.meEarthValidator
+	s.Require().True(validator.IsBonded(), "test setup needs a bonded validator")
+
+	oldConsAddr, err := validator.GetConsAddr()
+	s.Require().NoError(err)
+
+	oldSigningInfo := slashingtypes.NewValidatorSigningInfo(
+		oldConsAddr,
+		1,
+		99,
+		time.Unix(123, 0).UTC(),
+		false,
+		2,
+	)
+	s.App.SlashingKeeper.SetValidatorSigningInfo(ctx, oldConsAddr, oldSigningInfo)
+	s.App.SlashingKeeper.SetValidatorMissedBlockBitArray(ctx, oldConsAddr, 0, true)
+	s.App.SlashingKeeper.SetValidatorMissedBlockBitArray(ctx, oldConsAddr, 7, true)
+
+	newPubKey := ed25519.GenPrivKey().PubKey().(*ed25519.PubKey)
+	pubKeyData, err := newPubKey.Marshal()
+	s.Require().NoError(err)
+
+	err = s.Keeper().SetReplacePubKeyInfo(ctx, &types.UpdatePubKeyInfo{
+		OperatorAddress: validator.OperatorAddress,
+		OldConsAddress:  oldConsAddr.Bytes(),
+		PubKey:          pubKeyData,
+		UpdateAtHeight:  ctx.BlockHeight(),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.Keeper().UpdateValidatorPubKey(ctx)
+	s.Require().NoError(err)
+
+	newConsAddr := sdk.GetConsAddress(newPubKey)
+	newSigningInfo, found := s.App.SlashingKeeper.GetValidatorSigningInfo(ctx, newConsAddr)
+	s.Require().True(found, "new consensus address must have signing info")
+	s.Require().Equal(newConsAddr.String(), newSigningInfo.Address)
+	s.Require().Equal(oldSigningInfo.StartHeight, newSigningInfo.StartHeight)
+	s.Require().Equal(oldSigningInfo.IndexOffset, newSigningInfo.IndexOffset)
+	s.Require().Equal(oldSigningInfo.JailedUntil, newSigningInfo.JailedUntil)
+	s.Require().Equal(oldSigningInfo.Tombstoned, newSigningInfo.Tombstoned)
+	s.Require().Equal(oldSigningInfo.MissedBlocksCounter, newSigningInfo.MissedBlocksCounter)
+	s.Require().True(s.App.SlashingKeeper.GetValidatorMissedBlockBitArray(ctx, newConsAddr, 0))
+	s.Require().True(s.App.SlashingKeeper.GetValidatorMissedBlockBitArray(ctx, newConsAddr, 7))
+	s.Require().False(s.App.SlashingKeeper.GetValidatorMissedBlockBitArray(ctx, newConsAddr, 8))
+}

--- a/x/wstaking/keeper/update_pub_key.go
+++ b/x/wstaking/keeper/update_pub_key.go
@@ -74,17 +74,8 @@ func (k Keeper) UpdateValidatorPubKey(ctx sdk.Context) (*types.ReplaceNodePubKey
 				k.Logger(ctx).Info("AfterValidatorCreated hook ", "err", err.Error())
 				return nil, sdkerrors.Wrapf(types.ErrInterProc, "AfterValidatorCreated hook error: %v", err)
 			}
-			//directly set new signing info for new cons addr
 			newConsAddr := sdk.GetConsAddress(pk)
-			newSigningInfo := slashingtypes.NewValidatorSigningInfo(
-				newConsAddr,
-				ctx.BlockHeight(),
-				0,
-				time.Unix(0, 0),
-				false,
-				0,
-			)
-			k.slashingKeeper.SetValidatorSigningInfo(ctx, newConsAddr, newSigningInfo)
+			k.migrateValidatorSigningInfo(ctx, sdk.ConsAddress(updateInfo.OldConsAddress), newConsAddr)
 
 			ctx.EventManager().EmitEvent(
 				sdk.NewEvent(types.EventTypeStartReplacePubKey,
@@ -121,6 +112,29 @@ func (k Keeper) UpdateValidatorPubKey(ctx sdk.Context) (*types.ReplaceNodePubKey
 				ctx.BlockHeight(), updateInfo.UpdateAtHeight)
 		}
 	}
+}
+
+func (k Keeper) migrateValidatorSigningInfo(ctx sdk.Context, oldConsAddr, newConsAddr sdk.ConsAddress) {
+	signingInfo, found := k.slashingKeeper.GetValidatorSigningInfo(ctx, oldConsAddr)
+	if !found {
+		signingInfo = slashingtypes.NewValidatorSigningInfo(
+			newConsAddr,
+			ctx.BlockHeight(),
+			0,
+			time.Unix(0, 0),
+			false,
+			0,
+		)
+		k.slashingKeeper.SetValidatorSigningInfo(ctx, newConsAddr, signingInfo)
+		return
+	}
+
+	signingInfo.Address = newConsAddr.String()
+	k.slashingKeeper.SetValidatorSigningInfo(ctx, newConsAddr, signingInfo)
+	k.slashingKeeper.IterateValidatorMissedBlockBitArray(ctx, oldConsAddr, func(index int64, missed bool) (stop bool) {
+		k.slashingKeeper.SetValidatorMissedBlockBitArray(ctx, newConsAddr, index, missed)
+		return false
+	})
 }
 
 func (k Keeper) SetReplacePubKeyInfo(ctx sdk.Context, data *types.UpdatePubKeyInfo) error {


### PR DESCRIPTION
Fixes #367

This PR preserves slashing downtime state when a bonded validator rotates its consensus pubkey.

What changed:
- when old signing info exists, copy StartHeight, IndexOffset, JailedUntil, Tombstoned, and MissedBlocksCounter to the new consensus address
- copy the old consensus address missed-block bit array to the new consensus address
- keep the existing clean signing-info initialization only as a fallback when old signing info is missing
- add regression coverage for preserving downtime signing info and missed-block bits across UpdateValidatorPubKey

Local checks:
- go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestUpdateValidatorPubKeyPreservesDowntimeSigningInfo' -count=1 -v
- go test ./x/wstaking/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Baseline note:
- go test ./x/wstaking/keeper -count=1 currently fails on existing unrelated tests around delegate, stake accounting, KYC rewards, region permissions, and withdraw-from-region expectations. The new regression test passes in the full run before those baseline failures.

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099