### PR TITLE
fix(sequencer): prevent uint64-to-int64 overflow in ReplaceProposer validation (#871)

### DIFF
--- a/x/sequencer/keeper/msg_repalce_proposer.go
+++ b/x/sequencer/keeper/msg_repalce_proposer.go
@@ -50,7 +50,7 @@ func (k msgServer) ReplaceProposer(goCtx context.Context, msg *types.MsgReplaceP
 	if !found {
 		return nil, errorsmod.Wrapf(types.ErrUnknownRequest, "no state info found for rollapp %s at index %d", msg.ReplaceProposer.RollappId, stateInfoIndex.Index)
 	}
-	if msg.ReplaceProposer.BlockHeight <= int64(stateInfo.StartHeight+stateInfo.NumBlocks) {
+	if msg.ReplaceProposer.BlockHeight < 0 || uint64(msg.ReplaceProposer.BlockHeight) <= stateInfo.StartHeight+stateInfo.NumBlocks {
 		return nil, errorsmod.Wrapf(types.ErrInvalidRequest, "replace proposer block height %d must be greater than last state info end height %d", msg.ReplaceProposer.BlockHeight, stateInfo.StartHeight+stateInfo.NumBlocks)
 	}
 

--- a/x/sequencer/keeper/msg_repalce_proposer_test.go
+++ b/x/sequencer/keeper/msg_repalce_proposer_test.go
@@ -1,0 +1,50 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/openmetaearth/me-hub/x/sequencer/types"
+)
+
+func (suite *SequencerTestSuite) TestReplaceProposerSafeBlockHeight() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollappId := suite.CreateDefaultRollapp()
+	// Create proposer (old proposer)
+	oldProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	
+	// Create another sequencer (new proposer)
+	newProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	// Set state info end height to something high, greater than math.MaxInt64
+	stateInfo := rollapptypes.StateInfo{
+		StateInfoIndex: rollapptypes.StateInfoIndex{
+			RollappId: rollappId,
+			Index:     1,
+		},
+		StartHeight: 9223372036854775800, // close to MaxInt64
+		NumBlocks:   100, // StartHeight + NumBlocks = 9223372036854775900 > math.MaxInt64
+		Status:      1,
+	}
+	suite.App.RollappKeeper.SetStateInfo(suite.Ctx, stateInfo)
+	suite.App.RollappKeeper.SetLatestStateInfoIndex(suite.Ctx, rollapptypes.StateInfoIndex{
+		RollappId: rollappId,
+		Index:     1,
+	})
+
+	// Test ReplaceProposer with BlockHeight <= stateInfo end height
+	// We pass BlockHeight = 10. Since 10 <= end height, it must be rejected!
+	msg := &types.MsgReplaceProposerRequest{
+		Creator: alice, // rollapp creator
+		ReplaceProposer: &types.MsgRepalceProposer{
+			RollappId:   rollappId,
+			OldProposer: oldProposerAddr,
+			NewProposer: newProposerAddr,
+			BlockHeight: 10,
+		},
+	}
+	_, err := suite.msgServer.ReplaceProposer(goCtx, msg)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "replace proposer block height")
+}


### PR DESCRIPTION
This PR fixes a critical uint64-to-int64 casting overflow issue in the ReplaceProposer validation. Enforces block height validation as non-negative and casts safely to compare with the latest RollApp state height. Fixes #871.