### PR TITLE
fix(sequencer): add rollapp membership checks in ReplaceProposer validation (#860)

### DIFF
--- a/x/sequencer/keeper/msg_repalce_proposer.go
+++ b/x/sequencer/keeper/msg_repalce_proposer.go
@@ -35,12 +35,18 @@ func (k msgServer) ReplaceProposer(goCtx context.Context, msg *types.MsgReplaceP
 	if !oldSequencer.Proposer {
 		return nil, errorsmod.Wrapf(types.ErrInvalidSequencerStatus, "old proposer %s is not a proposer", msg.ReplaceProposer.OldProposer)
 	}
+	if oldSequencer.RollappId != msg.ReplaceProposer.RollappId {
+		return nil, errorsmod.Wrapf(types.ErrSequencerRollappMismatch, "old proposer %s does not belong to rollapp %s", msg.ReplaceProposer.OldProposer, msg.ReplaceProposer.RollappId)
+	}
 	newSequencer, found := k.GetSequencer(ctx, msg.ReplaceProposer.NewProposer)
 	if !found {
 		return nil, errorsmod.Wrapf(types.ErrUnknownSequencer, "new proposer %s not found", msg.ReplaceProposer.NewProposer)
 	}
 	if !newSequencer.IsBonded() {
 		return nil, errorsmod.Wrapf(types.ErrInvalidSequencerStatus, "new proposer %s is not bonded", msg.ReplaceProposer.NewProposer)
+	}
+	if newSequencer.RollappId != msg.ReplaceProposer.RollappId {
+		return nil, errorsmod.Wrapf(types.ErrSequencerRollappMismatch, "new proposer %s does not belong to rollapp %s", msg.ReplaceProposer.NewProposer, msg.ReplaceProposer.RollappId)
 	}
 	stateInfoIndex, found := k.rollappKeeper.GetLatestStateInfoIndex(ctx, msg.ReplaceProposer.RollappId)
 	if !found {

--- a/x/sequencer/keeper/msg_repalce_proposer_test.go
+++ b/x/sequencer/keeper/msg_repalce_proposer_test.go
@@ -1,0 +1,37 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/sequencer/types"
+)
+
+func (suite *SequencerTestSuite) TestReplaceProposerRollappBinding() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollappId := suite.CreateDefaultRollapp()
+	// Create proposer (old proposer)
+	oldProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	_ = oldProposerAddr
+	
+	// Create another sequencer (new proposer)
+	newProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+
+	// Test case: Check rollapp binding
+	// Let's create a sequencer for a different rollapp.
+	otherRollappId := suite.CreateDefaultRollapp()
+	otherSeqAddr := suite.CreateDefaultSequencer(suite.Ctx, otherRollappId)
+
+	msgWrongOld := &types.MsgReplaceProposerRequest{
+		Creator: alice,
+		ReplaceProposer: &types.MsgRepalceProposer{
+			RollappId:   rollappId,
+			OldProposer: otherSeqAddr, // does not belong to rollappId
+			NewProposer: newProposerAddr,
+			BlockHeight: 100,
+		},
+	}
+	_, err := suite.msgServer.ReplaceProposer(goCtx, msgWrongOld)
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "does not belong to rollapp")
+}


### PR DESCRIPTION
This PR adds verification checks to ensure that both the old proposer and the new proposer belong to the rollapp specified in the ReplaceProposer request. Returning types.ErrSequencerRollappMismatch on mismatch prevents sequencers from other RollApps from being registered as proposers. Fixes #860.