### PR TITLE
fix(sequencer): reject nil replace proposer queries

### DIFF
--- a/x/sequencer/keeper/grpc_query_sequencers_by_rollapp.go
+++ b/x/sequencer/keeper/grpc_query_sequencers_by_rollapp.go
@@ -89,6 +89,9 @@ func (k Keeper) UnConfirmSequencerAddressByRollappByStatus(goCtx context.Context
 	return nil, fmt.Errorf("unsupport function")
 }
 func (k Keeper) ReplaceProposerInfo(goCtx context.Context, req *types.QueryReplaceProposerInfoRequest) (*types.QueryReplaceProposerInfoResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	_, found := k.rollappKeeper.GetRollapp(ctx, req.RollappId)
 	if !found {

--- a/x/sequencer/keeper/grpc_query_sequencers_by_rollapp_test.go
+++ b/x/sequencer/keeper/grpc_query_sequencers_by_rollapp_test.go
@@ -173,3 +173,11 @@ func (suite *SequencerTestSuite) TestSequencersByRollappByStatusQuery() {
 		})
 	}
 }
+
+func (suite *SequencerTestSuite) TestReplaceProposerInfoInvalidRequest() {
+	suite.SetupTest()
+
+	response, err := suite.App.SequencerKeeper.ReplaceProposerInfo(suite.Ctx, nil)
+	require.Nil(suite.T(), response)
+	require.ErrorIs(suite.T(), err, status.Error(codes.InvalidArgument, "invalid request"))
+}


### PR DESCRIPTION
/claim #928

## Summary
- reject nil `ReplaceProposerInfo` query requests before reading `req.RollappId`
- return the same `InvalidArgument` error used by neighboring sequencer query handlers
- add regression coverage for the nil request path

## Validation
- `git diff --check`
- `git diff --cached --check`
- Attempted: `..\..\tools\go\bin\go.exe test .\x\sequencer\keeper -run TestSequencerKeeperTestSuite/TestReplaceProposerInfoInvalidRequest -count=1`
  - Blocked before package tests ran by existing upstream dependency compile errors in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.