### PR TITLE
fix(rollapp): validate genesis rollapp invariants

### DIFF
--- a/x/rollapp/types/genesis.go
+++ b/x/rollapp/types/genesis.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 )
 
 // DefaultIndex is the default capability global index
@@ -24,14 +25,49 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	// Check for duplicated index in rollapp
+	type rollappEIP155Entry struct {
+		chainID ChainID
+		rollapp Rollapp
+	}
+
 	rollappIndexMap := make(map[string]struct{})
+	eip155RollappIndexMap := make(map[uint64]rollappEIP155Entry)
 
 	for _, elem := range gs.RollappList {
+		if err := elem.ValidateBasic(); err != nil {
+			return err
+		}
 		index := string(RollappKey(elem.RollappId))
 		if _, ok := rollappIndexMap[index]; ok {
 			return errors.New("duplicated index for rollapp")
 		}
 		rollappIndexMap[index] = struct{}{}
+
+		chainID, err := NewChainID(elem.RollappId)
+		if err != nil {
+			return err
+		}
+		if !chainID.IsEIP155() {
+			continue
+		}
+
+		eip155 := chainID.GetEIP155ID()
+		if previous, ok := eip155RollappIndexMap[eip155]; ok {
+			if !previous.rollapp.Frozen {
+				return fmt.Errorf("duplicated eip155 rollapp index %d", eip155)
+			}
+			if chainID.GetName() != previous.chainID.GetName() {
+				return fmt.Errorf("eip155 rollapp %d name must be %s", eip155, previous.chainID.GetName())
+			}
+			nextRevision := previous.chainID.GetRevisionNumber() + 1
+			if chainID.GetRevisionNumber() != nextRevision {
+				return fmt.Errorf("eip155 rollapp %d revision number should be %d", eip155, nextRevision)
+			}
+		}
+		eip155RollappIndexMap[eip155] = rollappEIP155Entry{
+			chainID: chainID,
+			rollapp: elem,
+		}
 	}
 	// Check for duplicated index in stateInfo
 	stateInfoIndexMap := make(map[string]struct{})

--- a/x/rollapp/types/genesis_test.go
+++ b/x/rollapp/types/genesis_test.go
@@ -33,32 +33,34 @@ func TestGenesisState_Validate(t *testing.T) {
 				},
 				RollappList: []types.Rollapp{
 					{
-						RollappId: "0",
+						RollappId: "rollapp-1",
+						Creator:   deployerAddr1,
 					},
 					{
-						RollappId: "1",
+						RollappId: "otherrollapp-1",
+						Creator:   deployerAddr2,
 					},
 				},
 				StateInfoList: []types.StateInfo{
 					{
 						StateInfoIndex: types.StateInfoIndex{
-							RollappId: "0",
+							RollappId: "rollapp-1",
 							Index:     0,
 						},
 					},
 					{
 						StateInfoIndex: types.StateInfoIndex{
-							RollappId: "1",
+							RollappId: "otherrollapp-1",
 							Index:     1,
 						},
 					},
 				},
 				LatestStateInfoIndexList: []types.StateInfoIndex{
 					{
-						RollappId: "0",
+						RollappId: "rollapp-1",
 					},
 					{
-						RollappId: "1",
+						RollappId: "otherrollapp-1",
 					},
 				},
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
@@ -82,32 +84,34 @@ func TestGenesisState_Validate(t *testing.T) {
 				},
 				RollappList: []types.Rollapp{
 					{
-						RollappId: "0",
+						RollappId: "rollapp-1",
+						Creator:   deployerAddr1,
 					},
 					{
-						RollappId: "1",
+						RollappId: "otherrollapp-1",
+						Creator:   deployerAddr2,
 					},
 				},
 				StateInfoList: []types.StateInfo{
 					{
 						StateInfoIndex: types.StateInfoIndex{
-							RollappId: "0",
+							RollappId: "rollapp-1",
 							Index:     0,
 						},
 					},
 					{
 						StateInfoIndex: types.StateInfoIndex{
-							RollappId: "1",
+							RollappId: "otherrollapp-1",
 							Index:     1,
 						},
 					},
 				},
 				LatestStateInfoIndexList: []types.StateInfoIndex{
 					{
-						RollappId: "0",
+						RollappId: "rollapp-1",
 					},
 					{
-						RollappId: "1",
+						RollappId: "otherrollapp-1",
 					},
 				},
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
@@ -143,7 +147,122 @@ func TestGenesisState_Validate(t *testing.T) {
 					DisputePeriodInBlocks: types.DefaultGenesis().Params.DisputePeriodInBlocks,
 					DeployerWhitelist:     []types.DeployerParams{},
 				},
