### PR TITLE
fix(sequencer): enforce non-zero min bond

### DIFF
--- a/x/sequencer/keeper/msg_server_create_sequencer.go
+++ b/x/sequencer/keeper/msg_server_create_sequencer.go
@@ -46,26 +46,31 @@ func (k msgServer) CreateSequencer(goCtx context.Context, msg *types.MsgCreateSe
 		return nil, err
 	}
 
-	bond := sdk.Coins{}
 	minBond := k.GetParams(ctx).MinBond
-	if !minBond.IsNil() && !minBond.IsZero() {
-		if msg.Bond.Denom != minBond.Denom {
-			return nil, errorsmod.Wrapf(
-				types.ErrInvalidCoinDenom, "got %s, expected %s", msg.Bond.Denom, minBond.Denom,
-			)
-		}
+	if !minBond.IsValid() || !minBond.IsPositive() {
+		return nil, errorsmod.Wrapf(types.ErrInvalidMinBond, "expected positive min bond, got %s", minBond)
+	}
 
-		if msg.Bond.Amount.LT(minBond.Amount) {
-			return nil, errorsmod.Wrapf(
-				types.ErrInsufficientBond, "got %s, expected %s", msg.Bond.Amount, minBond,
-			)
-		}
+	if !msg.Bond.IsValid() || !msg.Bond.IsPositive() {
+		return nil, errorsmod.Wrapf(types.ErrInsufficientBond, "got %s, expected at least %s", msg.Bond, minBond)
+	}
 
-		err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, seqAcc, types.ModuleName, sdk.NewCoins(msg.Bond))
-		if err != nil {
-			return nil, err
-		}
-		bond = sdk.NewCoins(msg.Bond)
+	if msg.Bond.Denom != minBond.Denom {
+		return nil, errorsmod.Wrapf(
+			types.ErrInvalidCoinDenom, "got %s, expected %s", msg.Bond.Denom, minBond.Denom,
+		)
+	}
+
+	if msg.Bond.Amount.LT(minBond.Amount) {
+		return nil, errorsmod.Wrapf(
+			types.ErrInsufficientBond, "got %s, expected %s", msg.Bond.Amount, minBond,
+		)
+	}
+
+	bond := sdk.NewCoins(msg.Bond)
+	err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, seqAcc, types.ModuleName, bond)
+	if err != nil {
+		return nil, err
 	}
 
 	sequencer := types.Sequencer{

--- a/x/sequencer/keeper/msg_server_create_sequencer_test.go
+++ b/x/sequencer/keeper/msg_server_create_sequencer_test.go
@@ -37,16 +37,17 @@ func (suite *SequencerTestSuite) TestMinBond() {
 	rollappId := suite.CreateDefaultRollapp()
 
 	testCases := []struct {
-		name          string
-		requiredBond  sdk.Coin
-		bond          sdk.Coin
-		expectedError error
+		name             string
+		requiredBond     sdk.Coin
+		bond             sdk.Coin
+		expectedError    error
+		expectedParamErr bool
 	}{
 		{
-			name:          "No bond required",
-			requiredBond:  sdk.Coin{},
-			bond:          sdk.NewCoin("adym", sdk.NewInt(10000000)),
-			expectedError: nil,
+			name:             "No bond required is rejected",
+			requiredBond:     sdk.NewCoin(bond.Denom, sdk.ZeroInt()),
+			bond:             bond,
+			expectedParamErr: true,
 		},
 		{
 			name:          "Valid bond",
@@ -74,6 +75,12 @@ func (suite *SequencerTestSuite) TestMinBond() {
 			MinBond:       tc.requiredBond,
 			UnbondingTime: 100,
 		}
+		if tc.expectedParamErr {
+			suite.Require().Panics(func() {
+				suite.App.SequencerKeeper.SetParams(suite.Ctx, seqParams)
+			}, tc.name)
+			continue
+		}
 		suite.App.SequencerKeeper.SetParams(suite.Ctx, seqParams)
 
 		pubkey1 := secp256k1.GenPrivKey().PubKey()
@@ -88,7 +95,7 @@ func (suite *SequencerTestSuite) TestMinBond() {
 		sequencerMsg1 := types.MsgCreateSequencer{
 			Creator:      addr1.String(),
 			DymintPubKey: pkAny1,
-			Bond:         bond,
+			Bond:         tc.bond,
 			RollappId:    rollappId,
 			Description:  types.Description{},
 		}
@@ -100,13 +107,74 @@ func (suite *SequencerTestSuite) TestMinBond() {
 			suite.Require().NoError(err)
 			sequencer, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr1.String())
 			suite.Require().True(found, tc.name)
-			if tc.requiredBond.IsNil() {
-				suite.Require().True(sequencer.Tokens.IsZero(), tc.name)
-			} else {
-				suite.Require().Equal(sdk.NewCoins(tc.requiredBond), sequencer.Tokens, tc.name)
-			}
+			suite.Require().Equal(sdk.NewCoins(tc.bond), sequencer.Tokens, tc.name)
 		}
 	}
+}
+
+func (suite *SequencerTestSuite) TestCreateSequencerRejectsZeroBond() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollappId := suite.CreateDefaultRollapp()
+
+	pubkey := secp256k1.GenPrivKey().PubKey()
+	addr := sdk.AccAddress(pubkey.Address())
+	err := bankutil.FundAccount(suite.App.BankKeeper, suite.Ctx, addr, sdk.NewCoins(bond))
+	suite.Require().NoError(err)
+
+	pkAny, err := codectypes.NewAnyWithValue(pubkey)
+	suite.Require().NoError(err)
+
+	sequencerMsg := types.MsgCreateSequencer{
+		Creator:      addr.String(),
+		DymintPubKey: pkAny,
+		Bond:         sdk.NewCoin(bond.Denom, sdk.ZeroInt()),
+		RollappId:    rollappId,
+		Description:  types.Description{},
+	}
+
+	_, err = suite.msgServer.CreateSequencer(goCtx, &sequencerMsg)
+	suite.Require().ErrorIs(err, types.ErrInsufficientBond)
+
+	_, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr.String())
+	suite.Require().False(found)
+}
+
+func (suite *SequencerTestSuite) TestDefaultMinBondCreatesCollateralizedProposer() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollappId := suite.CreateDefaultRollapp()
+	suite.Require().True(types.DefaultParams().MinBond.IsPositive())
+
+	pubkey := secp256k1.GenPrivKey().PubKey()
+	addr := sdk.AccAddress(pubkey.Address())
+	err := bankutil.FundAccount(suite.App.BankKeeper, suite.Ctx, addr, sdk.NewCoins(bond))
+	suite.Require().NoError(err)
+
+	pkAny, err := codectypes.NewAnyWithValue(pubkey)
+	suite.Require().NoError(err)
+
+	sequencerMsg := types.MsgCreateSequencer{
+		Creator:      addr.String(),
+		DymintPubKey: pkAny,
+		Bond:         bond,
+		RollappId:    rollappId,
+		Description:  types.Description{},
+	}
+
+	_, err = suite.msgServer.CreateSequencer(goCtx, &sequencerMsg)
+	suite.Require().NoError(err)
+
+	sequencer, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr.String())
+	suite.Require().True(found)
+	suite.Require().Equal(types.Bonded, sequencer.Status)
+	suite.Require().True(sequencer.Proposer)
+	suite.Require().Equal(sdk.NewCoins(bond), sequencer.Tokens)
+
+	moduleAddr := suite.App.AccountKeeper.GetModuleAddress(types.ModuleName)
+	suite.Require().Equal(bond, suite.App.BankKeeper.GetBalance(suite.Ctx, moduleAddr, bond.Denom))
 }
 
 func (suite *SequencerTestSuite) TestCreateSequencer() {

--- a/x/sequencer/keeper/slashing.go
+++ b/x/sequencer/keeper/slashing.go
@@ -22,13 +22,17 @@ func (k Keeper) Slashing(ctx sdk.Context, seqAddr string) error {
 	}
 
 	seqTokens := seq.Tokens
-	if !seqTokens.Empty() {
-		err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, seqTokens)
-		if err != nil {
-			return err
-		}
-	} else {
-		k.Logger(ctx).Error("sequencer has no tokens to slash", "sequencer", seq.SequencerAddress)
+	if !seqTokens.IsValid() || seqTokens.Empty() {
+		return errorsmod.Wrapf(
+			types.ErrInvalidSequencerTokens,
+			"sequencer %s has no slashable bond",
+			seq.SequencerAddress,
+		)
+	}
+
+	err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, seqTokens)
+	if err != nil {
+		return err
 	}
 	seq.Tokens = sdk.Coins{}
 

