### PR TITLE
fix(wstaking): protect region reserves on withdrawal

### DIFF
--- a/x/wstaking/keeper/msg_server_region.go
+++ b/x/wstaking/keeper/msg_server_region.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/nft"
+	"github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/utils"
 	"github.com/openmetaearth/me-hub/x/wstaking/types"
 )
@@ -164,6 +165,24 @@ func (k MsgServer) WithdrawFromRegion(goCtx context.Context, msg *types.MsgWithd
 	toAddr, err := sdk.AccAddressFromBech32(msg.Receiver)
 	if err != nil {
 		return nil, sdkerrors.Wrapf(types.ErrUnknownAccount, "receiver account %s format error %s", msg.Receiver, err)
+	}
+
+	baseWithdrawAmount := msg.Amount.AmountOf(params.BaseDenom)
+	if baseWithdrawAmount.IsPositive() {
+		reservedBalance := region.DelegateInterest.Add(sdk.NewDecFromInt(region.FixedDepositAmount))
+		balanceAfterWithdraw := sdk.NewDecFromInt(
+			k.bankKeeper.GetBalance(ctx, fromAddr, params.BaseDenom).Amount.Sub(baseWithdrawAmount),
+		)
+		if balanceAfterWithdraw.LT(reservedBalance) {
+			return nil, sdkerrors.Wrapf(
+				sdkerrors.ErrInsufficientFunds,
+				"withdrawal would breach region reserve: balance after withdrawal %s%s, reserved %s%s",
+				balanceAfterWithdraw.String(),
+				params.BaseDenom,
+				reservedBalance.String(),
+				params.BaseDenom,
+			)
+		}
 	}
 
 	err = k.bankKeeper.Extend().SendCoinsWithTag(

--- a/x/wstaking/keeper/msg_server_region_test.go
+++ b/x/wstaking/keeper/msg_server_region_test.go
@@ -233,6 +233,49 @@ func (s *KeeperTestSuite) TestWithdrawFromRegion() {
 	}
 }
 
+func (s *KeeperTestSuite) TestWithdrawFromRegionPreservesReservedBalance() {
+	s.SetupTest()
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	regionResp, err := s.queryClient.Region(s.Ctx, &types.QueryRegionRequest{RegionId: strings.ToLower(types.ExperienceRegionName)})
+	s.Require().NoError(err)
+
+	treasuryAddr := sdk.MustAccAddressFromBech32(regionResp.Region.RegionTreasureAddr)
+	balance := s.App.BankKeeper.GetBalance(s.Ctx, treasuryAddr, params.BaseDenom)
+	s.Require().True(balance.Amount.IsPositive())
+
+	reserve := balance.Amount.QuoRaw(2)
+	available := balance.Amount.Sub(reserve)
+
+	region := regionResp.Region
+	region.DelegateInterest = sdk.NewDecFromInt(reserve)
+	region.FixedDepositAmount = sdk.ZeroInt()
+	s.Keeper().SetRegion(s.Ctx, region)
+
+	_, err = s.msgServer.WithdrawFromRegion(s.Ctx, &types.MsgWithdrawFromRegion{
+		Withdrawer: s.Dao.GlobalDao,
+		RegionId:   region.RegionId,
+		Receiver:   s.Dao.GlobalDao,
+		Amount:     sdk.NewCoins(sdk.NewCoin(params.BaseDenom, available.Add(sdk.NewInt(1)))),
+	})
+	s.Require().ErrorIs(err, sdkerrors.ErrInsufficientFunds)
+	s.Require().Equal(balance.String(), s.App.BankKeeper.GetBalance(s.Ctx, treasuryAddr, params.BaseDenom).String())
+
+	_, err = s.msgServer.WithdrawFromRegion(s.Ctx, &types.MsgWithdrawFromRegion{
+		Withdrawer: s.Dao.GlobalDao,
+		RegionId:   region.RegionId,
+		Receiver:   s.Dao.GlobalDao,
+		Amount:     sdk.NewCoins(sdk.NewCoin(params.BaseDenom, available)),
+	})
+	s.Require().NoError(err)
+
+	balanceAfter := s.App.BankKeeper.GetBalance(s.Ctx, treasuryAddr, params.BaseDenom)
+	s.Require().Equal(reserve.String(), balanceAfter.Amount.String())
+}
+
 func (s *KeeperTestSuite) TestGrantRegionWithdraw() {
 	s.SetupTest()
 


### PR DESCRIPTION
## Summary
- Reject base-denom `WithdrawFromRegion` requests that would leave the region treasury below its reserved obligations.
- Reserve calculation covers `DelegateInterest + FixedDepositAmount`, preserving funds needed for outstanding delegator and fixed-deposit obligations.
- Add regression coverage for both the over-withdrawal failure path and the exact available-withdrawal success path.

Fixes #89.

## Validation
- `git diff --check`
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\tools\go\bin\go.exe test .\x\wstaking\keeper -run TestKeeperTestSuite/TestWithdrawFromRegionPreservesReservedBalance -count=1` did not reach the package tests because the current dependency graph fails to compile in `github.com/openmetaearth/ethermint/app/ante` with missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature` symbols.