### PR TITLE
fix(wgov): avoid tally division by zero

### DIFF
--- a/x/wgov/keeper/tally.go
+++ b/x/wgov/keeper/tally.go
@@ -100,8 +100,12 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 
 	// If there is not enough quorum of votes, the proposal fails
 	//percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(keeper.stakingKeeper.TotalBondedStakePool(ctx)))
-	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(sdk.NewInt(int64(totalValidatorNumber))))
 	quorum, _ := sdk.NewDecFromStr(params.Quorum)
+	if totalValidatorNumber == 0 {
+		return false, params.BurnVoteQuorum, tallyResults
+	}
+
+	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(sdk.NewInt(int64(totalValidatorNumber))))
 	if percentVoting.LT(quorum) {
 		return false, params.BurnVoteQuorum, tallyResults
 	}


### PR DESCRIPTION
/claim #936

Fixes #936.

## Summary
- guard `Tally` before dividing by the bonded validator count
- when there are no bonded validators, fail quorum cleanly instead of computing `totalVotingPower / 0`
- preserve the existing `BurnVoteQuorum` behavior for quorum failure

## Tests
- `gofmt -w x/wgov/keeper/tally.go`
- `go test ./x/wgov/keeper -run '^$' -count=1`
- `go test ./x/wgov -run '^$' -count=1`
- `git diff --check`
- `git diff --cached --check`