### PR TITLE
fix(gravity): restrict relayer proposals to GlobalDao

### DIFF
--- a/x/gravity/keeper/abci_test.go
+++ b/x/gravity/keeper/abci_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/testutil/helpers"
 	"github.com/openmetaearth/me-hub/utils"
@@ -179,6 +180,24 @@ func (s *KeeperTestSuite) TestProposalRelayers() {
 		Relayers:  newRelayerList2,
 	})
 	s.Require().NoError(err)
+}
+
+func (s *KeeperTestSuite) TestProposalRelayersRejectsMeidDaoAuthority() {
+	proposalRelayers, found := s.Keeper().GetProposalRelayer(s.Ctx)
+	s.Require().True(found)
+	s.Require().EqualValues(s.relayerNumber, len(proposalRelayers.Relayers))
+
+	newRelayerList := []string{s.relayerAddrs[0].String()}
+	_, err := s.MsgServer().ProposalRelayers(sdk.WrapSDKContext(s.Ctx), &types.MsgProposalRelayers{
+		ChainName: s.chainName,
+		Authority: s.Dao.MeidDao,
+		Relayers:  newRelayerList,
+	})
+	s.Require().ErrorIs(err, govtypes.ErrInvalidSigner)
+
+	afterProposalRelayers, found := s.Keeper().GetProposalRelayer(s.Ctx)
+	s.Require().True(found)
+	s.Require().Equal(proposalRelayers.Relayers, afterProposalRelayers.Relayers)
 }
 
 func (s *KeeperTestSuite) TestAttestationAfterRelayerUpdate() {

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -366,7 +366,7 @@ func (s MsgServer) IncreaseBridgeFee(c context.Context, msg *types.MsgIncreaseBr
 
 func (s MsgServer) ProposalRelayers(c context.Context, msg *types.MsgProposalRelayers) (*types.MsgProposalRelayersResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	if !s.daoKeeper.IsDao(ctx, msg.Authority) {
+	if !s.daoKeeper.IsGlobalDao(ctx, msg.Authority) {
 		return nil, errorsmod.Wrapf(govtypes.ErrInvalidSigner, "invalid authority")
 	}
 	if err := s.UpdateProposalRelayers(ctx, msg.Relayers); err != nil {

--- a/x/gravity/types/expected_keepers.go
+++ b/x/gravity/types/expected_keepers.go
@@ -45,5 +45,5 @@ type (
 )
 
 type DaoKeeper interface {
-	IsDao(ctx sdk.Context, address string) bool
+	IsGlobalDao(ctx sdk.Context, address string) bool
 }


### PR DESCRIPTION
Fixes #354

This PR keeps Gravity relayer proposal updates under the narrower GlobalDao authority instead of the broad Dao predicate that also accepts MeidDao.

What changed:
- change MsgProposalRelayers authority check from IsDao to IsGlobalDao
- update the Gravity DaoKeeper interface accordingly
- add regression coverage that MeidDao is rejected and the existing proposal relayer set remains unchanged
- keep the existing GlobalDao proposal relayer path covered by TestProposalRelayers

Local checks:
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestProposalRelayersRejectsMeidDaoAuthority' -count=1 -v
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestProposalRelayers$' -count=1 -v
- go test ./x/gravity/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099