### PR TITLE
fix(wdistri): restore staking reward hooks

### DIFF
--- a/x/wdistri/keeper/hook.go
+++ b/x/wdistri/keeper/hook.go
@@ -26,10 +26,9 @@ func (k Keeper) Hooks() Hooks {
 // overwrite
 // withdraw delegation rewards (which also increments period)
 func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
-	return nil
+	return h.Hooks.BeforeDelegationSharesModified(ctx, delAddr, valAddr)
 }
 
 func (h Hooks) BeforeValidatorStakingModified(ctx sdk.Context, valAddr sdk.ValAddress) error {
-	ctx.Logger().Info("allocated block reward before validator's staking modified")
-	return h.k.AllocateBlockReward(ctx)
+	return nil
 }

--- a/x/wdistri/keeper/keeper_test.go
+++ b/x/wdistri/keeper/keeper_test.go
@@ -237,6 +237,37 @@ func (suite *KeeperTestSuite) TestEndBlocker() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestBeforeDelegationSharesModifiedUsesDistributionHook() {
+	ctx := suite.HelperNewContextWith(1)
+	delAddr := suite.TestAccs[0]
+	valAddr := sdk.ValAddress(suite.TestAccs[1])
+	validator := stakingtypes.Validator{
+		OperatorAddress: valAddr.String(),
+		Tokens:          sdk.NewInt(1),
+		DelegatorShares: sdk.NewDec(1),
+	}
+	delegation := stakingtypes.Delegation{
+		DelegatorAddress: delAddr.String(),
+		ValidatorAddress: valAddr.String(),
+		Shares:           sdk.NewDec(1),
+	}
+
+	suite.stakingKeeper.EXPECT().Validator(ctx, valAddr).Return(validator)
+	suite.stakingKeeper.EXPECT().Delegation(ctx, delAddr, valAddr).Return(delegation)
+
+	err := suite.App.DistrKeeper.Hooks().BeforeDelegationSharesModified(ctx, delAddr, valAddr)
+	suite.Require().ErrorIs(err, distrtypes.ErrEmptyDelegationDistInfo)
+}
+
+func (suite *KeeperTestSuite) TestBeforeValidatorStakingModifiedDoesNotAllocateRewards() {
+	ctx := suite.HelperNewContextWith(types.OneDayTotalBlocks / 2)
+	valAddr := sdk.ValAddress(suite.TestAccs[1])
+
+	err := suite.App.DistrKeeper.Hooks().BeforeValidatorStakingModified(ctx, valAddr)
+	suite.Require().NoError(err)
+	suite.Require().Empty(ctx.EventManager().ABCIEvents())
+}
+
 func (suite *KeeperTestSuite) mockGetRegionI(ctx sdk.Context, regionShare ...int) []string {
 	var addrs []string
 	if len(regionShare) == 0 {


### PR DESCRIPTION
## Summary
- restore the embedded distribution hook for `BeforeDelegationSharesModified` so delegator rewards are settled before delegation shares change
- stop `BeforeValidatorStakingModified` from calling `AllocateBlockReward` on every staking change; scheduled daily allocation remains handled by the wdistri begin blocker
- add regression coverage for both hook behaviors

Fixes #166.
Fixes #167.

## Tests
- `go test ./x/wdistri/keeper -run 'TestKeeperTestSuite/TestBefore(DelegationSharesModifiedUsesDistributionHook|ValidatorStakingModifiedDoesNotAllocateRewards)' -count=1 -v`\n- `go test ./x/wdistri/keeper -count=1`\n- `git diff --check`