### PR TITLE
fix(wstaking): preserve old consensus address index

### DIFF
--- a/x/wstaking/keeper/replace_consensus_pubkey_test.go
+++ b/x/wstaking/keeper/replace_consensus_pubkey_test.go
@@ -1,0 +1,45 @@
+package keeper_test
+
+import (
+	ed25519 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestReplaceConsensusPubKeyKeepsOldConsAddrForHistoricalEvidence() {
+	validator := s.meEarthValidator
+	oldConsAddr, err := validator.GetConsAddr()
+	s.Require().NoError(err)
+	s.Require().NoError(s.Keeper().SetValidatorByConsAddr(s.Ctx, validator))
+
+	_, found := s.Keeper().GetValidatorByConsAddr(s.Ctx, oldConsAddr)
+	s.Require().True(found, "test precondition: old consensus address should resolve before replacement")
+
+	newPubKey := ed25519.GenPrivKey().PubKey()
+	newConsAddr := sdk.GetConsAddress(newPubKey)
+	msg, err := types.NewMsgReplaceConsensusPubKeyRequest(s.Dao.GlobalDao, validator.OperatorAddress, newPubKey, 1)
+	s.Require().NoError(err)
+
+	_, err = s.msgServer.ReplaceConsensusPubKey(s.Ctx, msg)
+	s.Require().NoError(err)
+
+	s.Ctx = s.Ctx.WithBlockHeight(1)
+	updates := s.Keeper().BlockValidatorUpdates(s.Ctx)
+	s.Require().Len(updates, 2, "replacement block should remove old key power and add new key power")
+
+	_, found = s.Keeper().GetValidatorByConsAddr(s.Ctx, oldConsAddr)
+	s.Require().True(found, "old consensus address should still resolve immediately after replacement")
+	_, found = s.Keeper().GetValidatorByConsAddr(s.Ctx, newConsAddr)
+	s.Require().True(found, "new consensus address should resolve after replacement")
+
+	s.Ctx = s.Ctx.WithBlockHeight(2)
+	_ = s.Keeper().BlockValidatorUpdates(s.Ctx)
+	_, found = s.Keeper().GetValidatorByConsAddr(s.Ctx, oldConsAddr)
+	s.Require().True(found, "old consensus address should still resolve during replacement cleanup delay")
+
+	s.Ctx = s.Ctx.WithBlockHeight(3)
+	_ = s.Keeper().BlockValidatorUpdates(s.Ctx)
+	_, found = s.Keeper().GetValidatorByConsAddr(s.Ctx, oldConsAddr)
+	s.Require().True(found, "historical evidence for the old consensus key still needs old consAddr -> validator lookup")
+	s.Require().False(s.Keeper().IsHasReplaceConsensusPubKey(s.Ctx), "replacement state should be cleaned after the delay")
+}

--- a/x/wstaking/keeper/update_pub_key.go
+++ b/x/wstaking/keeper/update_pub_key.go
@@ -99,17 +99,9 @@ func (k Keeper) UpdateValidatorPubKey(ctx sdk.Context) (*types.ReplaceNodePubKey
 				NewPubKey:       pk,
 			}, nil
 
-		} else if ctx.BlockHeight() == (updateInfo.UpdateAtHeight + 2) { //delay remove old cons addr because of distribution rewards delayed by one block
-			k.RemoveValidatorByConsAddr(ctx, sdk.ConsAddress(updateInfo.OldConsAddress))
+		} else if ctx.BlockHeight() == (updateInfo.UpdateAtHeight + 2) {
 			k.DeleteReplaceConsensusPubKey(ctx)
-			ctx.EventManager().EmitEvent(
-				sdk.NewEvent(types.EventTypeDelayRemoveOldConsAddr,
-					sdk.NewAttribute(types.AttributeKeyOperatorAddress, updateInfo.OperatorAddress),
-					sdk.NewAttribute(types.AttributeKeyOldConsAddr, sdk.ConsAddress(updateInfo.OldConsAddress).String()),
-					sdk.NewAttribute(types.AttributeKeyUpdateAtHeight, fmt.Sprintf("%d", updateInfo.UpdateAtHeight)),
-					sdk.NewAttribute("height", fmt.Sprintf("%d", ctx.BlockHeight()))),
-			)
-			k.Logger(ctx).Info("completed delayed removed old cons addr from index", "old_cons_addr",
+			k.Logger(ctx).Info("completed pubkey replacement cleanup; preserved old cons addr for evidence", "old_cons_addr",
 				sdk.ConsAddress(updateInfo.OldConsAddress).String(), "height", ctx.BlockHeight())
 			return nil, nil
 


### PR DESCRIPTION
## Summary
- keep the old consensus-address lookup after `ReplaceConsensusPubKey` cleanup so historical evidence can still resolve the validator
- still delete the pending replacement state after the cleanup delay
- add a regression test covering the replacement height, delay height, and cleanup height

Fixes #290.

## Tests
- `go test ./x/wstaking/keeper -run TestKeeperTestSuite/TestReplaceConsensusPubKeyKeepsOldConsAddrForHistoricalEvidence -count=1 -v`
- `git diff --check`

## Baseline note
- `go test ./x/wstaking/keeper -count=1` currently fails on unrelated existing tests. I verified one of the failures also occurs on clean `origin/main`: `go test ./x/wstaking/keeper -run TestKeeperTestSuite/TestKycReward_WithoutDelegation -count=1`.