### PR TITLE
fix(types): prevent double EIP155 suffix and correct chain ID fallback at startup

### DIFF
--- a/cmd/med/cmd/start.go
+++ b/cmd/med/cmd/start.go
@@ -431,15 +431,17 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, opts ethermin
 		}
 	}
 
-	chainID := metypes.ChainIdWithEIP155()
+	var chainID string
 	if config.API.Enable || config.JSONRPC.Enable {
-		if chainID == "" {
-			genDoc, err := genDocProvider()
-			if err != nil {
-				return err
-			}
-			chainID = genDoc.ChainID
+		genDoc, err := genDocProvider()
+		if err != nil {
+			return err
 		}
+		metypes.SetChainId(genDoc.ChainID)
+		chainID = metypes.ChainIdWithEIP155()
+	} else {
+		chainID = metypes.ChainIdWithEIP155()
+	}
 
 		clientCtx = clientCtx.
 			WithHomeDir(home).
@@ -541,13 +543,6 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, opts ethermin
 	)
 
 	if config.JSONRPC.Enable {
-		if chainID == "" {
-			genDoc, err := genDocProvider()
-			if err != nil {
-				return err
-			}
-			chainID = genDoc.ChainID
-		}
 		clientCtx := clientCtx.WithChainID(chainID)
 
 		tmEndpoint := "/websocket"

--- a/types/version.go
+++ b/types/version.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 )
@@ -17,8 +18,9 @@ const (
 )
 
 var (
-	chainId = MainnetV1ChainId
-	once    sync.Once
+	chainId            = MainnetV1ChainId
+	once               sync.Once
+	eip155SuffixRegexp = regexp.MustCompile(`_[0-9]+-[0-9]+$`)
 )
 
 func SetChainId(id string) {
@@ -32,8 +34,15 @@ func ChainId() string {
 }
 
 func ChainIdWithEIP155() string {
-	if strings.Contains(ChainId(), "testnet") {
-		return fmt.Sprintf("%s_%d-1", ChainId(), TestnetEvmChainID)
+	curr := ChainId()
+	if curr == "" {
+		return ""
 	}
-	return fmt.Sprintf("%s_%d-1", ChainId(), MainnetEvmChainID)
+	if eip155SuffixRegexp.MatchString(curr) {
+		return curr
+	}
+	if strings.Contains(curr, "testnet") {
+		return fmt.Sprintf("%s_%d-1", curr, TestnetEvmChainID)
+	}
+	return fmt.Sprintf("%s_%d-1", curr, MainnetEvmChainID)
 }


### PR DESCRIPTION
## Summary

This PR resolves #896 by making `ChainIdWithEIP155()` idempotent and ensuring that `med start` parses the genesis chain ID before attempting to construct the EIP155 chain domain.

## Changes

1. **`types/version.go`**:
   - Integrated `regexp` to verify if the active `ChainId()` already contains an EIP155 suffix (matching `_[0-9]+-[0-9]+$`).
   - If a suffix is already present, `ChainIdWithEIP155()` returns the value unchanged, preventing double-suffixing (e.g. `mechain_testnet_202405-1_202405-1`).
2. **`cmd/med/cmd/start.go`**:
   - Moved the `genDoc` provider invocation to run before `ChainIdWithEIP155()`.
   - Set the genesis chain ID globally on the package using `metypes.SetChainId(genDoc.ChainID)` so that `ChainIdWithEIP155()` is evaluated against the correct, active genesis network parameters rather than the compiled mainnet fallback.
   - Removed the unreachable `chainID == ""` check blocks.

Closes #896
