### PR TITLE
[codex] fix gravity batch timeout underflow

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -82,7 +82,7 @@ func (k Keeper) BuildOutgoingTxBatch(ctx sdk.Context, contractAddress, feeReceiv
 
 // GetBatchTimeoutHeight This gets the batch timeout height in External blocks.
 func (k Keeper) GetBatchTimeoutHeight(ctx sdk.Context) (uint64, uint64) {
-	currentMeHeight := ctx.BlockHeight()
+	currentMeHeight := uint64(ctx.BlockHeight())
 	params := k.GetParams(ctx)
 	if params.AverageExternalBlockTime == 0 {
 		return 0, 0
@@ -93,8 +93,13 @@ func (k Keeper) GetBatchTimeoutHeight(ctx sdk.Context) (uint64, uint64) {
 	if heights.ExternalBlockHeight == 0 {
 		return 0, 0
 	}
+	// Genesis import may carry an old local height; clamp elapsed local blocks to avoid uint64 underflow.
+	elapsedMeBlocks := uint64(0)
+	if currentMeHeight >= heights.BlockHeight {
+		elapsedMeBlocks = currentMeHeight - heights.BlockHeight
+	}
 	// we project how long it has been in milliseconds since the last Ethereum block height was observed
-	projectedMillis := (uint64(currentMeHeight) - heights.BlockHeight) * params.AverageBlockTime
+	projectedMillis := elapsedMeBlocks * params.AverageBlockTime
 	// we convert that projection into the current Ethereum height using the average Ethereum block time in millis
 	projectedCurrentEthereumHeight := (projectedMillis / params.AverageExternalBlockTime) + heights.ExternalBlockHeight
 	// we convert our target time for block timeouts (lets say 12 hours) into a number of blocks to

--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -155,3 +155,16 @@ func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {
 	)
 	suite.Equal(len(batchs), index)
 }
+
+func (suite *KeeperTestSuite) TestBatchTimeoutHeightDoesNotUnderflowAfterGenesisImport() {
+	// Simulate a fresh chain height after importing an old-chain local observation height.
+	suite.Ctx = suite.Ctx.WithBlockHeight(1)
+	suite.Keeper().SetLastObservedBlockHeight(suite.Ctx, 1_000, 100)
+
+	projectedCurrentExternalHeight, batchTimeout := suite.Keeper().GetBatchTimeoutHeight(suite.Ctx)
+
+	params := suite.Keeper().GetParams(suite.Ctx)
+	expectedBatchTimeout := uint64(1_000) + params.ExternalBatchTimeout/params.AverageExternalBlockTime
+	suite.Equal(uint64(1_000), projectedCurrentExternalHeight)
+	suite.Equal(expectedBatchTimeout, batchTimeout)
+}


### PR DESCRIPTION
## Summary

- Clamp elapsed ME blocks in `GetBatchTimeoutHeight` when imported genesis state carries a local `LastObservedBlockHeight.BlockHeight` greater than the current chain height.
- Add a regression test for genesis import / fresh-chain contexts so timeout projection cannot underflow into a near-never-expiring external timeout.

## Root Cause

`GetBatchTimeoutHeight` projected elapsed time with an unchecked uint64 subtraction:

```go
uint64(currentMeHeight) - heights.BlockHeight
```

After genesis import, the restored local observation height can come from the old chain while the new chain context starts at height 0/1. In that case the subtraction underflows and creates a huge projected external height and batch timeout.

## Fix

When the current local height is lower than the stored local observation height, the projection now treats elapsed local blocks as zero. This preserves the imported external height and adds only the configured external batch timeout window.

Fixes #945.

## Validation

```bash
CGO_ENABLED=1 CC='/mnt/d/Backup/Documents/Playground/.tools/wsl/zig-x86_64-linux-0.16.0/zig cc' GOPROXY=https://goproxy.cn,https://proxy.golang.org,direct GOSUMDB=sum.golang.google.cn /mnt/d/Backup/Documents/Playground/.tools/wsl/go/bin/go test -buildvcs=false ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(Keeper_IterateBatch|LastPendingBatchRequestByAddr|BatchTimeoutHeightDoesNotUnderflowAfterGenesisImport)' -count=1 -v
```

Also ran full `./x/gravity/keeper`; it still has pre-existing failures unrelated to this batch timeout path:

- `TestGrav004_FailedAttestationMustNotLockNonce`
- `TestMsgBondedRelayer/error_-_relayer_existed`
- `TestMsgBondedRelayer/error_-_external_address_is_bound`
- `TestRelayerSetSlash`
