### PR TITLE
fix(tron): avoid panics for invalid external addresses

### DIFF
--- a/x/tron/types/address.go
+++ b/x/tron/types/address.go
@@ -22,17 +22,25 @@ func (b TronAddress) ValidateExternalAddr(addr string) error {
 func (b TronAddress) ExternalAddrToAccAddr(addr string) sdk.AccAddress {
 	tronAddr, err := tronaddress.Base58ToAddress(addr)
 	if err != nil {
-		panic(err)
+		return nil
 	}
-	return tronAddr.Bytes()[1:]
+	addrBytes := tronAddr.Bytes()
+	if len(addrBytes) <= 1 {
+		return nil
+	}
+	return addrBytes[1:]
 }
 
 func (b TronAddress) ExternalAddrToHexAddr(addr string) gethcommon.Address {
 	tronAddr, err := tronaddress.Base58ToAddress(addr)
 	if err != nil {
-		panic(err)
+		return gethcommon.Address{}
 	}
-	return gethcommon.BytesToAddress(tronAddr.Bytes()[1:])
+	addrBytes := tronAddr.Bytes()
+	if len(addrBytes) <= 1 {
+		return gethcommon.Address{}
+	}
+	return gethcommon.BytesToAddress(addrBytes[1:])
 }
 
 func (b TronAddress) ExternalAddrToStr(bz []byte) string {

--- a/x/tron/types/address_test.go
+++ b/x/tron/types/address_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/openmetaearth/me-hub/x/tron/types"
 	"github.com/stretchr/testify/require"
 )
@@ -59,6 +60,21 @@ func TestValidateTronAddress(t *testing.T) {
 				return
 			}
 			require.EqualValues(t, testCase.errStr, err.Error(), testCase.value)
+		})
+	}
+}
+
+func TestTronAddressExternalConversionsDoNotPanicOnInvalidInput(t *testing.T) {
+	converter := types.TronAddress{}
+
+	for _, value := range []string{"", "invalid_address"} {
+		t.Run(value, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				require.Nil(t, converter.ExternalAddrToAccAddr(value))
+			})
+			require.NotPanics(t, func() {
+				require.Equal(t, gethcommon.Address{}, converter.ExternalAddrToHexAddr(value))
+			})
 		})
 	}
 }


### PR DESCRIPTION
/claim #262

Fixes #262.

## Summary
- Stop TRON external-address conversion helpers from panicking on invalid Base58 input.
- Return zero values (`nil` account address / zero EVM address) when conversion cannot decode a valid TRON address, matching the existing no-error interface without widening the API.
- Preserve existing `ValidateExternalAddr` behavior for callers that need an explicit validation error.
- Add regression coverage for empty and malformed TRON address input.

## Tests
- `..\..\tools\go\bin\gofmt.exe -w x\tron\types\address.go x\tron\types\address_test.go`
- `..\..\tools\go\bin\go.exe test .\x\tron\types -run TestTronAddressExternalConversionsDoNotPanicOnInvalidInput -count=1`
- `..\..\tools\go\bin\go.exe test .\x\tron\types -count=1`
- `git diff --check`