### PR TITLE
fix(rollapp): validate genesis state indexes

### DIFF
--- a/x/rollapp/types/genesis.go
+++ b/x/rollapp/types/genesis.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 )
 
 // DefaultIndex is the default capability global index
@@ -51,6 +52,9 @@ func (gs GenesisState) Validate() error {
 		if _, ok := latestStateInfoIndexIndexMap[index]; ok {
 			return errors.New("duplicated index for latestStateInfoIndex")
 		}
+		if _, ok := stateInfoIndexMap[string(StateInfoKey(elem))]; !ok {
+			return fmt.Errorf("latestStateInfoIndex references missing stateInfo: rollappId=%s index=%d", elem.RollappId, elem.Index)
+		}
 		latestStateInfoIndexIndexMap[index] = struct{}{}
 	}
 	// Check for duplicated index in latestFinalizedStateIndex
@@ -61,6 +65,9 @@ func (gs GenesisState) Validate() error {
 		if _, ok := latestFinalizedStateIndexIndexMap[index]; ok {
 			return errors.New("duplicated index for latestFinalizedStateIndex")
 		}
+		if _, ok := stateInfoIndexMap[string(StateInfoKey(elem))]; !ok {
+			return fmt.Errorf("latestFinalizedStateIndex references missing stateInfo: rollappId=%s index=%d", elem.RollappId, elem.Index)
+		}
 		latestFinalizedStateIndexIndexMap[index] = struct{}{}
 	}
 	// Check for duplicated index in blockHeightToFinalizationQueue
@@ -70,6 +77,17 @@ func (gs GenesisState) Validate() error {
 		index := string(BlockHeightToFinalizationQueueKey(elem.CreationHeight))
 		if _, ok := blockHeightToFinalizationQueueIndexMap[index]; ok {
 			return errors.New("duplicated index for blockHeightToFinalizationQueue")
+		}
+		finalizationQueueIndexMap := make(map[string]struct{})
+		for _, stateInfoIndex := range elem.FinalizationQueue {
+			index := string(StateInfoKey(stateInfoIndex))
+			if _, ok := finalizationQueueIndexMap[index]; ok {
+				return fmt.Errorf("duplicated stateInfoIndex in finalization queue: creationHeight=%d rollappId=%s index=%d", elem.CreationHeight, stateInfoIndex.RollappId, stateInfoIndex.Index)
+			}
+			if _, ok := stateInfoIndexMap[index]; !ok {
+				return fmt.Errorf("finalization queue references missing stateInfo: creationHeight=%d rollappId=%s index=%d", elem.CreationHeight, stateInfoIndex.RollappId, stateInfoIndex.Index)
+			}
+			finalizationQueueIndexMap[index] = struct{}{}
 		}
 		blockHeightToFinalizationQueueIndexMap[index] = struct{}{}
 	}

--- a/x/rollapp/types/genesis_test.go
+++ b/x/rollapp/types/genesis_test.go
@@ -59,6 +59,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 					{
 						RollappId: "1",
+						Index:     1,
 					},
 				},
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
@@ -108,6 +109,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 					{
 						RollappId: "1",
+						Index:     1,
 					},
 				},
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
@@ -210,6 +212,81 @@ func TestGenesisState_Validate(t *testing.T) {
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{{CreationHeight: 0}, {CreationHeight: 0}},
 			},
 			valid: false,
+		},
+		{
+			desc: "latestStateInfoIndex references missing stateInfo",
+			genState: &types.GenesisState{
+				Params:                             types.DefaultParams(),
+				RollappList:                        []types.Rollapp{},
+				StateInfoList:                      []types.StateInfo{},
+				LatestStateInfoIndexList:           []types.StateInfoIndex{{RollappId: "rollapp-1", Index: 1}},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},
+			},
+			valid: false,
+		},
+		{
+			desc: "latestFinalizedStateIndex references missing stateInfo",
+			genState: &types.GenesisState{
+				Params:                        types.DefaultParams(),
+				RollappList:                   []types.Rollapp{},
+				StateInfoList:                 []types.StateInfo{},
+				LatestStateInfoIndexList:      []types.StateInfoIndex{},
+				LatestFinalizedStateIndexList: []types.StateInfoIndex{{RollappId: "rollapp-1", Index: 1}},
+			},
+			valid: false,
+		},
+		{
+			desc: "finalization queue references missing stateInfo",
+			genState: &types.GenesisState{
+				Params:                        types.DefaultParams(),
+				RollappList:                   []types.Rollapp{},
+				StateInfoList:                 []types.StateInfo{},
+				LatestStateInfoIndexList:      []types.StateInfoIndex{},
+				LatestFinalizedStateIndexList: []types.StateInfoIndex{},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
+					{
+						CreationHeight:    1,
+						FinalizationQueue: []types.StateInfoIndex{{RollappId: "rollapp-1", Index: 1}},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "duplicated stateInfoIndex in finalization queue",
+			genState: &types.GenesisState{
+				Params:                        types.DefaultParams(),
+				RollappList:                   []types.Rollapp{},
+				StateInfoList:                 []types.StateInfo{{StateInfoIndex: types.StateInfoIndex{RollappId: "rollapp-1", Index: 1}}},
+				LatestStateInfoIndexList:      []types.StateInfoIndex{},
+				LatestFinalizedStateIndexList: []types.StateInfoIndex{},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
+					{
+						CreationHeight: 1,
+						FinalizationQueue: []types.StateInfoIndex{
+							{RollappId: "rollapp-1", Index: 1},
+							{RollappId: "rollapp-1", Index: 1},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "valid finalization queue references existing stateInfo",
+			genState: &types.GenesisState{
+				Params:                   types.DefaultParams(),
+				RollappList:              []types.Rollapp{},
+				StateInfoList:            []types.StateInfo{{StateInfoIndex: types.StateInfoIndex{RollappId: "rollapp-1", Index: 1}}},
+				LatestStateInfoIndexList: []types.StateInfoIndex{{RollappId: "rollapp-1", Index: 1}},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
+					{
+						CreationHeight:    1,
+						FinalizationQueue: []types.StateInfoIndex{{RollappId: "rollapp-1", Index: 1}},
+					},
+				},
+			},
+			valid: true,
 		},
 		// this line is used by starport scaffolding # types/genesis/testcase
 	} {


### PR DESCRIPTION
## Summary

- reject latest and latest-finalized RollApp genesis indexes unless the referenced `StateInfo` is present
- reject finalization queue entries that point at missing `StateInfo`
- reject duplicate `StateInfoIndex` entries inside a finalization queue
- add focused genesis validation coverage for those import-time invariants

Fixes #930
Fixes #915

## Validation

- `go test ./x/rollapp/types -run TestGenesisState_Validate -count=1 -v`
- `go test ./x/rollapp/types -count=1`
- `go test ./x/rollapp -count=1`
- `git diff --check`

Additional check: `go test ./x/rollapp/keeper -run TestRollappKeeperTestSuite/TestKeeperFinalizePending -count=1 -v` currently fails the same way on upstream `main` with an existing queue expectation mismatch, so it is not included in the passing validation set.

Meta Earth bug bounty payout: `$MEC` via ME Pass, address `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.