### PR TITLE
fix(ante): require fees for join group transactions

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	didtypes "github.com/openmetaearth/me-hub/x/did/types"
-	megrouptypes "github.com/openmetaearth/me-hub/x/megroup/types"
 	wbanktypes "github.com/openmetaearth/me-hub/x/wbank/types"
 )
 
@@ -136,20 +135,6 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	isDao := dfd.daoKeeper.IsDao(ctx, feePayer.String())
 	isFreeGasAccount := dfd.daoKeeper.CheckFreeGasAccount(ctx, feePayer.String())
 	freeGas := isFreeGasAccount || isDao
-
-	// freeGas for MsgJoinGroup only when ALL messages in the tx are MsgJoinGroup.
-	// Mixing MsgJoinGroup with other message types is not allowed to get free gas,
-	// preventing attackers from bundling arbitrary messages with MsgJoinGroup to bypass fees.
-	if !freeGas && len(feeTx.GetMsgs()) > 0 {
-		allJoinGroup := true
-		for _, msg := range feeTx.GetMsgs() {
-			if _, ok := msg.(*megrouptypes.MsgJoinGroup); !ok {
-				allJoinGroup = false
-				break
-			}
-		}
-		freeGas = allJoinGroup
-	}
 
 	if !freeGas && !simulate {
 		_, priority, err = dfd.txFeeChecker(ctx, tx)


### PR DESCRIPTION
/claim #87

Fixes #87

## Summary
- remove the special case that granted free gas when every message in a transaction was `MsgJoinGroup`
- keep the existing DAO and explicit free-gas-account exemptions unchanged
- make ordinary `MsgJoinGroup` transactions go through the normal fee checker and fee deduction path, restoring a marginal cost to repeated group-join reward claims

## Rationale
`JoinGroup` can pay treasury-funded rewards on first join. When ordinary users can submit all-`MsgJoinGroup` transactions with no fees, a KYC/sybil flow can batch treasury-draining reward claims with zero transaction cost. This change keeps privileged operational accounts exempt while removing the public no-fee path.

## Tests
- `git diff --check` passes with only normal Windows LF-to-CRLF warnings
- Attempted `..\..\tools\go\bin\go.exe test .\app\ante -run '^$' -count=1`, but the run fails before package tests execute due to the current upstream dependency compile error:
  - `github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey`
  - `github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature`

If this qualifies for the bounty, I can coordinate payout details privately.