### PR TITLE
fix(rollapp): correct swapped RevisionNumber/RevisionHeight arguments in freezeClientState (#861)

### DIFF
--- a/x/rollapp/keeper/export_test.go
+++ b/x/rollapp/keeper/export_test.go
@@ -1,0 +1,18 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
+)
+
+func (k Keeper) FreezeClientStateForTest(ctx sdk.Context, clientId string) error {
+	return k.freezeClientState(ctx, clientId)
+}
+
+func (k Keeper) SetClientStateForTest(ctx sdk.Context, clientId string, clientState exported.ClientState) {
+	k.ibcClientKeeper.SetClientState(ctx, clientId, clientState)
+}
+
+func (k Keeper) GetClientStateForTest(ctx sdk.Context, clientId string) (exported.ClientState, bool) {
+	return k.ibcClientKeeper.GetClientState(ctx, clientId)
+}

--- a/x/rollapp/keeper/fraud_handler.go
+++ b/x/rollapp/keeper/fraud_handler.go
@@ -97,7 +97,7 @@ func (k Keeper) freezeClientState(ctx sdk.Context, clientId string) error {
 		return errorsmod.Wrapf(types.ErrInvalidClientState, "client state with ID %s is not a tendermint client state", clientId)
 	}
 
-	tmClientState.FrozenHeight = clienttypes.NewHeight(tmClientState.GetLatestHeight().GetRevisionHeight(), tmClientState.GetLatestHeight().GetRevisionNumber())
+	tmClientState.FrozenHeight = clienttypes.NewHeight(tmClientState.GetLatestHeight().GetRevisionNumber(), tmClientState.GetLatestHeight().GetRevisionHeight())
 	k.ibcClientKeeper.SetClientState(ctx, clientId, tmClientState)
 
 	return nil

--- a/x/rollapp/keeper/fraud_handler_test.go
+++ b/x/rollapp/keeper/fraud_handler_test.go
@@ -3,6 +3,8 @@ package keeper_test
 import (
 	common "github.com/openmetaearth/me-hub/x/common/types"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	cometbfttypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 )
 
 // Happy Flow
@@ -242,4 +244,25 @@ func (suite *RollappTestSuite) assertFraudHandled(rollappId string) {
 			suite.Require().NotEqual(rollappId, stateInfoIndex.RollappId)
 		}
 	}
+}
+
+func (suite *RollappTestSuite) TestFreezeClientState() {
+	suite.SetupTest()
+	k := suite.App.RollappKeeper
+
+	clientId := "07-tendermint-0"
+	clientState := &cometbfttypes.ClientState{
+		LatestHeight: clienttypes.NewHeight(2, 500),
+	}
+	k.SetClientStateForTest(suite.Ctx, clientId, clientState)
+
+	err := k.FreezeClientStateForTest(suite.Ctx, clientId)
+	suite.Require().NoError(err)
+
+	frozenState, ok := k.GetClientStateForTest(suite.Ctx, clientId)
+	suite.Require().True(ok)
+
+	tmFrozenState := frozenState.(*cometbfttypes.ClientState)
+	suite.Require().Equal(uint64(2), tmFrozenState.FrozenHeight.RevisionNumber)
+	suite.Require().Equal(uint64(500), tmFrozenState.FrozenHeight.RevisionHeight)
 }


### PR DESCRIPTION
This PR fixes a bug in the IBC light client freeze logic (freezeClientState) where the arguments to clienttypes.NewHeight were swapped (passing RevisionHeight as the RevisionNumber, and vice-versa). Fixing the order ensures the light client is correctly frozen at the latest height RevisionNumber/RevisionHeight. Fixes #861.