### PR TITLE
fix(delayedack): paginate packet queries

### DIFF
--- a/x/delayedack/keeper/grpc_query.go
+++ b/x/delayedack/keeper/grpc_query.go
@@ -3,8 +3,11 @@ package keeper
 import (
 	"context"
 
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
 
+	commontypes "github.com/openmetaearth/me-hub/x/common/types"
 	"github.com/openmetaearth/me-hub/x/delayedack/types"
 
 	"google.golang.org/grpc/codes"
@@ -39,16 +42,32 @@ func (q Querier) GetPackets(goCtx context.Context, req *types.QueryRollappPacket
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	res := &types.QueryRollappPacketListResponse{}
+	var filter types.RollappPacketListFilter
 
 	if req.RollappId == "" {
 		// query by status (PENDING by default) and type (if not UNDEFINED)
-		res.RollappPackets = q.ListRollappPackets(ctx, types.ByTypeByStatus(req.Type, req.Status))
+		filter = types.ByTypeByStatus(req.Type, req.Status)
 	} else {
 		// query by rollapp id and status (PENDING by default) and type (if not UNDEFINED)
-		res.RollappPackets = q.ListRollappPackets(ctx, types.ByRollappIDByTypeByStatus(req.RollappId, req.Type, req.Status))
+		filter = types.ByRollappIDByTypeByStatus(req.RollappId, req.Type, req.Status)
 	}
 
-	// TODO: handle pagination
+	packetStore := prefix.NewStore(ctx.KVStore(q.storeKey), filter.Prefixes[0].Start)
+	pageRes, err := query.FilteredPaginate(packetStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
+		var packet commontypes.RollappPacket
+		q.cdc.MustUnmarshal(value, &packet)
+		if !filter.FilterFunc(packet) {
+			return false, nil
+		}
+		if accumulate {
+			res.RollappPackets = append(res.RollappPackets, packet)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	res.Pagination = pageRes
 
 	return res, nil
 }

--- a/x/delayedack/keeper/rollapp_packet_test.go
+++ b/x/delayedack/keeper/rollapp_packet_test.go
@@ -2,8 +2,10 @@ package keeper_test
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkquery "github.com/cosmos/cosmos-sdk/types/query"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	commontypes "github.com/openmetaearth/me-hub/x/common/types"
+	delayedackkeeper "github.com/openmetaearth/me-hub/x/delayedack/keeper"
 	"github.com/openmetaearth/me-hub/x/delayedack/types"
 )
 
@@ -166,6 +168,51 @@ func (s *DelayedAckTestSuite) TestListRollappPackets() {
 	s.Equal(expectOnTimeoutLength, len(onTimeoutPackets))
 
 	s.Require().Equal(totalLength, len(onRecvPackets)+len(onAckPackets)+len(onTimeoutPackets))
+}
+
+func (s *DelayedAckTestSuite) TestGetPacketsAppliesPagination() {
+	keeper, ctx := s.App.DelayedAckKeeper, s.Ctx
+	rollappID := "paginationRollapp"
+
+	for i := 1; i <= 3; i++ {
+		keeper.SetRollappPacket(ctx, commontypes.RollappPacket{
+			RollappId: rollappID,
+			Packet: &channeltypes.Packet{
+				SourcePort:         "testSourcePort",
+				SourceChannel:      "testSourceChannel",
+				DestinationPort:    "testDestinationPort",
+				DestinationChannel: "testDestinationChannel",
+				Data:               []byte("testData"),
+				Sequence:           uint64(i),
+			},
+			Status:      commontypes.Status_PENDING,
+			Type:        commontypes.RollappPacket_ON_RECV,
+			ProofHeight: uint64(i),
+		})
+	}
+
+	querier := delayedackkeeper.NewQuerier(keeper)
+	response, err := querier.GetPackets(sdk.WrapSDKContext(ctx), &types.QueryRollappPacketsRequest{
+		RollappId: rollappID,
+		Status:    commontypes.Status_PENDING,
+		Pagination: &sdkquery.PageRequest{
+			Limit: 1,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(response.RollappPackets, 1)
+	s.Require().NotEmpty(response.Pagination.NextKey)
+
+	nextResponse, err := querier.GetPackets(sdk.WrapSDKContext(ctx), &types.QueryRollappPacketsRequest{
+		RollappId: rollappID,
+		Status:    commontypes.Status_PENDING,
+		Pagination: &sdkquery.PageRequest{
+			Key:   response.Pagination.NextKey,
+			Limit: 1,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(nextResponse.RollappPackets, 1)
 }
 
 func (suite *DelayedAckTestSuite) TestUpdateRollappPacketWithStatus() {


### PR DESCRIPTION
/claim #924

## Summary
- apply `req.Pagination` in the DelayedAck `GetPackets` query using the SDK filtered pagination helper
- keep the existing rollapp/status/type filtering semantics while returning a `PageResponse`
- add regression coverage for a `limit=1` packet query returning one packet plus a next key

## Validation
- `git diff --check`
- `git diff --cached --check`
- Attempted: `..\..\tools\go\bin\go.exe test .\x\delayedack\keeper -run TestKeeperTestSuite/TestGetPacketsAppliesPagination -count=1`
  - Blocked before package tests ran by existing upstream dependency compile errors in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.