### PR TITLE
fix(wstaking): reject unsupported transfer region tx

### DIFF
--- a/x/wstaking/keeper/msg_server_region.go
+++ b/x/wstaking/keeper/msg_server_region.go
@@ -189,7 +189,16 @@ func (k MsgServer) WithdrawFromRegion(goCtx context.Context, msg *types.MsgWithd
 }
 
 func (k MsgServer) TransferRegion(goCtx context.Context, msg *types.MsgTransferRegion) (*types.MsgTransferRegionResponse, error) {
-	return &types.MsgTransferRegionResponse{}, nil
+	if msg == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "nil transfer region message")
+	}
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+	return nil, sdkerrors.Wrap(
+		sdkerrors.ErrInvalidRequest,
+		"MsgTransferRegion is not supported; update the holder KYC region through the kyc Update flow",
+	)
 }
 
 // GrantRegionWithdraw grants (or overwrites) a address for who can withdraw from the region treasury.

--- a/x/wstaking/keeper/msg_server_region_test.go
+++ b/x/wstaking/keeper/msg_server_region_test.go
@@ -168,6 +168,18 @@ func (s *KeeperTestSuite) TestRemoveRegionThenCreateRegion() {
 	s.Require().NoError(err)
 }
 
+func (s *KeeperTestSuite) TestTransferRegionReturnsExplicitUnsupportedError() {
+	s.SetupTest()
+
+	_, err := s.msgServer.TransferRegion(s.Ctx, &types.MsgTransferRegion{
+		Creator:    s.Dao.GlobalDao,
+		FromRegion: strings.ToLower(types.MeEarthRegionName),
+		ToRegion:   "usa",
+		Address:    []string{s.Dao.DevOperator},
+	})
+	s.Require().ErrorIs(err, sdkerrors.ErrInvalidRequest)
+}
+
 func (s *KeeperTestSuite) TestWithdrawFromRegion() {
 	s.SetupTest()
 

--- a/x/wstaking/types/message_transfer_region_test.go
+++ b/x/wstaking/types/message_transfer_region_test.go
@@ -1,0 +1,78 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgTransferRegion_ValidateBasic(t *testing.T) {
+	validAddress := sample.AccAddress()
+
+	tests := []struct {
+		name string
+		msg  MsgTransferRegion
+		err  error
+	}{
+		{
+			name: "valid message",
+			msg: MsgTransferRegion{
+				Creator:    sample.AccAddress(),
+				FromRegion: "me_earth",
+				ToRegion:   "usa",
+				Address:    []string{validAddress},
+			},
+		},
+		{
+			name: "invalid creator",
+			msg: MsgTransferRegion{
+				Creator:    "invalid_address",
+				FromRegion: "me_earth",
+				ToRegion:   "usa",
+				Address:    []string{validAddress},
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "same regions",
+			msg: MsgTransferRegion{
+				Creator:    sample.AccAddress(),
+				FromRegion: "usa",
+				ToRegion:   "USA",
+				Address:    []string{validAddress},
+			},
+			err: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "missing address",
+			msg: MsgTransferRegion{
+				Creator:    sample.AccAddress(),
+				FromRegion: "me_earth",
+				ToRegion:   "usa",
+			},
+			err: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid transfer address",
+			msg: MsgTransferRegion{
+				Creator:    sample.AccAddress(),
+				FromRegion: "me_earth",
+				ToRegion:   "usa",
+				Address:    []string{"invalid_address"},
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/x/wstaking/types/msgs.go
+++ b/x/wstaking/types/msgs.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	gomath "math"
+	"strings"
 
 	"cosmossdk.io/math"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -27,6 +28,7 @@ const (
 	TypeMsgResetValidator                  = "create_validator"
 	TypeMsgNewMeid                         = "new_meid"
 	TypeMsgRemoveMeid                      = "remove_meid"
+	TypeMsgTransferRegion                  = "msg_transfer_meid"
 )
 
 var (
@@ -37,6 +39,7 @@ var (
 	_ sdk.Msg = &MsgWithdrawDelegatorReward{}
 	_ sdk.Msg = &MsgWithdrawFromRegion{}
 	_ sdk.Msg = &MsgWithdrawFromGlobalDaoFeePool{}
+	_ sdk.Msg = &MsgTransferRegion{}
 )
 
 // NewMsgStake creates a new MsgStake instance.
@@ -469,7 +472,7 @@ func (msg *MsgTransferRegion) Route() string {
 }
 
 func (msg *MsgTransferRegion) Type() string {
-	return "msg_transfer_meid"
+	return TypeMsgTransferRegion
 }
 
 func (msg *MsgTransferRegion) GetSigners() []sdk.AccAddress {
@@ -489,6 +492,23 @@ func (msg *MsgTransferRegion) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+	if strings.TrimSpace(msg.FromRegion) == "" {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "from region cannot be empty")
+	}
+	if strings.TrimSpace(msg.ToRegion) == "" {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "to region cannot be empty")
+	}
+	if strings.EqualFold(strings.TrimSpace(msg.FromRegion), strings.TrimSpace(msg.ToRegion)) {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "from region and to region must be different")
+	}
+	if len(msg.Address) == 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "transfer address cannot be empty")
+	}
+	for _, address := range msg.Address {
+		if _, err := sdk.AccAddressFromBech32(strings.TrimSpace(address)); err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid transfer address (%s)", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
/claim #225

Fixes #225.

## Summary
- Stop `MsgTransferRegion` from returning an empty success response while doing no state transition.
- Validate `MsgTransferRegion` inputs before the handler returns, including creator, regions, and transfer addresses.
- Return an explicit unsupported-flow error directing callers to the existing KYC `Update` path, which is the flow that can keep KYC records, filters, and wstaking reward/delegation state in sync.
- Add regression coverage for the message validation and the no-empty-success handler behavior.

## Why fail closed instead of wiring `TransferKycRegion` directly
`TransferKycRegion` only moves wstaking reward/delegation accounting. In the existing KYC update flow, the KYC module updates the holder DID/KYC record and region filters first, then calls the wstaking migration helper. Calling that helper directly from this public wstaking tx would produce a half-migrated state where staking moved but KYC still reports the old region.

## Tests
- `..\..\tools\go\bin\gofmt.exe -w x\wstaking\types\message_transfer_region_test.go x\wstaking\keeper\msg_server_region.go x\wstaking\keeper\msg_server_region_test.go x\wstaking\types\msgs.go`
- `..\..\tools\go\bin\go.exe test .\x\wstaking\types -run TestMsgTransferRegion_ValidateBasic -count=1`
- `git diff --check`

## Known baseline blocker
- Attempted `..\..\tools\go\bin\go.exe test .\x\wstaking\keeper -run TestKeeperTestSuite/TestTransferRegionReturnsExplicitUnsupportedError -count=1`
- Blocked before package tests ran by upstream dependency compile errors in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.