### PR TITLE
fix: bound gravity bridge token decimals

### DIFF
--- a/x/gravity/keeper/attestation_handler.go
+++ b/x/gravity/keeper/attestation_handler.go
@@ -41,6 +41,9 @@ func (k Keeper) AttestationHandler(ctx sdk.Context, externalClaim types.External
 		k.OutgoingTxBatchExecuted(ctx, claim.TokenContract, claim.BatchNonce)
 
 	case *types.MsgBridgeTokenClaim:
+		if err := claim.ValidateBasic(); err != nil {
+			return err
+		}
 		// Check if it already exists
 		exists := k.HasBridgeToken(ctx, claim.TokenContract)
 		if exists {

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -250,6 +250,9 @@ func (s MsgServer) RelayerSetUpdateClaim(c context.Context, msg *types.MsgRelaye
 
 func (s MsgServer) BridgeTokenClaim(c context.Context, msg *types.MsgBridgeTokenClaim) (*types.MsgBridgeTokenClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
 	if err := s.claimHandlerCommon(ctx, msg); err != nil {
 		return nil, err
 	}

--- a/x/gravity/keeper/msg_server_test.go
+++ b/x/gravity/keeper/msg_server_test.go
@@ -736,6 +736,35 @@ func (s *KeeperTestSuite) TestMsgBridgeTokenClaim() {
 	}
 }
 
+func (s *KeeperTestSuite) TestBridgeTokenClaimRejectsOversizedDecimalsBeforeAttestation() {
+	randomPrivateKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	tokenContract := s.PubKeyToExternalAddr(randomPrivateKey.PublicKey)
+
+	msg := &types.MsgBridgeTokenClaim{
+		EventNonce:     1,
+		BlockHeight:    1,
+		TokenContract:  tokenContract,
+		Name:           "Tether USD",
+		Symbol:         "USDT",
+		Decimals:       types.MaxBridgeTokenDecimals + 1,
+		RelayerAddress: s.relayerAddrs[0].String(),
+		ChainName:      s.chainName,
+	}
+
+	err = msg.ValidateBasic()
+	s.Require().ErrorContains(err, "bridge token decimals")
+	s.Require().ErrorContains(err, "exceeds maximum")
+
+	_, err = s.MsgServer().BridgeTokenClaim(sdk.WrapSDKContext(s.Ctx), msg)
+	s.Require().ErrorContains(err, "bridge token decimals")
+	s.Require().ErrorContains(err, "exceeds maximum")
+	s.Require().False(s.Keeper().HasBridgeToken(s.Ctx, tokenContract))
+
+	msg.Decimals = types.MaxBridgeTokenDecimals
+	s.Require().NoError(msg.ValidateBasic())
+}
+
 func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 	// 1. First sets up a valid relayer set
 	totalPower := sdk.ZeroInt()

--- a/x/gravity/types/convert.go
+++ b/x/gravity/types/convert.go
@@ -26,6 +26,9 @@ func GetMintCoin(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk
 
 func GetMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
 	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
+		if bridgeToken.Decimal > MaxBridgeTokenDecimals {
+			return sdk.ZeroInt()
+		}
 		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
 		amount = amount.Quo(convert)
 	}
@@ -34,6 +37,9 @@ func GetMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) s
 
 func GetExternalUnlockAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
 	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
+		if bridgeToken.Decimal > MaxBridgeTokenDecimals {
+			return sdk.ZeroInt()
+		}
 		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
 		amount = amount.Mul(convert)
 	}

--- a/x/gravity/types/convert_test.go
+++ b/x/gravity/types/convert_test.go
@@ -89,3 +89,20 @@ func TestGetExternalUnlockAmount(t *testing.T) {
 		})
 	}
 }
+
+func TestBscStablecoinOversizedDecimalsFailClosed(t *testing.T) {
+	bridgeToken := &BridgeToken{
+		Symbol:  "USDT",
+		Decimal: 255,
+	}
+
+	require.NotPanics(t, func() {
+		result := GetMintAmount(sdkmath.NewIntWithDecimal(1, 18), "bsc", bridgeToken)
+		require.True(t, result.IsZero(), "oversized mint conversion should fail closed")
+	})
+
+	require.NotPanics(t, func() {
+		result := GetExternalUnlockAmount(sdkmath.NewInt(1_000_000), "bsc", bridgeToken)
+		require.True(t, result.IsZero(), "oversized external unlock conversion should fail closed")
+	})
+}

--- a/x/gravity/types/msg_claim.go
+++ b/x/gravity/types/msg_claim.go
@@ -14,6 +14,7 @@ const (
 	TypeMsgSendToExternalClaim   = "send_to_external_claim"
 	TypeMsgRelayerSetUpdateClaim = "relayer_set_updated_claim"
 	TypeMsgBridgeTokenClaim      = "bridge_token_claim"
+	MaxBridgeTokenDecimals       = 18
 )
 
 // ExternalClaim represents a claim on ethereum state
@@ -191,11 +192,25 @@ func (m *MsgBridgeTokenClaim) ValidateBasic() (err error) {
 	if len(m.Symbol) == 0 {
 		return errortypes.ErrInvalidRequest.Wrap("empty token symbol")
 	}
+	if err = ValidateBridgeTokenDecimals(m.Decimals); err != nil {
+		return err
+	}
 	if m.EventNonce == 0 {
 		return errortypes.ErrInvalidRequest.Wrap("zero event nonce")
 	}
 	if m.BlockHeight == 0 {
 		return errortypes.ErrInvalidRequest.Wrap("zero block height")
+	}
+	return nil
+}
+
+func ValidateBridgeTokenDecimals(decimals uint64) error {
+	if decimals > MaxBridgeTokenDecimals {
+		return errortypes.ErrInvalidRequest.Wrapf(
+			"bridge token decimals %d exceeds maximum %d",
+			decimals,
+			MaxBridgeTokenDecimals,
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #941

## Summary

- cap `MsgBridgeTokenClaim.Decimals` at 18 before bridge tokens can enter Gravity state
- validate direct message-server and attestation-handler paths before storing a `BridgeToken`
- fail closed in BSC USDT/USDC conversion helpers if corrupted or legacy state already contains oversized decimals
- add regression coverage for boundary rejection and both oversized conversion helpers

## Why

`MsgBridgeTokenClaim.Decimals` is untrusted external token metadata. If an oversized BSC stablecoin decimal value reaches `BridgeToken.Decimal`, `GetMintAmount()` and `GetExternalUnlockAmount()` can call `sdk.Dec.Power(Decimal - 6)` with an unsafe exponent and panic.

Rejecting the claim before state is written prevents the bad state from being created. The conversion guards keep existing invalid state from panicking if it is encountered later.

## Validation

- `go test ./x/gravity/types -count=1`
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/(TestMsgBridgeTokenClaim|TestBridgeTokenClaimRejectsOversizedDecimalsBeforeAttestation|TestRequestBatchBaseFee|TestClaimMsgGasConsumed)$' -count=1 -v`
- `git diff --check`

I also ran `go test ./x/gravity/keeper -count=1`; it still fails on existing unrelated tests:

- `TestGrav004_FailedAttestationMustNotLockNonce`
- `TestMsgBondedRelayer` expected error string assertions
- `TestRelayerSetSlash`

## Bounty payout

Meta Earth / OpenMetaEarth bug bounty payout: `$MEC` via ME Pass.

Wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`
