### PR TITLE
fix: remove rate equality check in transferDeposit

### DIFF
--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -306,10 +306,10 @@ func (k Keeper) transferDeposit(ctx sdk.Context, fromRegion, toRegion *types.Reg
 	for _, fixed := range fixedDeposits {
 		totalFixedDepositByAcc = totalFixedDepositByAcc.Add(fixed.Principal.Amount)
 		totalFixedInterestCoin = totalFixedInterestCoin.Add(fixed.Interest.Amount)
-		//check toRegion deposit config is exist and deposit rate is equal
-		rate, exists := depositConfigMap[fixed.Term]
-		if !exists || !rate.Equal(fixed.Rate) {
-			return errors.New(fmt.Sprintf("deposit cfg not same.rate=%s,fixed.Rate=%s,exists=%v,fixed.Term=%v", rate.String(), fixed.Rate.String(), exists, fixed.Term))
+		//check toRegion deposit config exists and has an active term
+		_, exists := depositConfigMap[fixed.Term]
+		if !exists {
+			return errors.New(fmt.Sprintf("deposit cfg not found for term=%v in target region %s", fixed.Term, toRegion.RegionId))
 		}
 
 		err := k.IncreaseFixedDepositCountOfCfg(ctx, toRegion.RegionId, fixed.Term)


### PR DESCRIPTION
## Summary

The `transferDeposit` function required the target region's current fixed-deposit config rate to equal every historical deposit's stored rate. This is inconsistent with the fixed-deposit lifecycle where interest is calculated and stored at deposit time.

## Problem

When Global DAO updates a target region's fixed-deposit rate through `SetFixedDepositCfgRate`, users with older fixed deposits from another region can no longer transfer KYC into that target region even when the target term still exists and is active.

```
deposit cfg not same.rate=0.200000000000000000,fixed.Rate=0.100000000000000000,exists=true,fixed.Term=30: transfer region err
```

## Root Cause

In `x/wstaking/keeper/kyc_reward.go`, the `transferDeposit` function builds a map of the target region's current fixed-deposit configs and then rejects each user deposit unless the current config rate equals the deposit's historical rate:

```go
rate, exists := depositConfigMap[fixed.Term]
if !exists || !rate.Equal(fixed.Rate) {
    return errors.New(fmt.Sprintf("deposit cfg not same...", ...))
}
```

This equality check is inconsistent with the fixed-deposit lifecycle:
- `DoFixedDeposit` calculates and stores `FixedDeposit.Interest` and `FixedDeposit.Rate` at deposit time
- `WithdrawFixedDeposit` pays the stored `fixedDeposit.Interest`; it does not recalculate from the current config rate
- `transferDeposit` also moves `totalFixedInterestCoin` from the target treasury to the target interest account, so it already transfers the exact stored liability

## Fix

Only check that the target region has an active config for each deposit term. Do not require the current target rate to equal the historical rate for existing deposits whose interest is already fixed.

```go
//check toRegion deposit config exists and has an active term
_, exists := depositConfigMap[fixed.Term]
if !exists {
    return errors.New(fmt.Sprintf("deposit cfg not found for term=%v in target region %s", fixed.Term, toRegion.RegionId))
}
```

The inactive status check is already handled earlier in the function when building the `depositConfigMap`.

## Impact

1. Users can now transfer KYC regions even after a normal DAO rate update in the destination region
2. Region-level fixed-deposit accounting can be properly migrated
3. Historical deposit terms are preserved unchanged

## Testing

The issue author has provided a failing test in `x/wstaking/keeper/kyc_region_fixed_deposit_rate_mismatch_poc_test.go` that demonstrates the bug. After this fix, the test should pass.

Closes #933