### PR TITLE
fix(rollapp): validate updates before persisting

### DIFF
--- a/x/rollapp/keeper/msg_server_update_rollapp.go
+++ b/x/rollapp/keeper/msg_server_update_rollapp.go
@@ -10,6 +10,10 @@ import (
 func (k msgServer) UpdateRollapp(goCtx context.Context, msg *types.MsgUpdateRollapp) (*types.MsgUpdateRollappResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	if !k.RollappsEnabled(ctx) {
+		return nil, types.ErrRollappsDisabled
+	}
+
 	// check to see if there is an active whitelist
 	if whitelist := k.DeployerWhitelist(ctx); len(whitelist) > 0 {
 		if !k.IsAddressInDeployerWhiteList(ctx, msg.Creator) {
@@ -22,16 +26,21 @@ func (k msgServer) UpdateRollapp(goCtx context.Context, msg *types.MsgUpdateRoll
 		return nil, types.ErrUnknownRollappID
 	}
 
+	updatedRollapp := rollapp
 	if msg.MaxSequencers != 0 {
-		rollapp.MaxSequencers = msg.MaxSequencers
+		updatedRollapp.MaxSequencers = msg.MaxSequencers
 	}
 	if msg.ChannelId != "" {
-		rollapp.ChannelId = msg.ChannelId
+		updatedRollapp.ChannelId = msg.ChannelId
 	}
 	if len(msg.PermissionedAddresses) != 0 {
-		rollapp.PermissionedAddresses = msg.PermissionedAddresses
+		updatedRollapp.PermissionedAddresses = msg.PermissionedAddresses
 	}
 
-	k.SetRollapp(ctx, rollapp)
+	if err := updatedRollapp.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
+	k.SetRollapp(ctx, updatedRollapp)
 	return &types.MsgUpdateRollappResponse{}, nil
 }

--- a/x/rollapp/keeper/msg_server_update_rollapp_test.go
+++ b/x/rollapp/keeper/msg_server_update_rollapp_test.go
@@ -1,0 +1,58 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+)
+
+func (suite *RollappTestSuite) TestUpdateRollappRejectsWhenRollappsDisabled() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	msg := types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             "rollapp_1234-1",
+		MaxSequencers:         2,
+		PermissionedAddresses: []string{alice},
+	}
+	_, err := suite.msgServer.CreateRollapp(goCtx, &msg)
+	suite.Require().NoError(err)
+
+	params := suite.App.RollappKeeper.GetParams(suite.Ctx)
+	params.RollappsEnabled = false
+	suite.App.RollappKeeper.SetParams(suite.Ctx, params)
+
+	_, err = suite.msgServer.UpdateRollapp(goCtx, &types.MsgUpdateRollapp{
+		Creator:       alice,
+		RollappId:     msg.RollappId,
+		MaxSequencers: 3,
+	})
+	suite.Require().ErrorIs(err, types.ErrRollappsDisabled)
+}
+
+func (suite *RollappTestSuite) TestUpdateRollappValidatesMutatedStateBeforePersisting() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	msg := types.MsgCreateRollapp{
+		Creator:               alice,
+		RollappId:             "rollapp_1234-1",
+		MaxSequencers:         2,
+		PermissionedAddresses: []string{alice},
+	}
+	_, err := suite.msgServer.CreateRollapp(goCtx, &msg)
+	suite.Require().NoError(err)
+
+	_, err = suite.msgServer.UpdateRollapp(goCtx, &types.MsgUpdateRollapp{
+		Creator:               alice,
+		RollappId:             msg.RollappId,
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{alice, bob},
+	})
+	suite.Require().ErrorIs(err, types.ErrTooManyPermissionedAddresses)
+
+	rollapp, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, msg.RollappId)
+	suite.Require().True(found)
+	suite.Require().Equal(uint64(2), rollapp.MaxSequencers)
+	suite.Require().Equal([]string{alice}, rollapp.PermissionedAddresses)
+}


### PR DESCRIPTION
/claim #921

Fixes #921.

## Summary
- reject `MsgUpdateRollapp` while rollapps are globally disabled, matching the create/state-update policy
- apply requested update fields to a temporary rollapp value and run `ValidateBasic()` before persisting
- prevent invalid post-update state such as too many permissioned addresses for `MaxSequencers` from being stored
- add regression coverage for disabled updates and failed validation not mutating the stored rollapp

## Overlap note
PR #850 addresses missing creator ownership on `UpdateRollapp`. This PR is separate and focused on the state-invariant / `RollappsEnabled` bypass described in #921.

## Tests
- `gofmt -w x/rollapp/keeper/msg_server_update_rollapp.go x/rollapp/keeper/msg_server_update_rollapp_test.go`
- `git diff --check`
- `git diff --cached --check`
- attempted: `go test ./x/rollapp/keeper -run TestRollappKeeperTestSuite/TestUpdateRollapp -count=1`

The targeted Go test is currently blocked before package tests run by an upstream dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature` are undefined. This is the same repository-level compile blocker seen on other keeper test runs in this Windows environment.