### PR TITLE
fix(wnft): reject nil nft filter queries

### DIFF
--- a/x/wnft/keeper/grpc_query.go
+++ b/x/wnft/keeper/grpc_query.go
@@ -46,6 +46,10 @@ func (k Keeper) ClassAddress(goCtx context.Context, r *types.QueryClassAddressRe
 }
 
 func (k Keeper) NftFilter(goCtx context.Context, r *types.QueryNftFilterRequest) (*types.QueryNftFilterResponse, error) {
+	if r == nil {
+		return nil, sdkerrors.ErrInvalidRequest.Wrap("empty request")
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	var list []*types.NftList


### PR DESCRIPTION
/claim #927

## Summary
- add the missing nil request guard to `NftFilter`
- return the same invalid-request error style already used by `ClassAddress`
- leave the existing WNFT query branches unchanged for valid requests

## Validation
- `..\..\tools\go\bin\go.exe test .\x\wnft\keeper -run '^$' -count=1`
- `git diff --check`
- `git diff --cached --check`