### PR TITLE
fix: guard relayer set observation nonce

### DIFF
--- a/x/gravity/keeper/attestation_handler.go
+++ b/x/gravity/keeper/attestation_handler.go
@@ -101,24 +101,31 @@ func (k Keeper) AttestationHandler(ctx sdk.Context, externalClaim types.External
 			Nonce:   claim.RelayerSetNonce,
 			Members: claim.Members,
 		}
-		// check the contents of the validator set against the store
-		if claim.RelayerSetNonce != 0 {
-			trustedRelayerSet := k.GetRelayerSet(ctx, claim.RelayerSetNonce)
-			if trustedRelayerSet == nil {
-				ctx.Logger().Error("Received attestation for a relayer set which does not exist in store", "relayerSetNonce", claim.RelayerSetNonce, "claim", claim)
-				return errorsmod.Wrapf(types.ErrInvalid, "attested relayerSet (%v) does not exist in store", claim.RelayerSetNonce)
-			}
+		if claim.RelayerSetNonce == 0 {
+			return errorsmod.Wrap(types.ErrInvalid, "zero relayer set nonce")
+		}
 
-			// overwrite the height, since it's not part of the claim
-			observedRelayerSet.Height = trustedRelayerSet.Height
-			match, err := trustedRelayerSet.Equal(observedRelayerSet)
-			if err != nil {
-				// this indicates that the members of the two sets are not equal
-				return errorsmod.Wrapf(types.ErrInvalid, "potential bridge hijacking: observed relayerSet (%+v) does not match stored relayerSet (%+v)! %s", observedRelayerSet, trustedRelayerSet, err.Error())
-			}
-			if !match {
-				return errorsmod.Wrapf(types.ErrInvalid, "potential bridge hijacking: observed relayerSet (%d) does not match stored relayerSet (%d)", observedRelayerSet.Nonce, trustedRelayerSet.Nonce)
-			}
+		// Check the contents of the relayer set against the store.
+		trustedRelayerSet := k.GetRelayerSet(ctx, claim.RelayerSetNonce)
+		if trustedRelayerSet == nil {
+			ctx.Logger().Error("Received attestation for a relayer set which does not exist in store", "relayerSetNonce", claim.RelayerSetNonce, "claim", claim)
+			return errorsmod.Wrapf(types.ErrInvalid, "attested relayerSet (%v) does not exist in store", claim.RelayerSetNonce)
+		}
+
+		// overwrite the height, since it's not part of the claim
+		observedRelayerSet.Height = trustedRelayerSet.Height
+		match, err := trustedRelayerSet.Equal(observedRelayerSet)
+		if err != nil {
+			// this indicates that the members of the two sets are not equal
+			return errorsmod.Wrapf(types.ErrInvalid, "potential bridge hijacking: observed relayerSet (%+v) does not match stored relayerSet (%+v)! %s", observedRelayerSet, trustedRelayerSet, err.Error())
+		}
+		if !match {
+			return errorsmod.Wrapf(types.ErrInvalid, "potential bridge hijacking: observed relayerSet (%d) does not match stored relayerSet (%d)", observedRelayerSet.Nonce, trustedRelayerSet.Nonce)
+		}
+
+		lastObservedRelayerSet := k.GetLastObservedRelayerSet(ctx)
+		if lastObservedRelayerSet != nil && observedRelayerSet.Nonce < lastObservedRelayerSet.Nonce {
+			return errorsmod.Wrapf(types.ErrInvalid, "relayer set nonce regression: observed relayerSet (%d) is older than last observed relayerSet (%d)", observedRelayerSet.Nonce, lastObservedRelayerSet.Nonce)
 		}
 		k.SetLastObservedRelayerSet(ctx, observedRelayerSet)
 	default:

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -195,6 +195,76 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 	}
 }
 
