### PR TITLE
fix(gravity): reject external block height regressions

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -35,9 +35,11 @@ func (k Keeper) Attest(ctx sdk.Context, relayerAddr sdk.AccAddress, claim types.
 		// second: if not continuous, event nonce must greater than last observed nonce.
 		return nil, errorsmod.Wrapf(types.ErrNonContinuousEventNonce, "got %v, expected %v", claim.GetEventNonce(), expectedNonce)
 	}
-
 	gasMeter := ctx.GasMeter()
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+	if err := k.validateExternalBlockHeightProgression(ctx, claim); err != nil {
+		return nil, err
+	}
 
 	// Tries to get an attestation with the same eventNonce and claim as the claim that was submitted.
 	att := k.GetAttestation(ctx, claim.GetEventNonce(), claim.ClaimHash())
@@ -101,6 +103,11 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 		if attestationPower.LT(requiredPower) {
 			continue
 		}
+		if err := k.validateExternalBlockHeightProgression(ctx, claim); err != nil {
+			k.Logger(ctx).Error("TryAttestation", "external block height regression", "error", err,
+				"claimEventNonce", claim.GetEventNonce(), "claimType", claim.GetType(), "claimHeight", claim.GetBlockHeight())
+			break
+		}
 
 		k.SetLastObservedEventNonce(ctx, claim.GetEventNonce())
 
@@ -143,6 +150,14 @@ func (k Keeper) processAttestation(ctx sdk.Context, claim types.ExternalClaim) e
 		return err
 	}
 	commit() // persist transient storage
+	return nil
+}
+
+func (k Keeper) validateExternalBlockHeightProgression(ctx sdk.Context, claim types.ExternalClaim) error {
+	lastHeight := k.GetLastObservedBlockHeight(ctx).ExternalBlockHeight
+	if lastHeight != 0 && claim.GetBlockHeight() < lastHeight {
+		return errorsmod.Wrapf(types.ErrInvalid, "external block height regression: got %d, observed %d", claim.GetBlockHeight(), lastHeight)
+	}
 	return nil
 }
 

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -10,6 +10,7 @@ package keeper_test
 // Coverage:
 //   GRAV-001  Attest must reject historical-nonce claims (no backward rewind)
 //   GRAV-004  Failed AttestationHandler must not advance lastObservedEventNonce
+//   GRAV-005  External block height must not rewind LastObservedBlockHeight
 
 import (
 	"encoding/hex"
@@ -193,6 +194,85 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 				"handler failed; retries are now impossible",
 			probeClaim.GetEventNonce())
 	}
+}
+
+// ---------------------------------------------------------------------------
+// GRAV-005: Later attestations must not rewind external block height
+// ---------------------------------------------------------------------------
+//
+// cleanupTimedOutBatches depends on LastObservedBlockHeight.ExternalBlockHeight
+// to decide which outgoing batches have expired on the external chain. A later
+// claim with a lower external block height must not be accepted, otherwise the
+// timeout watermark can move backwards and keep expired batches alive.
+
+func (s *KeeperTestSuite) TestGrav005_AttestRejectsExternalBlockHeightRegression() {
+	k := s.Keeper()
+	s.setupBondedRelayerSetForAuditTest()
+
+	tokenContract := "0x42D755c5494180be5a44D6Ca7D9291F6D4B4228A"
+	for i := 0; i < 7; i++ {
+		claim := &types.MsgBridgeTokenClaim{
+			EventNonce:     2,
+			BlockHeight:    1000,
+			TokenContract:  tokenContract,
+			Name:           "Height Guard Token",
+			Symbol:         "HGT",
+			Decimals:       6,
+			RelayerAddress: s.relayerAddrs[i].String(),
+			ChainName:      s.chainName,
+		}
+		_, err := s.MsgServer().BridgeTokenClaim(sdk.WrapSDKContext(s.Ctx), claim)
+		s.Require().NoError(err)
+	}
+
+	s.Require().EqualValues(1000, k.GetLastObservedBlockHeight(s.Ctx).ExternalBlockHeight)
+	s.Require().EqualValues(2, k.GetLastObservedEventNonce(s.Ctx))
+
+	expiredBatch := &types.OutgoingTxBatch{
+		BatchNonce:   77,
+		BatchTimeout: 500,
+		Transactions: []*types.OutgoingTransferTx{
+			{
+				Id:          1,
+				Sender:      s.relayerAddrs[0].String(),
+				DestAddress: s.PubKeyToExternalAddr(s.externalPris[1].PublicKey),
+				Token: types.ERC20Token{
+					Contract: tokenContract,
+					Amount:   sdkmath.NewInt(100),
+				},
+				Fee: types.ERC20Token{
+					Contract: tokenContract,
+					Amount:   sdkmath.NewInt(1),
+				},
+			},
+		},
+		TokenContract: tokenContract,
+		Block:         uint64(s.Ctx.BlockHeight()),
+		FeeReceive:    s.PubKeyToExternalAddr(s.externalPris[2].PublicKey),
+	}
+	s.Require().NoError(k.StoreBatch(s.Ctx, expiredBatch))
+
+	regressingClaim := &types.MsgBridgeTokenClaim{
+		EventNonce:     3,
+		BlockHeight:    1,
+		TokenContract:  tokenContract,
+		Name:           "Height Guard Token",
+		Symbol:         "HGT",
+		Decimals:       6,
+		RelayerAddress: s.relayerAddrs[0].String(),
+		ChainName:      s.chainName,
+	}
+	_, err := s.MsgServer().BridgeTokenClaim(sdk.WrapSDKContext(s.Ctx), regressingClaim)
+	s.Require().ErrorIs(err, types.ErrInvalid)
+	s.Require().Contains(err.Error(), "external block height regression")
+
+	s.Require().EqualValues(1000, k.GetLastObservedBlockHeight(s.Ctx).ExternalBlockHeight)
+	s.Require().EqualValues(2, k.GetLastObservedEventNonce(s.Ctx))
+	s.Require().EqualValues(2, k.GetLastEventNonceByRelayer(s.Ctx, s.relayerAddrs[0]))
+	s.Require().Nil(k.GetAttestation(s.Ctx, regressingClaim.GetEventNonce(), regressingClaim.ClaimHash()))
+
+	k.EndBlocker(s.Ctx)
+	s.Require().Nil(k.GetOutgoingTxBatch(s.Ctx, tokenContract, expiredBatch.BatchNonce))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reject bridge claims whose external block height is lower than the current observed external block height.
- Keep the quorum observation path guarded before updating observed event and block heights.
- Add a regression test proving a lower-height claim cannot keep an expired batch alive.

## Validation
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/(TestGrav005_AttestRejectsExternalBlockHeightRegression|TestClaimMsgGasConsumed|TestAttestationAfterRelayerUpdate|TestMsgBridgeTokenClaim)$' -count=1 -v`\n- `go test ./x/gravity/types -count=1`\n- `git diff --check`\n\nNote: full `go test ./x/gravity/keeper -count=1` still fails on pre-existing tests unrelated to this change: GRAV-004 nonce expectation, bonded-relayer error-string expectations, and TestRelayerSetSlash.\n\n## Bounty payout\nPayment method: Meta Earth bug bounty payout in `$MEC` via ME Pass.\nWallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`\n\nFixes #944