### PR TITLE
fix(gravity): structure bridge token claim hash

### DIFF
--- a/x/gravity/types/msg_claim.go
+++ b/x/gravity/types/msg_claim.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
@@ -217,8 +220,27 @@ func (m *MsgBridgeTokenClaim) GetType() ClaimType {
 }
 
 func (m *MsgBridgeTokenClaim) ClaimHash() []byte {
-	path := fmt.Sprintf("%d/%d/%s/%s/%s/%d", m.BlockHeight, m.EventNonce, m.TokenContract, m.Name, m.Symbol, m.Decimals)
-	return tmhash.Sum([]byte(path))
+	var bz bytes.Buffer
+	writeClaimString(&bz, TypeMsgBridgeTokenClaim)
+	writeClaimString(&bz, m.ChainName)
+	writeClaimUint64(&bz, m.BlockHeight)
+	writeClaimUint64(&bz, m.EventNonce)
+	writeClaimString(&bz, m.TokenContract)
+	writeClaimString(&bz, m.Name)
+	writeClaimString(&bz, m.Symbol)
+	writeClaimUint64(&bz, m.Decimals)
+	return tmhash.Sum(bz.Bytes())
+}
+
+func writeClaimUint64(buf *bytes.Buffer, value uint64) {
+	var bz [8]byte
+	binary.BigEndian.PutUint64(bz[:], value)
+	buf.Write(bz[:])
+}
+
+func writeClaimString(buf *bytes.Buffer, value string) {
+	writeClaimUint64(buf, uint64(len(value)))
+	buf.WriteString(value)
 }
 
 // MsgRelayerSetUpdateClaim //

--- a/x/gravity/types/msg_claim_test.go
+++ b/x/gravity/types/msg_claim_test.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBridgeTokenClaimHashSeparatesNameAndSymbol(t *testing.T) {
+	base := MsgBridgeTokenClaim{
+		BlockHeight:   100,
+		EventNonce:    7,
+		TokenContract: "0x0000000000000000000000000000000000000001",
+		Decimals:      18,
+		ChainName:     "bsc",
+	}
+
+	first := base
+	first.Name = "AAA"
+	first.Symbol = "BBB/CCC"
+
+	second := base
+	second.Name = "AAA/BBB"
+	second.Symbol = "CCC"
+
+	require.False(t, bytes.Equal(first.ClaimHash(), second.ClaimHash()))
+}
+
+func TestBridgeTokenClaimHashIncludesChainName(t *testing.T) {
+	first := MsgBridgeTokenClaim{
+		BlockHeight:   100,
+		EventNonce:    7,
+		TokenContract: "0x0000000000000000000000000000000000000001",
+		Name:          "AAA",
+		Symbol:        "BBB",
+		Decimals:      18,
+		ChainName:     "bsc",
+	}
+	second := first
+	second.ChainName = "tron"
+
+	require.False(t, bytes.Equal(first.ClaimHash(), second.ClaimHash()))
+}


### PR DESCRIPTION
## Summary
- replace delimiter-joined `MsgBridgeTokenClaim` hash input with length-prefixed structured fields
- include claim type and chain name in the bridge-token claim hash domain
- add regression coverage for `Name` / `Symbol` slash-delimiter collision and cross-chain hash separation

Fixes #279.

## Tests
- `go test ./x/gravity/types -run 'TestBridgeTokenClaimHash(SeparatesNameAndSymbol|IncludesChainName)' -count=1 -v`\n- `go test ./x/gravity/types -count=1`\n- `git diff --check`