### PR TITLE
fix(wstaking): reject nil non-region query requests

### DIFF
--- a/x/wstaking/keeper/grpc_query.go
+++ b/x/wstaking/keeper/grpc_query.go
@@ -160,6 +160,10 @@ func (k Keeper) Stakes(goCtx context.Context, req *types.QueryStakesRequest) (*t
 }
 
 func (k Keeper) QueryAllRecord(goCtx context.Context, req *types.QueryAllRecords) (*types.QueryAllRecordsResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
 	var records []types.Record
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -184,6 +188,10 @@ func (k Keeper) QueryAllRecord(goCtx context.Context, req *types.QueryAllRecords
 }
 
 func (k Querier) QueryRecordByAddress(goCtx context.Context, req *types.QueryRecordsByAddress) (*types.QueryRecordsByAddressResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	from, err := sdk.AccAddressFromBech32(req.Account)
 	if err != nil {
@@ -194,6 +202,10 @@ func (k Querier) QueryRecordByAddress(goCtx context.Context, req *types.QueryRec
 }
 
 func (k Querier) QueryReviewRecordByID(goCtx context.Context, req *types.QueryReviewRecordByNumber) (*types.QueryReviewRecordByNumberResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	if req.ActionNumber == "" {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ActionNumber is empty"))
@@ -204,6 +216,10 @@ func (k Querier) QueryReviewRecordByID(goCtx context.Context, req *types.QueryRe
 
 // Delegation queries delegate info for given validator delegator pair
 func (k Querier) AllDelegations(c context.Context, req *types.QueryAllDelegationsRequest) (*types.QueryAllDelegationsResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
 	ctx := sdk.UnwrapSDKContext(c)
 
 	store := ctx.KVStore(k.storeKey)

--- a/x/wstaking/keeper/grpc_query_nil_test.go
+++ b/x/wstaking/keeper/grpc_query_nil_test.go
@@ -1,0 +1,27 @@
+package keeper_test
+
+import (
+	"github.com/openmetaearth/me-hub/x/wstaking/keeper"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *KeeperTestSuite) TestNonRegionQueriesRejectNilRequests() {
+	s.SetupTest()
+
+	expectedErr := status.Error(codes.InvalidArgument, "invalid request")
+	querier := keeper.Querier{Keeper: s.Keeper()}
+
+	_, err := s.Keeper().QueryAllRecord(s.Ctx, nil)
+	s.Require().ErrorIs(err, expectedErr)
+
+	_, err = querier.QueryRecordByAddress(s.Ctx, (*types.QueryRecordsByAddress)(nil))
+	s.Require().ErrorIs(err, expectedErr)
+
+	_, err = querier.QueryReviewRecordByID(s.Ctx, (*types.QueryReviewRecordByNumber)(nil))
+	s.Require().ErrorIs(err, expectedErr)
+
+	_, err = querier.AllDelegations(s.Ctx, (*types.QueryAllDelegationsRequest)(nil))
+	s.Require().ErrorIs(err, expectedErr)
+}


### PR DESCRIPTION
/claim #926

## Summary
- add nil request guards to the affected non-Region WStaking query handlers
- cover `QueryAllRecord`, `QueryRecordByAddress`, `QueryReviewRecordByID`, and `AllDelegations`
- add regression coverage proving each nil request returns `InvalidArgument` instead of panicking

## Validation
- `git diff --check`
- `git diff --cached --check`
- Attempted: `..\..\tools\go\bin\go.exe test .\x\wstaking\keeper -run TestKeeperTestSuite/TestNonRegionQueriesRejectNilRequests -count=1`
  - Blocked before package tests ran by existing upstream dependency compile errors in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.