+func (s *KeeperTestSuite) TestRelayerSetUpdateClaimRejectsNonceZeroObservedSetForgery() {
+	k := s.Keeper()
+	s.setupBondedRelayerSetForAuditTest()
+
+	nonce1RelayerSet := k.GetRelayerSet(s.Ctx, 1)
+	s.Require().NotNil(nonce1RelayerSet)
+
+	preObserved := k.GetLastObservedRelayerSet(s.Ctx)
+	s.Require().NotNil(preObserved)
+	s.Require().EqualValues(1, preObserved.Nonce)
+
+	forgedMembers := types.BridgeValidators{
+		{
+			Power:           types.PowerBase,
+			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[0].PublicKey),
+		},
+	}
+
+	for _, relayer := range s.relayerAddrs {
+		msg := &types.MsgRelayerSetUpdateClaim{
+			EventNonce:      k.GetLastEventNonceByRelayer(s.Ctx, relayer) + 1,
+			BlockHeight:     2,
+			RelayerSetNonce: 0,
+			Members:         forgedMembers,
+			RelayerAddress:  relayer.String(),
+			ChainName:       s.chainName,
+		}
+		_, err := s.MsgServer().RelayerSetUpdateClaim(sdk.WrapSDKContext(s.Ctx), msg)
+		s.Require().Error(err)
+	}
+
+	postObserved := k.GetLastObservedRelayerSet(s.Ctx)
+	s.Require().NotNil(postObserved)
+	s.Require().EqualValues(1, postObserved.Nonce)
+	s.Require().Equal(nonce1RelayerSet.Members, postObserved.Members)
+}
+
+func (s *KeeperTestSuite) TestRelayerSetUpdateClaimRejectsObservedSetNonceRegression() {
+	k := s.Keeper()
+	s.setupBondedRelayerSetForAuditTest()
+
+	nonce1RelayerSet := k.GetRelayerSet(s.Ctx, 1)
+	s.Require().NotNil(nonce1RelayerSet)
+
+	nonce2RelayerSet := *nonce1RelayerSet
+	nonce2RelayerSet.Nonce = 2
+	nonce2RelayerSet.Height = uint64(s.Ctx.BlockHeight()) + 1
+	k.StoreRelayerSet(s.Ctx, &nonce2RelayerSet)
+	k.SetLastRelayerSetNonce(s.Ctx, 2)
+	k.SetLastObservedRelayerSet(s.Ctx, &nonce2RelayerSet)
+
+	for _, relayer := range s.relayerAddrs {
+		msg := &types.MsgRelayerSetUpdateClaim{
+			EventNonce:      k.GetLastEventNonceByRelayer(s.Ctx, relayer) + 1,
+			BlockHeight:     2,
+			RelayerSetNonce: 1,
+			Members:         nonce1RelayerSet.Members,
+			RelayerAddress:  relayer.String(),
+			ChainName:       s.chainName,
+		}
+		_, err := s.MsgServer().RelayerSetUpdateClaim(sdk.WrapSDKContext(s.Ctx), msg)
+		s.Require().NoError(err)
+	}
+
+	postObserved := k.GetLastObservedRelayerSet(s.Ctx)
+	s.Require().NotNil(postObserved)
+	s.Require().EqualValues(2, postObserved.Nonce)
+	s.Require().Equal(nonce2RelayerSet.Members, postObserved.Members)
+}
+
 // ---------------------------------------------------------------------------
 // Helper: bond relayers, confirm and observe the initial relayer set.
 // Mirrors the opening of TestRequestBatchBaseFee in msg_server_test.go, but

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -228,6 +228,10 @@ func (s MsgServer) RelayerSetConfirm(c context.Context, msg *types.MsgRelayerSet
 
 // RelayerSetUpdateClaim handles claims for executing a relayer set update on Ethereum
 func (s MsgServer) RelayerSetUpdateClaim(c context.Context, msg *types.MsgRelayerSetUpdateClaim) (*types.MsgRelayerSetUpdateClaimResponse, error) {
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	ctx := sdk.UnwrapSDKContext(c)
 	relayerAddress := sdk.MustAccAddressFromBech32(msg.RelayerAddress)
 	err := s.checkIsRelayer(ctx, relayerAddress)

--- a/x/gravity/types/msg_claim.go
+++ b/x/gravity/types/msg_claim.go
@@ -239,6 +239,9 @@ func (m *MsgRelayerSetUpdateClaim) ValidateBasic() (err error) {
 	if len(m.Members) == 0 {
 		return errortypes.ErrInvalidRequest.Wrap("empty members")
 	}
+	if m.RelayerSetNonce == 0 {
+		return errortypes.ErrInvalidRequest.Wrap("zero relayer set nonce")
+	}
 	for _, member := range m.Members {
 		if err = ValidateExternalAddr(m.ChainName, member.ExternalAddress); err != nil {
 			return errortypes.ErrInvalidAddress.Wrapf("invalid external address: %s", err)


### PR DESCRIPTION
Fixes #942
Fixes #943

## Summary
- reject relayer-set update claims with `RelayerSetNonce == 0`
- always compare relayer-set update claims against the stored trusted relayer set
- keep `LastObservedRelayerSet` monotonic by rejecting older stored relayer-set nonces
- add regression coverage for nonce-zero forged observed sets and stale observed-set rewinds

## Validation
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/(TestRelayerSetUpdateClaimRejectsNonceZeroObservedSetForgery|TestRelayerSetUpdateClaimRejectsObservedSetNonceRegression)$' -count=1 -v`
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestClaimMsgGasConsumed$' -count=1 -v`
- `go test ./x/gravity/types -count=1`
- `git diff --check`

## Bounty payout
Meta Earth / OpenMetaEarth bug bounty payout: `$MEC` via ME Pass.

Wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`