### PR TITLE
fix(gravity): reject offline relayer confirmations

### DIFF
--- a/x/gravity/keeper/claim.go
+++ b/x/gravity/keeper/claim.go
@@ -34,6 +34,9 @@ func (s MsgServer) confirmHandlerCommon(ctx sdk.Context, relayerAddr sdk.AccAddr
 	if !found {
 		return types.ErrNotFoundRelayer
 	}
+	if !relayer.Online {
+		return types.ErrRelayerNotOnLine
+	}
 
 	if relayer.ExternalAddress != signatureAddr {
 		return errorsmod.Wrapf(types.ErrExternalAddressNotMatch, "got %s, expected %s", signatureAddr, relayer.ExternalAddress)

--- a/x/gravity/keeper/grpc_query.go
+++ b/x/gravity/keeper/grpc_query.go
@@ -82,16 +82,23 @@ func (k QueryServer) RelayerSetConfirm(c context.Context, req *types.QueryRelaye
 		return nil, status.Error(codes.InvalidArgument, "nonce")
 	}
 	ctx := sdk.UnwrapSDKContext(c)
-	return &types.QueryRelayerSetConfirmResponse{Confirm: k.GetRelayerSetConfirm(ctx, req.Nonce, sdk.MustAccAddressFromBech32(req.RelayerAddress))}, nil
+	relayerAddress := sdk.MustAccAddressFromBech32(req.RelayerAddress)
+	if !k.confirmRelayerOnlineAddress(ctx, relayerAddress) {
+		return &types.QueryRelayerSetConfirmResponse{}, nil
+	}
+	return &types.QueryRelayerSetConfirmResponse{Confirm: k.GetRelayerSetConfirm(ctx, req.Nonce, relayerAddress)}, nil
 }
 
 func (k QueryServer) RelayerSetConfirmsByNonce(c context.Context, req *types.QueryRelayerSetConfirmsByNonceRequest) (*types.QueryRelayerSetConfirmsByNonceResponse, error) {
 	if req.GetNonce() <= 0 {
 		return nil, status.Error(codes.InvalidArgument, "nonce")
 	}
+	ctx := sdk.UnwrapSDKContext(c)
 	var confirms []*types.MsgRelayerSetConfirm
-	k.IterateRelayerSetConfirmByNonce(sdk.UnwrapSDKContext(c), req.Nonce, func(confirm *types.MsgRelayerSetConfirm) bool {
-		confirms = append(confirms, confirm)
+	k.IterateRelayerSetConfirmByNonce(ctx, req.Nonce, func(confirm *types.MsgRelayerSetConfirm) bool {
+		if k.confirmRelayerOnline(ctx, confirm.RelayerAddress) {
+			confirms = append(confirms, confirm)
+		}
 		return false
 	})
 	return &types.QueryRelayerSetConfirmsByNonceResponse{Confirms: confirms}, nil
@@ -224,9 +231,12 @@ func (k QueryServer) BatchConfirm(c context.Context, req *types.QueryBatchConfir
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 	RelayerAddress := sdk.MustAccAddressFromBech32(req.RelayerAddress)
-	_, ok := k.GetRelayer(ctx, RelayerAddress)
+	relayer, ok := k.GetRelayer(ctx, RelayerAddress)
 	if !ok {
 		return nil, types.ErrNotFoundRelayer
+	}
+	if !relayer.Online {
+		return &types.QueryBatchConfirmResponse{}, nil
 	}
 	confirm := k.GetBatchConfirm(ctx, req.TokenContract, req.Nonce, RelayerAddress)
 	return &types.QueryBatchConfirmResponse{Confirm: confirm}, nil
@@ -239,12 +249,28 @@ func (k QueryServer) BatchConfirms(c context.Context, req *types.QueryBatchConfi
 	if req.GetNonce() <= 0 {
 		return nil, status.Error(codes.InvalidArgument, "nonce")
 	}
+	ctx := sdk.UnwrapSDKContext(c)
 	var confirms []*types.MsgConfirmBatch
-	k.IterateBatchConfirmByNonceAndTokenContract(sdk.UnwrapSDKContext(c), req.Nonce, req.TokenContract, func(confirm *types.MsgConfirmBatch) bool {
-		confirms = append(confirms, confirm)
+	k.IterateBatchConfirmByNonceAndTokenContract(ctx, req.Nonce, req.TokenContract, func(confirm *types.MsgConfirmBatch) bool {
+		if k.confirmRelayerOnline(ctx, confirm.RelayerAddress) {
+			confirms = append(confirms, confirm)
+		}
 		return false
 	})
 	return &types.QueryBatchConfirmsResponse{Confirms: confirms}, nil
+}
+
+func (k QueryServer) confirmRelayerOnline(ctx sdk.Context, relayerAddress string) bool {
+	relayerAddr, err := sdk.AccAddressFromBech32(relayerAddress)
+	if err != nil {
+		return false
+	}
+	return k.confirmRelayerOnlineAddress(ctx, relayerAddr)
+}
+
+func (k QueryServer) confirmRelayerOnlineAddress(ctx sdk.Context, relayerAddr sdk.AccAddress) bool {
+	relayer, found := k.GetRelayer(ctx, relayerAddr)
+	return found && relayer.Online
 }
 
 func (k QueryServer) PendingOutgoingTxByAddr(c context.Context, req *types.QueryPendingOutgoingTxByAddrRequest) (*types.QueryPendingOutgoingTxByAddrResponse, error) {

--- a/x/gravity/keeper/offline_relayer_confirm_test.go
+++ b/x/gravity/keeper/offline_relayer_confirm_test.go
@@ -1,0 +1,198 @@
+package keeper_test
+
+import (
+	"encoding/hex"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/testutil/helpers"
+	"github.com/openmetaearth/me-hub/x/gravity/keeper"
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+)
+
+func (s *KeeperTestSuite) TestOfflineRelayerCannotSubmitRelayerSetConfirm() {
+	relayerAddr := s.relayerAddrs[0]
+	externalAddr := s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)
+	msg := &types.MsgBondedRelayer{
+		RelayerAddress:  relayerAddr.String(),
+		ExternalAddress: externalAddr,
+		DelegateAmount:  sdk.NewCoin(params.BaseDenom, s.Keeper().GetGravityMinDelegate(s.Ctx)),
+		ChainName:       s.chainName,
+	}
+	_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msg)
+	s.Require().NoError(err)
+
+	s.Ctx = s.Ctx.WithBlockHeight(s.Ctx.BlockHeight() + 1)
+	s.Keeper().EndBlocker(s.Ctx)
+
+	relayerSet := s.Keeper().GetRelayerSet(s.Ctx, 1)
+	s.Require().NotNil(relayerSet)
+	checkpoint, err := relayerSet.GetCheckpoint(s.Keeper().GetGravityID(s.Ctx))
+	s.Require().NoError(err)
+	signature, err := types.NewEthereumSignature(checkpoint, s.externalPris[0])
+	s.Require().NoError(err)
+
+	relayer, found := s.Keeper().GetRelayer(s.Ctx, relayerAddr)
+	s.Require().True(found)
+	relayer.Online = false
+	s.Keeper().SetRelayer(s.Ctx, relayerAddr, relayer)
+
+	confirm := &types.MsgRelayerSetConfirm{
+		Nonce:           relayerSet.Nonce,
+		RelayerAddress:  relayerAddr.String(),
+		ExternalAddress: externalAddr,
+		Signature:       hex.EncodeToString(signature),
+		ChainName:       s.chainName,
+	}
+	_, err = s.MsgServer().RelayerSetConfirm(sdk.WrapSDKContext(s.Ctx), confirm)
+	s.Require().ErrorIs(err, types.ErrRelayerNotOnLine)
+	s.Require().Nil(s.Keeper().GetRelayerSetConfirm(s.Ctx, relayerSet.Nonce, relayerAddr))
+}
+
+func (s *KeeperTestSuite) TestOfflineRelayerCannotSubmitBatchConfirm() {
+	s.setupBondedRelayerSetForAuditTest()
+
+	relayerAddr := s.relayerAddrs[0]
+	externalAddr := s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)
+	bridgeToken := s.NewBridgeToken(relayerAddr, sdk.NewCoin("uofflineconfirm", sdkmath.NewInt(100)))
+
+	_, err := s.MsgServer().SendToExternal(sdk.WrapSDKContext(s.Ctx), &types.MsgSendToExternal{
+		Sender:    relayerAddr.String(),
+		Dest:      externalAddr,
+		Amount:    sdk.NewCoin(bridgeToken.Denom, sdkmath.NewInt(10)),
+		BridgeFee: sdk.NewCoin(bridgeToken.Denom, sdkmath.NewInt(1)),
+		ChainName: s.chainName,
+	})
+	s.Require().NoError(err)
+
+	s.Keeper().SetLastObservedBlockHeight(s.Ctx, 1_000, uint64(s.Ctx.BlockHeight()))
+	s.Ctx = s.Ctx.WithBlockHeight(s.Ctx.BlockHeight() + 1)
+	batchResponse, err := s.MsgServer().RequestBatch(sdk.WrapSDKContext(s.Ctx), &types.MsgRequestBatch{
+		Sender:     relayerAddr.String(),
+		Denom:      bridgeToken.Denom,
+		MinimumFee: sdkmath.NewInt(1),
+		FeeReceive: helpers.GenerateAddress().Hex(),
+		ChainName:  s.chainName,
+		BaseFee:    sdkmath.ZeroInt(),
+	})
+	s.Require().NoError(err)
+
+	batch := s.Keeper().GetOutgoingTxBatch(s.Ctx, bridgeToken.ContractAddress, batchResponse.BatchNonce)
+	s.Require().NotNil(batch)
+	checkpoint, err := batch.GetCheckpoint(s.Keeper().GetGravityID(s.Ctx))
+	s.Require().NoError(err)
+	signature, err := types.NewEthereumSignature(checkpoint, s.externalPris[0])
+	s.Require().NoError(err)
+
+	relayer, found := s.Keeper().GetRelayer(s.Ctx, relayerAddr)
+	s.Require().True(found)
+	relayer.Online = false
+	s.Keeper().SetRelayer(s.Ctx, relayerAddr, relayer)
+
+	confirm := &types.MsgConfirmBatch{
+		Nonce:           batch.BatchNonce,
+		TokenContract:   batch.TokenContract,
+		RelayerAddress:  relayerAddr.String(),
+		ExternalAddress: externalAddr,
+		Signature:       hex.EncodeToString(signature),
+		ChainName:       s.chainName,
+	}
+	_, err = s.MsgServer().ConfirmBatch(sdk.WrapSDKContext(s.Ctx), confirm)
+	s.Require().ErrorIs(err, types.ErrRelayerNotOnLine)
+	s.Require().Nil(s.Keeper().GetBatchConfirm(s.Ctx, batch.TokenContract, batch.BatchNonce, relayerAddr))
+}
+
+func (s *KeeperTestSuite) TestOfflineRelayerConfirmsAreFilteredFromQueries() {
+	queryServer := keeper.NewQueryServerImpl(s.Keeper())
+	onlineRelayer := s.relayerAddrs[0]
+	offlineRelayer := s.relayerAddrs[1]
+	tokenContract := helpers.GenerateAddress().Hex()
+
+	s.Keeper().SetRelayer(s.Ctx, onlineRelayer, types.Relayer{
+		RelayerAddress:  onlineRelayer.String(),
+		ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[0].PublicKey),
+		Online:          true,
+	})
+	s.Keeper().SetRelayer(s.Ctx, offlineRelayer, types.Relayer{
+		RelayerAddress:  offlineRelayer.String(),
+		ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[1].PublicKey),
+		Online:          false,
+	})
+
+	s.Keeper().SetRelayerSetConfirm(s.Ctx, onlineRelayer, &types.MsgRelayerSetConfirm{
+		Nonce:          1,
+		RelayerAddress: onlineRelayer.String(),
+		ChainName:      s.chainName,
+	})
+	s.Keeper().SetRelayerSetConfirm(s.Ctx, offlineRelayer, &types.MsgRelayerSetConfirm{
+		Nonce:          1,
+		RelayerAddress: offlineRelayer.String(),
+		ChainName:      s.chainName,
+	})
+	s.Keeper().SetBatchConfirm(s.Ctx, onlineRelayer, &types.MsgConfirmBatch{
+		Nonce:          1,
+		TokenContract:  tokenContract,
+		RelayerAddress: onlineRelayer.String(),
+		ChainName:      s.chainName,
+	})
+	s.Keeper().SetBatchConfirm(s.Ctx, offlineRelayer, &types.MsgConfirmBatch{
+		Nonce:          1,
+		TokenContract:  tokenContract,
+		RelayerAddress: offlineRelayer.String(),
+		ChainName:      s.chainName,
+	})
+
+	relayerSetConfirms, err := queryServer.RelayerSetConfirmsByNonce(s.Ctx, &types.QueryRelayerSetConfirmsByNonceRequest{
+		ChainName: s.chainName,
+		Nonce:     1,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(relayerSetConfirms.Confirms, 1)
+	s.Require().Equal(onlineRelayer.String(), relayerSetConfirms.Confirms[0].RelayerAddress)
+
+	onlineRelayerSetConfirm, err := queryServer.RelayerSetConfirm(s.Ctx, &types.QueryRelayerSetConfirmRequest{
+		ChainName:      s.chainName,
+		RelayerAddress: onlineRelayer.String(),
+		Nonce:          1,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(onlineRelayerSetConfirm.Confirm)
+	s.Require().Equal(onlineRelayer.String(), onlineRelayerSetConfirm.Confirm.RelayerAddress)
+
+	offlineRelayerSetConfirm, err := queryServer.RelayerSetConfirm(s.Ctx, &types.QueryRelayerSetConfirmRequest{
+		ChainName:      s.chainName,
+		RelayerAddress: offlineRelayer.String(),
+		Nonce:          1,
+	})
+	s.Require().NoError(err)
+	s.Require().Nil(offlineRelayerSetConfirm.Confirm)
+
+	batchConfirms, err := queryServer.BatchConfirms(s.Ctx, &types.QueryBatchConfirmsRequest{
+		ChainName:     s.chainName,
+		TokenContract: tokenContract,
+		Nonce:         1,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(batchConfirms.Confirms, 1)
+	s.Require().Equal(onlineRelayer.String(), batchConfirms.Confirms[0].RelayerAddress)
+
+	onlineBatchConfirm, err := queryServer.BatchConfirm(s.Ctx, &types.QueryBatchConfirmRequest{
+		ChainName:      s.chainName,
+		TokenContract:  tokenContract,
+		RelayerAddress: onlineRelayer.String(),
+		Nonce:          1,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(onlineBatchConfirm.Confirm)
+	s.Require().Equal(onlineRelayer.String(), onlineBatchConfirm.Confirm.RelayerAddress)
+
+	offlineBatchConfirm, err := queryServer.BatchConfirm(s.Ctx, &types.QueryBatchConfirmRequest{
+		ChainName:      s.chainName,
+		TokenContract:  tokenContract,
+		RelayerAddress: offlineRelayer.String(),
+		Nonce:          1,
+	})
+	s.Require().NoError(err)
+	s.Require().Nil(offlineBatchConfirm.Confirm)
+}

--- a/x/tron/keeper/keeper_test.go
+++ b/x/tron/keeper/keeper_test.go
@@ -142,6 +142,7 @@ func (s *KeeperTestSuite) NewRelayer() (sdk.AccAddress, cryptotypes.PrivKey) {
 	newRelayer := gravitytypes.Relayer{
 		RelayerAddress:  relayer.String(),
 		ExternalAddress: externalAddress,
+		Online:          true,
 	}
 	s.App.TronKeeper.SetRelayer(s.Ctx, relayer, newRelayer)
 	s.App.TronKeeper.SetRelayerByExternalAddress(s.Ctx, externalAddress, relayer)


### PR DESCRIPTION
## Summary

- Reject `ConfirmBatch` and `RelayerSetConfirm` submissions when the relayer's stored record is offline.
- Filter stored batch and relayer-set confirmation query results, including both list and specific-confirm endpoints, so offline relayer signatures are not returned as executable bridge material.
- Add regression coverage for both confirmation message paths and for stale stored confirmation query results.
- Keep TRON keeper test relayers active so the shared confirmation tests continue covering the successful active-relayer paths.

## Root cause

`confirmHandlerCommon` loaded the relayer record and verified the external address and signature, but it did not enforce the same `Online` gate that claim handling already uses. That allowed a slashed/offline relayer to keep submitting valid external signatures for pending bridge work.

## Validation

- `go test ./x/tron/keeper -run 'TestKeeperTestSuite/(TestQuery_BatchConfirms|Test_msgServer_ConfirmBatch|Test_msgServer_RelayerSetConfirm)' -count=1 -v`
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestOfflineRelayer' -count=1 -v`
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(MsgSetRelayerSetConfirm|ClaimWithRelayerOnline|Keeper_DeleteBatchConfirm|LastPendingBatchRequestByAddr|QueryUnbatchedTxs)' -count=1 -v`
- `go test ./x/tron/keeper ./x/gravity/keeper -count=1`
- `git diff --check`

Fixes #940

Meta Earth bug bounty payout: `$MEC` via ME Pass address `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.
