### PR TITLE
fix(gravity): avoid double counting pending withdrawals

### DIFF
--- a/x/gravity/keeper/outgoing_tx_pool.go
+++ b/x/gravity/keeper/outgoing_tx_pool.go
@@ -26,12 +26,6 @@ func (k Keeper) AddToOutgoingPool(ctx sdk.Context, sender sdk.AccAddress, receiv
 			totalInVouchers.Amount.String(), bridgeToken.Supply.String(), k.moduleName)
 	}
 
-	totalPending := k.GetOutgoingPendingTxTotal(ctx, k.moduleName, bridgeToken)
-	if totalInVouchers.Amount.Add(totalPending).GT(bridgeToken.Supply) {
-		return 0, errorsmod.Wrapf(types.ErrInvalid, "total pending amount %s plus current amount %s exceeds bridge token supply %s in %s chain",
-			totalPending.String(), totalInVouchers.Amount.String(), bridgeToken.Supply.String(), k.moduleName)
-	}
-
 	sendCoins := sdk.NewCoins(totalInVouchers)
 	// If it is an external blockchain asset we burn it send coins to module in prep for burn
 	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, k.moduleName, sendCoins); err != nil {

--- a/x/gravity/keeper/outgoing_tx_pool_test.go
+++ b/x/gravity/keeper/outgoing_tx_pool_test.go
@@ -39,3 +39,47 @@ func (s *KeeperTestSuite) TestKeeper_OutgoingAncCancel() {
 	s.Equal(s.App.BankKeeper.GetAllBalances(s.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 	s.Equal(sendAmount, s.App.BankKeeper.GetSupply(s.Ctx, denom))
 }
+
+func (s *KeeperTestSuite) TestSendToExternalPendingDoesNotBlockRemainingSupply() {
+	attacker := sdk.AccAddress(helpers.GenerateAddress().Bytes())
+	victim := sdk.AccAddress(helpers.GenerateAddress().Bytes())
+	receiver := helpers.GenerateAddress().Hex()
+	denom := "pendingdoublecount"
+
+	bridgeToken := s.NewBridgeToken(attacker, sdk.NewCoin(denom, sdkmath.NewInt(60)))
+	victimInitialBalance := sdk.NewCoin(denom, sdkmath.NewInt(40))
+	s.Require().NoError(s.App.BankKeeper.MintCoins(s.Ctx, s.chainName, sdk.NewCoins(victimInitialBalance)))
+	s.Require().NoError(s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, s.chainName, victim, sdk.NewCoins(victimInitialBalance)))
+
+	bridgeToken.Supply = bridgeToken.Supply.Add(victimInitialBalance.Amount)
+	s.Keeper().SetBridgeToken(s.Ctx, &bridgeToken)
+
+	_, err := s.MsgServer().SendToExternal(sdk.WrapSDKContext(s.Ctx), &types.MsgSendToExternal{
+		Sender:    attacker.String(),
+		Dest:      receiver,
+		Amount:    sdk.NewCoin(denom, sdkmath.NewInt(50)),
+		BridgeFee: sdk.NewCoin(denom, sdkmath.NewInt(10)),
+		ChainName: s.chainName,
+	})
+	s.Require().NoError(err)
+
+	storedBridgeToken, err := s.Keeper().GetBridgeTokenByDenom(s.Ctx, denom)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewInt(40), storedBridgeToken.Supply)
+	s.Require().Equal(sdkmath.NewInt(40), s.App.BankKeeper.GetBalance(s.Ctx, victim, denom).Amount)
+	s.Require().Equal(sdkmath.NewInt(60), s.Keeper().GetOutgoingPendingTxTotal(s.Ctx, s.chainName, &bridgeToken))
+
+	_, err = s.MsgServer().SendToExternal(sdk.WrapSDKContext(s.Ctx), &types.MsgSendToExternal{
+		Sender:    victim.String(),
+		Dest:      receiver,
+		Amount:    sdk.NewCoin(denom, sdkmath.NewInt(1)),
+		BridgeFee: sdk.NewCoin(denom, sdkmath.ZeroInt()),
+		ChainName: s.chainName,
+	})
+	s.Require().NoError(err)
+
+	storedBridgeToken, err = s.Keeper().GetBridgeTokenByDenom(s.Ctx, denom)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewInt(39), storedBridgeToken.Supply)
+	s.Require().Equal(sdkmath.NewInt(39), s.App.BankKeeper.GetBalance(s.Ctx, victim, denom).Amount)
+}


### PR DESCRIPTION
/claim #18

Fixes #18

## Summary
- remove the pending-withdrawal total from the `AddToOutgoingPool` supply preflight because pending outgoing transfers were already burned and deducted from `BridgeToken.Supply`
- keep the direct current-withdrawal supply guard before the bank burn
- add a regression test where one account has a 60-token pending withdrawal and another holder can still withdraw 1 token from the remaining 40-token supply

## Tests
- `git diff --check` passes with only normal Windows LF-to-CRLF warnings
- Attempted `..\..\tools\go\bin\go.exe test .\x\gravity\keeper -run TestGravityKeeperTestSuite/TestSendToExternalPendingDoesNotBlockRemainingSupply -count=1`, but the run fails before repository tests execute due to the current upstream dependency compile error:
  - `github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey`
  - `github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature`

If this qualifies for the bounty, I can coordinate payout details privately.