### PR TITLE
fix(wstaking): require combined capacity on unstake

### DIFF
--- a/x/wstaking/keeper/msg_server_stake_test.go
+++ b/x/wstaking/keeper/msg_server_stake_test.go
@@ -217,3 +217,27 @@ func (s *KeeperTestSuite) TestUnStake() {
 		})
 	}
 }
+
+func (s *KeeperTestSuite) TestValidateUnbondAmountProtectsCombinedMeidAndDelegationAmount() {
+	s.SetupTest()
+
+	valAddress, err := sdk.ValAddressFromBech32(s.meEarthValidator.OperatorAddress)
+	s.Require().NoError(err)
+	stakerAddress := sdk.MustAccAddressFromBech32(s.Dao.GlobalDao)
+
+	validator, found := s.Keeper().GetValidator(s.Ctx, valAddress)
+	s.Require().True(found)
+
+	validator.Tokens = sdk.NewInt(6)
+	validator.DelegatorShares = sdk.NewDec(6)
+	validator.DelegationAmount = sdk.NewInt(3)
+	validator.MeidAmount = sdk.NewInt(3)
+	s.Keeper().SetValidator(s.Ctx, validator)
+	s.Keeper().SetStake(s.Ctx, types.NewStake(stakerAddress, valAddress, sdk.NewDec(6)))
+
+	_, err = s.Keeper().ValidateUnbondAmount(s.Ctx, stakerAddress, valAddress, sdk.NewInt(1))
+	s.Require().ErrorIs(err, types.ErrValidatorTokensAmount)
+
+	_, err = s.Keeper().ValidateUnbondAmount(s.Ctx, stakerAddress, valAddress, sdk.ZeroInt())
+	s.Require().NoError(err)
+}

--- a/x/wstaking/keeper/stake.go
+++ b/x/wstaking/keeper/stake.go
@@ -298,19 +298,10 @@ func (k Keeper) ValidateUnbondAmount(
 		return shares, stakingtypes.ErrNoValidatorFound
 	}
 
-	valTokens := math.ZeroInt()
-
-	// ensure validator's tokens can not less than meid amount or delegate amount
-	if validator.MeidAmount.GTE(validator.DelegationAmount) {
-		valTokens = validator.Tokens.Sub(amt)
-		if valTokens.LT(validator.MeidAmount) {
-			return shares, types.ErrValidatorTokensAmount
-		}
-	} else {
-		valTokens = validator.Tokens.Sub(amt)
-		if valTokens.LT(validator.DelegationAmount) {
-			return shares, types.ErrValidatorTokensAmount
-		}
+	valTokens := validator.Tokens.Sub(amt)
+	requiredTokens := validator.MeidAmount.Add(validator.DelegationAmount)
+	if valTokens.LT(requiredTokens) {
+		return shares, types.ErrValidatorTokensAmount
 	}
 
 	sta, found := k.GetStake(ctx, stakerAddr, valAddr)


### PR DESCRIPTION
/claim #961

Fixes #961.

## Summary
- replace the previous max-style unstake guard with a combined-capacity guard: remaining validator tokens must cover `MeidAmount + DelegationAmount`
- prevent GlobalDao unstake from taking a validator below the real occupied region capacity
- add a regression test for `Tokens=6`, `DelegationAmount=3`, `MeidAmount=3`, where unbonding `1` must fail but unbonding `0` still passes the capacity check

## Tests
- `gofmt -w x/wstaking/keeper/stake.go x/wstaking/keeper/msg_server_stake_test.go`
- `git diff --check`
- `git diff --cached --check`
- attempted: `go test ./x/wstaking/keeper -run TestKeeperTestSuite/TestValidateUnbondAmountProtectsCombinedMeidAndDelegationAmount -count=1`

The targeted Go test is currently blocked before package tests run by an upstream dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature` are undefined. This is the same repository-level compile blocker seen on other `x/wstaking/keeper` test runs in this Windows environment.