### PR TITLE
fix(gravity): prevent relayer concentration after relayers slashed offline

### DIFF
--- a/x/gravity/keeper/relayer.go
+++ b/x/gravity/keeper/relayer.go
@@ -83,9 +83,32 @@ func (k Keeper) GetLastTotalPower(ctx sdk.Context) sdkmath.Int {
 func (k Keeper) SetLastTotalPower(ctx sdk.Context) {
 	relayers := k.GetAllRelayers(ctx, true)
 	totalPower := sdkmath.ZeroInt()
+	maxOnlinePower := sdkmath.ZeroInt()
 	for _, relayer := range relayers {
-		totalPower = totalPower.Add(relayer.GetPower())
+		power := relayer.GetPower()
+		totalPower = totalPower.Add(power)
+		if power.GT(maxOnlinePower) {
+			maxOnlinePower = power
+		}
 	}
+
+	// Calculate total bonded power (including offline relayers)
+	totalBondedPower := sdkmath.ZeroInt()
+	allRelayers := k.GetAllRelayers(ctx, false)
+	for _, relayer := range allRelayers {
+		totalBondedPower = totalBondedPower.Add(relayer.GetPower())
+	}
+
+	// If online power is over-concentrated (max online relayer > 33.34% of total online power)
+	// and there is offline power, override totalPower to totalBondedPower.
+	if totalPower.IsPositive() && totalBondedPower.GT(totalPower) {
+		// threshold = 33.34% of totalPower
+		threshold := types.AttestationProposalRelayerChangePowerThreshold.Mul(totalPower).Quo(sdkmath.NewIntFromUint64(types.PowerBase))
+		if maxOnlinePower.GT(threshold) {
+			totalPower = totalBondedPower
+		}
+	}
+
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.LastTotalPowerKey, k.cdc.MustMarshal(&sdk.IntProto{Int: totalPower}))
 }

--- a/x/gravity/keeper/relayer_test.go
+++ b/x/gravity/keeper/relayer_test.go
@@ -1,6 +1,9 @@
 package keeper_test
 
 import (
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/gravity/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -8,4 +11,49 @@ func (suite *KeeperTestSuite) TestGravityAndBridger() {
 	for _, relayer := range suite.relayerAddrs {
 		require.True(suite.T(), suite.Keeper().IsProposalRelayer(suite.Ctx, relayer.String()))
 	}
+}
+
+func (suite *KeeperTestSuite) TestOfflineRelayersDoNotConcentrateAttestationPower() {
+	k := suite.Keeper()
+	ctx := suite.Ctx
+
+	// Setup 3 relayers: A, B, C with equal delegated stake
+	relayers := suite.relayerAddrs[:3]
+	
+	for _, relayerAddr := range relayers {
+		relayer := types.Relayer{
+			Online:         true,
+			DelegateAmount: sdk.DefaultPowerReduction.MulRaw(1000), // 1000 power
+			SlashTimes:     0,
+			RelayerAddress: relayerAddr.String(),
+		}
+		k.SetRelayer(ctx, relayerAddr, relayer)
+	}
+
+	// Delete all other relayers to clean state
+	for _, relayerAddr := range suite.relayerAddrs[3:] {
+		k.DelRelayer(ctx, relayerAddr)
+	}
+
+	// Initially, all 3 are online.
+	k.SetLastTotalPower(ctx)
+	// total online power should be 3000 (1000 * 3)
+	require.Equal(suite.T(), sdkmath.NewInt(3000), k.GetLastTotalPower(ctx))
+
+	// Now Relayer B and C go offline
+	relayerB, _ := k.GetRelayer(ctx, relayers[1])
+	relayerB.Online = false
+	k.SetRelayer(ctx, relayers[1], relayerB)
+
+	relayerC, _ := k.GetRelayer(ctx, relayers[2])
+	relayerC.Online = false
+	k.SetRelayer(ctx, relayers[2], relayerC)
+
+	// Refresh total power
+	k.SetLastTotalPower(ctx)
+
+	// Since only Relayer A is online, its power (1000) represents 100% of online power,
+	// which is over the concentration threshold (33.34%).
+	// The total power should be overridden to total bonded power (3000) instead of just online power (1000).
+	require.Equal(suite.T(), sdkmath.NewInt(3000), k.GetLastTotalPower(ctx))
 }


### PR DESCRIPTION
Fixes #783. Overrides the active total power used for attestation with the full total bonded power (including offline relayers) if the maximum online relayer's power exceeds the allowed threshold of 33.34% relative to total online power. This prevents the remaining relayer set from becoming over-concentrated after some relayers are slashed offline.