### PR TITLE
fix(gravity): reject any relayer claim whose nonce is not expected (#859)

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -27,12 +27,7 @@ func (k Keeper) Attest(ctx sdk.Context, relayerAddr sdk.AccAddress, claim types.
 	lastEventNonce := k.GetLastEventNonceByRelayer(ctx, relayerAddr)
 	expectedNonce := lastEventNonce + 1
 
-	// fist check continuity
-	if claim.GetEventNonce() <= lastEventNonce {
-		return nil, errorsmod.Wrapf(types.ErrNonContinuousEventNonce, "got %v, expected %v", claim.GetEventNonce(), expectedNonce)
-	}
-	if claim.GetEventNonce() != expectedNonce && claim.GetEventNonce() > lastObservedNonce {
-		// second: if not continuous, event nonce must greater than last observed nonce.
+	if claim.GetEventNonce() != expectedNonce {
 		return nil, errorsmod.Wrapf(types.ErrNonContinuousEventNonce, "got %v, expected %v", claim.GetEventNonce(), expectedNonce)
 	}
 


### PR DESCRIPTION
This PR hardens the relayer event nonce continuity check in the Gravity bridge by strictly requiring that the submitted claim's event nonce matches the next expected nonce for the relayer (lastEventNonce + 1). This prevents relayers from bypassing continuity checks and creating duplicate attestations or corrupting slashing accounting. Fixes #859.