### PR TITLE
fix(kyc): preserve issuers during dao rotation

### DIFF
--- a/x/kyc/keeper/did.go
+++ b/x/kyc/keeper/did.go
@@ -45,7 +45,6 @@ func (k Keeper) SetKycIssers(ctx sdk.Context, oldDaoAddress, newDaoAddress []str
 		return fmt.Errorf("kyc service not found")
 	}
 
-	dids := []string{}
 	for i, dao := range oldDaoAddress {
 		did, found := k.GetDID(ctx, sdk.MustAccAddressFromBech32(dao))
 		if !found {
@@ -62,10 +61,8 @@ func (k Keeper) SetKycIssers(ctx sdk.Context, oldDaoAddress, newDaoAddress []str
 
 		didInfo.Address = newDaoAddress[i]
 		k.SetDidInfo(ctx, did, didInfo)
-		dids = append(dids, did)
 	}
 
-	service.Issuers = dids
 	k.didKeeper.SetService(ctx, types.ModuleName, service)
 	return nil
 }

--- a/x/kyc/keeper/did.go
+++ b/x/kyc/keeper/did.go
@@ -45,20 +45,31 @@ func (k Keeper) SetKycIssers(ctx sdk.Context, oldDaoAddress, newDaoAddress []str
 		return fmt.Errorf("kyc service not found")
 	}
 
+	dids := make([]string, len(oldDaoAddress))
+	didInfos := make([]didtypes.DidInfo, len(oldDaoAddress))
 	for i, dao := range oldDaoAddress {
 		did, found := k.GetDID(ctx, sdk.MustAccAddressFromBech32(dao))
 		if !found {
 			return fmt.Errorf("old address %s did not exists, please create did before repalce did", dao)
 		}
 
-		k.didKeeper.DeleteDID(ctx, sdk.MustAccAddressFromBech32(dao))
-		k.didKeeper.SetDID(ctx, sdk.MustAccAddressFromBech32(newDaoAddress[i]), did)
-
 		didInfo, found := k.GetDidInfo(ctx, did)
 		if !found {
 			return fmt.Errorf("old address %s did info not exists, please create did info before replace did info", dao)
 		}
 
+		dids[i] = did
+		didInfos[i] = didInfo
+	}
+
+	for _, dao := range oldDaoAddress {
+		k.didKeeper.DeleteDID(ctx, sdk.MustAccAddressFromBech32(dao))
+	}
+
+	for i, did := range dids {
+		k.didKeeper.SetDID(ctx, sdk.MustAccAddressFromBech32(newDaoAddress[i]), did)
+
+		didInfo := didInfos[i]
 		didInfo.Address = newDaoAddress[i]
 		k.SetDidInfo(ctx, did, didInfo)
 	}

--- a/x/kyc/keeper/did_test.go
+++ b/x/kyc/keeper/did_test.go
@@ -60,3 +60,52 @@ func (s *KeeperTestSuite) TestSetKycIssersPreservesOtherIssuers() {
 	s.Require().True(found)
 	s.Require().Equal(thirdPartyDid, preservedThirdPartyDid)
 }
+
+func (s *KeeperTestSuite) TestSetKycIssersPreservesDistinctIssuersWhenDaoAddressesSwap() {
+	s.SetupTest()
+
+	oldGlobalAddr := sdk.MustAccAddressFromBech32(s.Dao.GlobalDao)
+	oldMeidAddr := sdk.MustAccAddressFromBech32(s.Dao.MeidDao)
+	oldGlobalDid, found := s.Keeper().GetDID(s.Ctx, oldGlobalAddr)
+	s.Require().True(found)
+
+	oldMeidDid := "0000000000002"
+	s.Keeper().SetDID(s.Ctx, oldMeidAddr, oldMeidDid)
+	s.Keeper().SetDidInfo(s.Ctx, oldMeidDid, didtypes.DidInfo{
+		Did:     oldMeidDid,
+		Address: oldMeidAddr.String(),
+		Status:  didtypes.DID_STATUS_ACTIVE,
+	})
+
+	service, found := s.Keeper().GetService(s.Ctx)
+	s.Require().True(found)
+	service.Issuers = []string{oldGlobalDid, oldMeidDid}
+	s.Keeper().SetService(s.Ctx, service)
+
+	err := s.Keeper().SetKycIssers(
+		s.Ctx,
+		[]string{s.Dao.GlobalDao, s.Dao.MeidDao},
+		[]string{s.Dao.MeidDao, s.Dao.GlobalDao},
+	)
+	s.Require().NoError(err)
+
+	newGlobalDid, found := s.Keeper().GetDID(s.Ctx, oldMeidAddr)
+	s.Require().True(found)
+	s.Require().Equal(oldGlobalDid, newGlobalDid)
+
+	newMeidDid, found := s.Keeper().GetDID(s.Ctx, oldGlobalAddr)
+	s.Require().True(found)
+	s.Require().Equal(oldMeidDid, newMeidDid)
+
+	updatedGlobalInfo, found := s.Keeper().GetDidInfo(s.Ctx, oldGlobalDid)
+	s.Require().True(found)
+	s.Require().Equal(oldMeidAddr.String(), updatedGlobalInfo.Address)
+
+	updatedMeidInfo, found := s.Keeper().GetDidInfo(s.Ctx, oldMeidDid)
+	s.Require().True(found)
+	s.Require().Equal(oldGlobalAddr.String(), updatedMeidInfo.Address)
+
+	updatedService, found := s.Keeper().GetService(s.Ctx)
+	s.Require().True(found)
+	s.Require().Equal([]string{oldGlobalDid, oldMeidDid}, updatedService.Issuers)
+}

--- a/x/kyc/keeper/did_test.go
+++ b/x/kyc/keeper/did_test.go
@@ -1,0 +1,62 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+)
+
+func (s *KeeperTestSuite) TestSetKycIssersPreservesOtherIssuers() {
+	s.SetupTest()
+
+	oldGlobalAddr := sdk.MustAccAddressFromBech32(s.Dao.GlobalDao)
+	oldMeidAddr := sdk.MustAccAddressFromBech32(s.Dao.MeidDao)
+	oldGlobalDid, found := s.Keeper().GetDID(s.Ctx, oldGlobalAddr)
+	s.Require().True(found)
+
+	oldMeidDid := "0000000000002"
+	s.Keeper().SetDID(s.Ctx, oldMeidAddr, oldMeidDid)
+	s.Keeper().SetDidInfo(s.Ctx, oldMeidDid, didtypes.DidInfo{
+		Did:     oldMeidDid,
+		Address: oldMeidAddr.String(),
+		Status:  didtypes.DID_STATUS_ACTIVE,
+	})
+
+	thirdPartyAddr, _ := s.NewAccount()
+	thirdPartyDid := "third-party-issuer"
+	s.Keeper().SetDID(s.Ctx, thirdPartyAddr, thirdPartyDid)
+	s.Keeper().SetDidInfo(s.Ctx, thirdPartyDid, didtypes.DidInfo{
+		Did:     thirdPartyDid,
+		Address: thirdPartyAddr.String(),
+		Status:  didtypes.DID_STATUS_ACTIVE,
+	})
+
+	service, found := s.Keeper().GetService(s.Ctx)
+	s.Require().True(found)
+	service.Issuers = []string{oldGlobalDid, thirdPartyDid, oldMeidDid}
+	s.Keeper().SetService(s.Ctx, service)
+
+	newGlobalAddr, _ := s.NewAccount()
+	newMeidAddr, _ := s.NewAccount()
+	err := s.Keeper().SetKycIssers(
+		s.Ctx,
+		[]string{s.Dao.GlobalDao, s.Dao.MeidDao},
+		[]string{newGlobalAddr.String(), newMeidAddr.String()},
+	)
+	s.Require().NoError(err)
+
+	updatedService, found := s.Keeper().GetService(s.Ctx)
+	s.Require().True(found)
+	s.Require().Equal([]string{oldGlobalDid, thirdPartyDid, oldMeidDid}, updatedService.Issuers)
+
+	newGlobalDid, found := s.Keeper().GetDID(s.Ctx, newGlobalAddr)
+	s.Require().True(found)
+	s.Require().Equal(oldGlobalDid, newGlobalDid)
+
+	newMeidDid, found := s.Keeper().GetDID(s.Ctx, newMeidAddr)
+	s.Require().True(found)
+	s.Require().Equal(oldMeidDid, newMeidDid)
+
+	preservedThirdPartyDid, found := s.Keeper().GetDID(s.Ctx, thirdPartyAddr)
+	s.Require().True(found)
+	s.Require().Equal(thirdPartyDid, preservedThirdPartyDid)
+}


### PR DESCRIPTION
## Summary
- preserve existing KYC service issuers when DAO addresses are rotated
- snapshot all old DAO DID mappings before mutating any address-to-DID index, so GlobalDao/MeidDao address swaps keep distinct issuer DIDs instead of overwriting one another
- keep moving the DAO DID records and DID info addresses to the replacement addresses
- add regressions for preserving a third-party issuer and for swapping GlobalDao/MeidDao addresses without corrupting issuer mappings

Fixes #265
/claim #371
Fixes #371

## Testing
- `git diff --check`
- `..\..\tools\go\bin\go.exe test .\x\kyc\keeper -run TestKeeperTestSuite/TestSetKycIssers -count=1` *(blocked before package tests run by upstream dependency compile errors in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`)*