### PR TITLE
fix: harden v2.0.13 gov periods and slashing perms

### DIFF
--- a/app/keepers/modules.go
+++ b/app/keepers/modules.go
@@ -171,7 +171,7 @@ var MaccPerms = map[string][]string{
 	nft.ModuleName:                                     nil,
 	bsctypes.ModuleName:                                {authtypes.Minter, authtypes.Burner},
 	trontypes.ModuleName:                               {authtypes.Minter, authtypes.Burner},
-	gravitytypes.SlashingModuleAccount:                 {authtypes.Minter, authtypes.Burner},
+	gravitytypes.SlashingModuleAccount:                 {authtypes.Burner},
 }
 
 var BeginBlockers = []string{

--- a/app/keepers/modules_test.go
+++ b/app/keepers/modules_test.go
@@ -1,0 +1,15 @@
+package keepers
+
+import (
+	"testing"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	gravitytypes "github.com/openmetaearth/me-hub/x/gravity/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGravitySlashingModuleAccountCannotMint(t *testing.T) {
+	perms := MaccPerms[gravitytypes.SlashingModuleAccount]
+	require.NotContains(t, perms, authtypes.Minter)
+	require.Contains(t, perms, authtypes.Burner)
+}

--- a/app/upgrades/v2_0_13/upgrade.go
+++ b/app/upgrades/v2_0_13/upgrade.go
@@ -3,6 +3,8 @@ package v2_0_13
 import (
 	sdkmath "cosmossdk.io/math"
 	"fmt"
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -15,7 +17,11 @@ import (
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 	gravitytypes "github.com/openmetaearth/me-hub/x/gravity/types"
 	trontypes "github.com/openmetaearth/me-hub/x/tron/types"
-	"time"
+)
+
+const (
+	govMaxDepositPeriod = 14 * 24 * time.Hour
+	govVotingPeriod     = 7 * 24 * time.Hour
 )
 
 // CreateUpgradeHandler creates an SDK upgrade handler for v2.0.13
@@ -38,9 +44,9 @@ func CreateUpgradeHandler(
 		}
 
 		params := keepers.GovKeeper.GetParams(ctx)
-		maxDepositPeriod := 30 * time.Minute
+		maxDepositPeriod := govMaxDepositPeriod
 		params.MaxDepositPeriod = &maxDepositPeriod
-		votingPeriod := 30 * time.Minute
+		votingPeriod := govVotingPeriod
 		params.VotingPeriod = &votingPeriod
 		if err := keepers.GovKeeper.SetParams(ctx, params); err != nil {
 			panic(fmt.Sprintf("failed to set gov module params during upgrade: %s", err.Error()))

--- a/app/upgrades/v2_0_13/upgrade_test.go
+++ b/app/upgrades/v2_0_13/upgrade_test.go
@@ -1,0 +1,15 @@
+package v2_0_13
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGovPeriodsUseDeliberativeWindows(t *testing.T) {
+	require.Equal(t, 14*24*time.Hour, govMaxDepositPeriod)
+	require.Equal(t, 7*24*time.Hour, govVotingPeriod)
+	require.GreaterOrEqual(t, govMaxDepositPeriod, 7*24*time.Hour)
+	require.GreaterOrEqual(t, govVotingPeriod, 7*24*time.Hour)
+}


### PR DESCRIPTION
## Summary
- replace v2.0.13 30-minute governance windows with 14-day max deposit and 7-day voting periods
- remove `Minter` from the Gravity slashing module account permissions
- add regression tests for both security invariants

Fixes #247.

## Tests
- `go test ./app/upgrades/v2_0_13 -run TestGovPeriodsUseDeliberativeWindows -count=1 -v`
- `go test ./app/keepers -run TestGravitySlashingModuleAccountCannotMint -count=1 -v`
- `go test ./app/upgrades/v2_0_13 ./app/keepers -count=1`
- `git diff --check`