--- a/x/sequencer/keeper/slashing_test.go
+++ b/x/sequencer/keeper/slashing_test.go
@@ -79,6 +79,31 @@ func (suite *SequencerTestSuite) TestSlashingUnbondingSequencer() {
 	suite.assertSlashed(seqAddr)
 }
 
+func (suite *SequencerTestSuite) TestSlashingBondedSequencerWithoutTokensFails() {
+	suite.SetupTest()
+	keeper := suite.App.SequencerKeeper
+
+	rollappId := suite.CreateDefaultRollapp()
+	seqAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	seq, found := keeper.GetSequencer(suite.Ctx, seqAddr)
+	suite.Require().True(found)
+	suite.Require().Equal(types.Bonded, seq.Status)
+	suite.Require().True(seq.Proposer)
+
+	seq.Tokens = sdk.Coins{}
+	keeper.SetSequencer(suite.Ctx, seq)
+
+	err := keeper.Slashing(suite.Ctx, seqAddr)
+	suite.Require().ErrorIs(err, types.ErrInvalidSequencerTokens)
+
+	seq, found = keeper.GetSequencer(suite.Ctx, seqAddr)
+	suite.Require().True(found)
+	suite.Require().Equal(types.Bonded, seq.Status)
+	suite.Require().True(seq.Proposer)
+	suite.Require().True(seq.Tokens.Empty())
+}
+
 func (suite *SequencerTestSuite) TestSlashingPropserSequencer() {
 	suite.SetupTest()
 	keeper := suite.App.SequencerKeeper

--- a/x/sequencer/simulation/create_sequencer.go
+++ b/x/sequencer/simulation/create_sequencer.go
@@ -44,6 +44,7 @@ func SimulateMsgCreateSequencer(
 			DymintPubKey: pkAny,
 			RollappId:    rollappId,
 			Description:  types.Description{},
+			Bond:         k.GetParams(ctx).MinBond,
 		}
 
 		bNotPermissioned := false

--- a/x/sequencer/types/errors.go
+++ b/x/sequencer/types/errors.go
@@ -31,4 +31,5 @@ var (
 	ErrExistingReplaceProposer        = errorsmod.Register(ModuleName, 1020, "there is already a pending replace proposer request")
 	ErrReplacedSequencerCannotPropose = errorsmod.Register(ModuleName, 1021, "replaced sequencer cannot propose new state")
 	ErrorExceedAuthoredBlockHeight    = errorsmod.Register(ModuleName, 1022, "exceed authored block height limit")
+	ErrInvalidMinBond                 = errorsmod.Register(ModuleName, 1023, "invalid min bond")
 )

--- a/x/sequencer/types/genesis.go
+++ b/x/sequencer/types/genesis.go
@@ -13,6 +13,10 @@ func DefaultGenesis() *GenesisState {
 // Validate performs basic genesis state validation returning an error upon any
 // failure.
 func (gs GenesisState) Validate() error {
+	if err := gs.Params.Validate(); err != nil {
+		return err
+	}
+
 	// Check for duplicated index in sequencer
 	sequencerIndexMap := make(map[string]struct{})
 
@@ -25,9 +29,23 @@ func (gs GenesisState) Validate() error {
 			return fmt.Errorf("duplicated index for sequencer")
 		}
 		sequencerIndexMap[index] = struct{}{}
+
+		if elem.Status == Bonded || elem.Status == Unbonding {
+			if !elem.Tokens.IsValid() || elem.Tokens.Empty() {
+				return fmt.Errorf("sequencer %s has no slashable bond", elem.SequencerAddress)
+			}
+
+			if elem.Tokens.AmountOf(gs.Params.MinBond.Denom).LT(gs.Params.MinBond.Amount) {
+				return fmt.Errorf(
+					"sequencer %s bond is below min bond: got %s, expected at least %s",
+					elem.SequencerAddress,
+					elem.Tokens,
+					gs.Params.MinBond,
+				)
+			}
+		}
 	}
 
 	// FIXME: validate single PROPOSER per rollapp
-
-	return gs.Params.Validate()
+	return nil
 }

--- a/x/sequencer/types/genesis_test.go
+++ b/x/sequencer/types/genesis_test.go
@@ -3,12 +3,15 @@ package types_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenesisState_Validate(t *testing.T) {
+	params := types.DefaultParams()
+
 	for _, tc := range []struct {
 		desc     string
 		genState *types.GenesisState
@@ -18,6 +21,73 @@ func TestGenesisState_Validate(t *testing.T) {
 			desc:     "default is valid",
 			genState: types.DefaultGenesis(),
 			valid:    true,
+		},
+		{
+			desc: "bonded sequencer with min bond is valid",
+			genState: &types.GenesisState{
+				Params: params,
+				SequencerList: []types.Sequencer{
+					{
+						SequencerAddress: "sequencer-1",
+						Status:           types.Bonded,
+						Tokens:           sdk.NewCoins(params.MinBond),
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			desc: "zero min bond is invalid",
+			genState: &types.GenesisState{
+				Params: types.Params{
+					MinBond:       sdk.NewCoin(params.MinBond.Denom, sdk.ZeroInt()),
+					UnbondingTime: params.UnbondingTime,
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "bonded sequencer without tokens is invalid",
+			genState: &types.GenesisState{
+				Params: params,
+				SequencerList: []types.Sequencer{
+					{
+						SequencerAddress: "sequencer-1",
+						Status:           types.Bonded,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "unbonding sequencer below min bond is invalid",
+			genState: &types.GenesisState{
+				Params: params,
+				SequencerList: []types.Sequencer{
+					{
+						SequencerAddress: "sequencer-1",
+						Status:           types.Unbonding,
+						Tokens: sdk.NewCoins(sdk.NewCoin(
+							params.MinBond.Denom,
+							params.MinBond.Amount.Sub(sdk.OneInt()),
+						)),
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "unbonded sequencer without tokens is valid",
+			genState: &types.GenesisState{
+				Params: params,
+				SequencerList: []types.Sequencer{
+					{
+						SequencerAddress: "sequencer-1",
+						Status:           types.Unbonded,
+					},
+				},
+			},
+			valid: true,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/x/sequencer/types/messages.go
+++ b/x/sequencer/types/messages.go
@@ -98,7 +98,7 @@ func (msg *MsgCreateSequencer) ValidateBasic() error {
 		return err
 	}
 
-	if !msg.Bond.IsValid() {
+	if !msg.Bond.IsValid() || !msg.Bond.IsPositive() {
 		return errorsmod.Wrapf(ErrInvalidCoins, "invalid bond amount: %s", msg.Bond.String())
 	}
 

--- a/x/sequencer/types/params.go
+++ b/x/sequencer/types/params.go
@@ -15,8 +15,8 @@ var (
 	// MinBond types.Coin `protobuf:"bytes,1,opt,name=min_bond,json=minBond,proto3" json:"min_bond,omitempty"`
 	// UnbondingTime time.Duration `protobuf:"bytes,2,opt,name=unbonding_time,json=unbondingTime,proto3,stdduration" json:"unbonding_time"`
 
-	// MinBond is the minimum bond required to be a validator
-	DefaultMinBond uint64 = 0
+	// MinBond is the minimum bond required to be a sequencer.
+	DefaultMinBond uint64 = 100_000_000
 	// UnbondingTime is the time duration for unbonding
 	DefaultUnbondingTime time.Duration = time.Hour
 
@@ -78,13 +78,14 @@ func validateMinBond(i interface{}) error {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 
-	if v.IsNil() || v.IsZero() {
-		return nil
-	}
-
 	if !v.IsValid() {
 		return fmt.Errorf("invalid coin: %s", v)
 	}
+
+	if !v.IsPositive() {
+		return fmt.Errorf("min bond must be positive: %s", v)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #907

## Summary
- set the default sequencer `MinBond` to a positive `umec` amount instead of allowing a free bonded identity
- reject invalid, zero, or under-minimum sequencer bonds before any bonded sequencer is stored
- reject bonded/unbonding genesis sequencers that do not carry at least the configured min-bond collateral
- make slashing fail with `ErrInvalidSequencerTokens` when a slashable sequencer has no tokens, instead of silently jailing it with no burn
- keep create-sequencer simulation messages aligned with the configured min bond

## Validation
- `go test ./x/sequencer/types -count=1`
- `go test ./x/sequencer/keeper -run 'TestSequencerKeeperTestSuite/(TestMinBond|TestCreateSequencerRejectsZeroBond|TestDefaultMinBondCreatesCollateralizedProposer|TestSlashingBondedSequencerWithoutTokensFails|TestSlashingPropserSequencer|TestSlashingUnbondingSequencer)$' -count=1 -v`\n- `go test ./x/sequencer/... -count=1`\n- `git diff --check`\n\n## Bounty payout\nMeta Earth / OpenMetaEarth bug bounty payout: `$MEC` via ME Pass.\n\nWallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`