### PR TITLE
fix(gravity): enforce exact attestation quorum threshold

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -80,7 +80,7 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 	// This conditional stops the attestation from accidentally being applied twice.
 	// Sum the current powers of all validators who have voted and see if it passes the current threshold
 	totalPower := k.GetLastTotalPower(ctx)
-	requiredPower := types.AttestationVotesPowerThreshold.Mul(totalPower).Quo(sdk.NewIntFromUint64(types.PowerBase))
+	requiredPower := types.AttestationVotesPowerThreshold.Mul(totalPower)
 	attestationPower := sdkmath.NewInt(0)
 
 	for _, relayerStr := range att.Votes {
@@ -98,7 +98,7 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 		relayerPower := relayer.GetPower()
 		// Add it to the attestation power's sum
 		attestationPower = attestationPower.Add(relayerPower)
-		if attestationPower.LT(requiredPower) {
+		if attestationPower.Mul(sdk.NewIntFromUint64(types.PowerBase)).LT(requiredPower) {
 			continue
 		}
 

--- a/x/gravity/keeper/attestation_threshold_rounding_test.go
+++ b/x/gravity/keeper/attestation_threshold_rounding_test.go
@@ -1,0 +1,66 @@
+package keeper_test
+
+import (
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/testutil/helpers"
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+)
+
+func (s *KeeperTestSuite) TestAttestationThresholdDoesNotFloorBelowConfiguredRatio() {
+	k := s.Keeper()
+
+	highPowerRelayer := s.relayerAddrs[0]
+	lowPowerRelayer := s.relayerAddrs[1]
+	k.SetRelayer(s.Ctx, highPowerRelayer, types.Relayer{
+		RelayerAddress:  highPowerRelayer.String(),
+		ExternalAddress: helpers.GenExternalAddr(s.chainName),
+		DelegateAmount:  sdkmath.NewInt(199).Mul(sdk.DefaultPowerReduction),
+		StartHeight:     s.Ctx.BlockHeight(),
+		Online:          true,
+	})
+	k.SetRelayer(s.Ctx, lowPowerRelayer, types.Relayer{
+		RelayerAddress:  lowPowerRelayer.String(),
+		ExternalAddress: helpers.GenExternalAddr(s.chainName),
+		DelegateAmount:  sdkmath.NewInt(100).Mul(sdk.DefaultPowerReduction),
+		StartHeight:     s.Ctx.BlockHeight(),
+		Online:          true,
+	})
+	k.SetLastTotalPower(s.Ctx)
+	s.Require().Equal(sdkmath.NewInt(299), k.GetLastTotalPower(s.Ctx))
+
+	tokenContract := helpers.GenHexAddress().String()
+	bridgeToken := &types.BridgeToken{
+		ContractAddress: tokenContract,
+		Denom:           "rounding",
+		Name:            "Rounding Token",
+		Symbol:          "ROUNDING",
+		Decimal:         6,
+		Supply:          sdkmath.ZeroInt(),
+	}
+	k.SetBridgeToken(s.Ctx, bridgeToken)
+
+	receiver := s.relayerAddrs[2]
+	claim := &types.MsgSendToMeClaim{
+		EventNonce:     1,
+		BlockHeight:    1,
+		TokenContract:  tokenContract,
+		Amount:         sdkmath.NewInt(1234),
+		Sender:         helpers.GenExternalAddr(s.chainName),
+		Receiver:       receiver.String(),
+		RelayerAddress: highPowerRelayer.String(),
+		ChainName:      s.chainName,
+	}
+
+	_, err := s.MsgServer().SendToMeClaim(sdk.WrapSDKContext(s.Ctx), claim)
+	s.Require().NoError(err)
+
+	attestation := k.GetAttestation(s.Ctx, claim.EventNonce, claim.ClaimHash())
+	s.Require().NotNil(attestation)
+	s.Require().False(attestation.Observed, "199/299 power is below the configured 6666/10000 threshold")
+	s.Require().Equal(sdkmath.ZeroInt(), s.App.BankKeeper.GetBalance(s.Ctx, receiver, bridgeToken.Denom).Amount)
+
+	storedBridgeToken, err := k.GetBridgeTokenByContract(s.Ctx, tokenContract)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.ZeroInt(), storedBridgeToken.Supply)
+}


### PR DESCRIPTION
Fixes #351

This PR removes the integer-flooring gap in Gravity attestation quorum checks.

What changed:
- compare attestationPower * PowerBase against threshold * totalPower instead of dividing first
- prevent below-threshold coalitions like 199/299 from satisfying a 6666/10000 quorum due to floor rounding
- add regression coverage proving a 199-power vote over total power 299 remains unobserved and does not mint vouchers
- keep existing 7/10 quorum behavior covered by TestDepositClaim

Local checks:
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestAttestationThresholdDoesNotFloorBelowConfiguredRatio' -count=1 -v
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(DepositClaim|ProposalRelayers)$' -count=1 -v
- go test ./x/gravity/keeper -run '^$' -count=1
- go test ./app -run '^$' -count=1
- git diff --check

Payout wallet: 0x6017613e80d7893EB2aD5c0585b3f1f88CD6e099