### PR TITLE
fix(wdistri): prevent silent int64 truncation in AllocateBlockReward (#862)

### DIFF
--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -101,7 +101,7 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		// calculate every region coins: RegionShare * totalMintCoins / totalRegionShare
 		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(totalMintCoin.AmountOf(params.BaseDenom).ToLegacyDec()).Quo(totalRegionShareDec)
 		regionAmount := amount.TruncateInt()
-		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
+		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, regionAmount))
 		treasuryAddr, addrErr := sdk.AccAddressFromBech32(region.GetRegionTreasureAddr())
 		if addrErr != nil {
 			ctx.Logger().Error("invalid region treasure address, skipping reward", "regionId", region.GetRegionId(), "addr", region.GetRegionTreasureAddr(), "err", addrErr)

--- a/x/wdistri/keeper/keeper_test.go
+++ b/x/wdistri/keeper/keeper_test.go
@@ -283,3 +283,27 @@ func (suite *KeeperTestSuite) setMockSendCoinsFromModuleToAccountExpect(ctx sdk.
 			).Return(nil)
 	}
 }
+
+func (suite *KeeperTestSuite) TestAllocateBlockRewardLargeAmount() {
+	largeAmount, ok := sdkmath.NewIntFromString("100000000000000000000") // 10^20 > MaxInt64
+	suite.Require().True(ok)
+
+	ctx := suite.HelperNewContextWith(types.OneDayTotalBlocks)
+	regions := suite.mockGetRegionI(ctx, 1)
+	addr := regions[0]
+
+	acc := authtypes.NewModuleAddress(suite.App.DistrKeeper.GetTreasuryModuleAccount())
+	suite.authKeeper.EXPECT().GetModuleAddress(suite.App.DistrKeeper.GetTreasuryModuleAccount()).Return(acc)
+	suite.bankKeeper.EXPECT().GetAllBalances(ctx, acc).Return(sdk.NewCoins(sdk.NewCoin(params.BaseDenom, largeAmount)))
+
+	suite.bankKeeper.EXPECT().
+		SendCoinsFromModuleToAccount(
+			ctx,
+			suite.App.DistrKeeper.GetTreasuryModuleAccount(),
+			sdk.MustAccAddressFromBech32(addr),
+			sdk.NewCoins(sdk.NewCoin(params.BaseDenom, largeAmount)),
+		).Return(nil)
+
+	err := suite.App.DistrKeeper.AllocateBlockReward(ctx)
+	suite.Require().NoError(err)
+}


### PR DESCRIPTION
This PR resolves an issue in the daily block reward distribution logic where the computed reward amount was cast to int64 via .Int64(), causing silent truncation for large values exceeding math.MaxInt64. By passing the arbitrary-precision sdkmath.Int (regionAmount) directly to sdk.NewCoin, we preserve correct and precise distribution. Fixes #862.