-				RollappList:                        []types.Rollapp{{RollappId: "0"}, {RollappId: "0"}},
+				RollappList:                        []types.Rollapp{{RollappId: "rollapp-1", Creator: deployerAddr1}, {RollappId: "rollapp-1", Creator: deployerAddr1}},
+				StateInfoList:                      []types.StateInfo{},
+				LatestStateInfoIndexList:           []types.StateInfoIndex{},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},
+			},
+			valid: false,
+		},
+		{
+			desc: "invalid rollapp basic validation",
+			genState: &types.GenesisState{
+				Params: types.Params{
+					DisputePeriodInBlocks: types.DefaultGenesis().Params.DisputePeriodInBlocks,
+					DeployerWhitelist:     []types.DeployerParams{},
+				},
+				RollappList: []types.Rollapp{
+					{
+						RollappId:     "rollapp-1",
+						Creator:       deployerAddr1,
+						MaxSequencers: types.MaxAllowedSequencers + 1,
+					},
+				},
+				StateInfoList:                      []types.StateInfo{},
+				LatestStateInfoIndexList:           []types.StateInfoIndex{},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},
+			},
+			valid: false,
+		},
+		{
+			desc: "duplicated active eip155 rollapp",
+			genState: &types.GenesisState{
+				Params: types.Params{
+					DisputePeriodInBlocks: types.DefaultGenesis().Params.DisputePeriodInBlocks,
+					DeployerWhitelist:     []types.DeployerParams{},
+				},
+				RollappList: []types.Rollapp{
+					{
+						RollappId: "alpha_42-1",
+						Creator:   deployerAddr1,
+					},
+					{
+						RollappId: "beta_42-1",
+						Creator:   deployerAddr2,
+					},
+				},
+				StateInfoList:                      []types.StateInfo{},
+				LatestStateInfoIndexList:           []types.StateInfoIndex{},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},
+			},
+			valid: false,
+		},
+		{
+			desc: "valid frozen eip155 revision replacement",
+			genState: &types.GenesisState{
+				Params: types.Params{
+					DisputePeriodInBlocks: types.DefaultGenesis().Params.DisputePeriodInBlocks,
+					DeployerWhitelist:     []types.DeployerParams{},
+				},
+				RollappList: []types.Rollapp{
+					{
+						RollappId: "rollapp_42-1",
+						Creator:   deployerAddr1,
+						Frozen:    true,
+					},
+					{
+						RollappId: "rollapp_42-2",
+						Creator:   deployerAddr2,
+					},
+				},
+				StateInfoList:                      []types.StateInfo{},
+				LatestStateInfoIndexList:           []types.StateInfoIndex{},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},
+			},
+			valid: true,
+		},
+		{
+			desc: "invalid frozen eip155 revision replacement name",
+			genState: &types.GenesisState{
+				Params: types.Params{
+					DisputePeriodInBlocks: types.DefaultGenesis().Params.DisputePeriodInBlocks,
+					DeployerWhitelist:     []types.DeployerParams{},
+				},
+				RollappList: []types.Rollapp{
+					{
+						RollappId: "rollapp_42-1",
+						Creator:   deployerAddr1,
+						Frozen:    true,
+					},
+					{
+						RollappId: "otherrollapp_42-2",
+						Creator:   deployerAddr2,
+					},
+				},
+				StateInfoList:                      []types.StateInfo{},
+				LatestStateInfoIndexList:           []types.StateInfoIndex{},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},
+			},
+			valid: false,
+		},
+		{
+			desc: "invalid frozen eip155 revision replacement gap",
+			genState: &types.GenesisState{
+				Params: types.Params{
+					DisputePeriodInBlocks: types.DefaultGenesis().Params.DisputePeriodInBlocks,
+					DeployerWhitelist:     []types.DeployerParams{},
+				},
+				RollappList: []types.Rollapp{
+					{
+						RollappId: "rollapp_42-1",
+						Creator:   deployerAddr1,
+						Frozen:    true,
+					},
+					{
+						RollappId: "rollapp_42-3",
+						Creator:   deployerAddr2,
+					},
+				},
 				StateInfoList:                      []types.StateInfo{},
 				LatestStateInfoIndexList:           []types.StateInfoIndex{},
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},

--- a/x/sequencer/keeper/msg_server_create_sequencer.go
+++ b/x/sequencer/keeper/msg_server_create_sequencer.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
 
 	errorsmod "cosmossdk.io/errors"
@@ -87,7 +88,11 @@ func (k msgServer) CreateSequencer(goCtx context.Context, msg *types.MsgCreateSe
 	unbondingSequencers := k.GetSequencersByRollappByStatus(ctx, msg.RollappId, types.Unbonding)
 	// check to see if we reached the maximum number of sequencers for this rollapp
 	currentNumOfSequencers := len(bondedSequencers) + len(unbondingSequencers)
-	if rollapp.MaxSequencers > 0 && uint64(currentNumOfSequencers) >= rollapp.MaxSequencers {
+	maxSequencers := rollapp.MaxSequencers
+	if maxSequencers > rollapptypes.MaxAllowedSequencers {
+		maxSequencers = rollapptypes.MaxAllowedSequencers
+	}
+	if maxSequencers > 0 && uint64(currentNumOfSequencers) >= maxSequencers {
 		return nil, types.ErrMaxSequencersLimit
 	}
 	// this is the first sequencer, make it a PROPOSER

--- a/x/sequencer/keeper/msg_server_create_sequencer_test.go
+++ b/x/sequencer/keeper/msg_server_create_sequencer_test.go
@@ -503,6 +503,45 @@ func (suite *SequencerTestSuite) TestMaxSequencersLimit() {
 	}
 }
 
+func (suite *SequencerTestSuite) TestMaxSequencersAboveProtocolLimitIsCapped() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollapp := rollapptypes.Rollapp{
+		RollappId:             "rollapp1",
+		Creator:               alice,
+		Version:               0,
+		MaxSequencers:         rollapptypes.MaxAllowedSequencers + 1,
+		PermissionedAddresses: []string{},
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	createSequencer := func() error {
+		pubkey := secp256k1.GenPrivKey().PubKey()
+		addr := sdk.AccAddress(pubkey.Address())
+		err := bankutil.FundAccount(suite.App.BankKeeper, suite.Ctx, addr, sdk.NewCoins(bond))
+		suite.Require().Nil(err)
+
+		pkAny, err := codectypes.NewAnyWithValue(pubkey)
+		suite.Require().Nil(err)
+
+		_, err = suite.msgServer.CreateSequencer(goCtx, &types.MsgCreateSequencer{
+			Creator:      addr.String(),
+			DymintPubKey: pkAny,
+			Bond:         bond,
+			RollappId:    rollapp.RollappId,
+			Description:  types.Description{},
+		})
+		return err
+	}
+
+	for i := uint64(0); i < rollapptypes.MaxAllowedSequencers; i++ {
+		suite.Require().NoError(createSequencer())
+	}
+
+	suite.Require().ErrorIs(createSequencer(), types.ErrMaxSequencersLimit)
+}
+
 func (suite *SequencerTestSuite) TestMaxSequencersNotSet() {
 	suite.SetupTest()
 	goCtx := sdk.WrapSDKContext(suite.Ctx)


### PR DESCRIPTION
## Summary

- validate each RollApp during genesis validation, so imported RollApps follow the same basic rules as runtime creation
- reject duplicate EIP155 RollApp indexes unless they follow the frozen same-name next-revision replacement rule
- cap sequencer registration against the protocol maximum when a stored RollApp has an oversized `MaxSequencers` value

Fixes #931
Fixes #932

## Validation

- `go test ./x/rollapp/types -run TestGenesisState_Validate -count=1 -v`
- `go test ./x/rollapp/types -count=1`
- `go test ./x/rollapp -count=1`
- `go test ./x/sequencer/keeper -run 'TestSequencerKeeperTestSuite/TestMaxSequencers(AboveProtocolLimitIsCapped|Limit)$' -count=1 -v`
- `go test ./x/sequencer/keeper -count=1`
- `go test ./x/sequencer/... -count=1`
- `git diff --check`

I also ran `go test ./x/rollapp/... -count=1`; it still fails on existing `x/rollapp/keeper` tests unrelated to this change (`TestCreateRollappId/default_is_valid_without_revision_number`, `TestCreateRollappUnauthorizedRollappCreator`, and `TestKeeperFinalizePending`). I reproduced the same failures on untouched `origin/main` at `ddb75edc` in `/tmp/mehub-baseline-931-932`.

Meta Earth bug bounty payout: `$MEC` via ME Pass, address `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.
