### PR TITLE
fix(did): length-delimit credential filter keys

### DIFF
--- a/x/did/keeper/credential.go
+++ b/x/did/keeper/credential.go
@@ -55,18 +55,26 @@ func (k Keeper) GetCredentialsByDid(ctx sdk.Context, did string) (vcs []types.Cr
 	return vcs
 }
 
-func (k Keeper) GetCredentialsByFilter(
+func (k Keeper) credentialMatchesFilter(ctx sdk.Context, sid string, filter []byte, vc types.Credential) bool {
+	if vc.Sid != sid {
+		return false
+	}
+
+	flog, found := k.GetFilterLogger(ctx, vc.Did, sid)
+	return found && flog.Contains(filter)
+}
+
+func (k Keeper) getCredentialsByExactFilterPrefix(
 	ctx sdk.Context,
-	sid string,
-	filter []byte,
+	keyPrefix []byte,
 	pageReq *query.PageRequest,
 ) (vcs []types.Credential, pageRes *query.PageResponse, err error) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.GetFilterPrefixBySidAndFilter(sid, filter))
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), keyPrefix)
 
 	pageRes, err = query.Paginate(store, pageReq, func(key []byte, value []byte) error {
 		var vc types.Credential
 		if err := k.cdc.Unmarshal(value, &vc); err != nil {
-			return err // todo: warp error
+			return err
 		}
 		vcs = append(vcs, vc)
 		return nil
@@ -75,7 +83,55 @@ func (k Keeper) GetCredentialsByFilter(
 		return []types.Credential{}, &query.PageResponse{}, err
 	}
 
-	return vcs, pageRes, err
+	return vcs, pageRes, nil
+}
+
+func (k Keeper) getLegacyCredentialsByFilter(
+	ctx sdk.Context,
+	sid string,
+	filter []byte,
+	pageReq *query.PageRequest,
+) (vcs []types.Credential, pageRes *query.PageResponse, err error) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.GetLegacyFilterPrefixBySidAndFilter(sid, filter))
+
+	pageRes, err = query.FilteredPaginate(store, pageReq, func(key []byte, value []byte, accumulate bool) (bool, error) {
+		var vc types.Credential
+		if err := k.cdc.Unmarshal(value, &vc); err != nil {
+			return false, err
+		}
+
+		if !k.credentialMatchesFilter(ctx, sid, filter, vc) {
+			return false, nil
+		}
+
+		if accumulate {
+			vcs = append(vcs, vc)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return []types.Credential{}, &query.PageResponse{}, err
+	}
+
+	return vcs, pageRes, nil
+}
+
+func (k Keeper) GetCredentialsByFilter(
+	ctx sdk.Context,
+	sid string,
+	filter []byte,
+	pageReq *query.PageRequest,
+) (vcs []types.Credential, pageRes *query.PageResponse, err error) {
+	vcs, pageRes, err = k.getCredentialsByExactFilterPrefix(ctx, types.GetFilterPrefixBySidAndFilter(sid, filter), pageReq)
+	if err != nil {
+		return []types.Credential{}, &query.PageResponse{}, err
+	}
+	if len(vcs) > 0 {
+		return vcs, pageRes, nil
+	}
+
+	return k.getLegacyCredentialsByFilter(ctx, sid, filter, pageReq)
 }
 
 func (k Keeper) SetCredential(ctx sdk.Context, did, sid string, credential types.Credential) {
@@ -89,15 +145,45 @@ func (k Keeper) DeleteCredential(ctx sdk.Context, did, sid string) {
 }
 
 func (k Keeper) IteratorCredentialsByFilter(ctx sdk.Context, sid string, filter []byte, cb func(delegation types.Credential) (stop bool)) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.GetFilterPrefixBySidAndFilter(sid, filter))
+	seen := map[string]struct{}{}
+	stop := k.iterateCredentialsByFilterPrefix(ctx, types.GetFilterPrefixBySidAndFilter(sid, filter), nil, seen, cb)
+	if stop {
+		return
+	}
+
+	k.iterateCredentialsByFilterPrefix(ctx, types.GetLegacyFilterPrefixBySidAndFilter(sid, filter), func(vc types.Credential) bool {
+		return k.credentialMatchesFilter(ctx, sid, filter, vc)
+	}, seen, cb)
+}
+
+func (k Keeper) iterateCredentialsByFilterPrefix(
+	ctx sdk.Context,
+	keyPrefix []byte,
+	match func(types.Credential) bool,
+	seen map[string]struct{},
+	cb func(delegation types.Credential) (stop bool),
+) bool {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), keyPrefix)
 	iterator := sdk.KVStorePrefixIterator(store, nil)
-	defer iterator.Close()
+	defer iterator.Close() // nolint: errcheck
 
 	for ; iterator.Valid(); iterator.Next() {
 		var vc types.Credential
 		k.cdc.MustUnmarshal(iterator.Value(), &vc)
+		if match != nil && !match(vc) {
+			continue
+		}
+
+		credentialID := vc.Did + "\x00" + vc.Sid
+		if _, ok := seen[credentialID]; ok {
+			continue
+		}
+		seen[credentialID] = struct{}{}
+
 		if cb(vc) {
-			break
+			return true
 		}
 	}
+
+	return false
 }

--- a/x/did/keeper/filter.go
+++ b/x/did/keeper/filter.go
@@ -50,6 +50,7 @@ func (k Keeper) DeleteFilters(ctx sdk.Context, did, sid string, filters [][]byte
 
 	for _, filter := range filters {
 		store.Delete(types.GetFilterKey(sid, did, filter))
+		store.Delete(types.GetLegacyFilterKey(sid, did, filter))
 		// delete the filter form FilterLogger
 		flog.Delete(filter)
 	}

--- a/x/did/keeper/filter_test.go
+++ b/x/did/keeper/filter_test.go
@@ -47,3 +47,27 @@ func TestKeeper_Filter(t *testing.T) {
 	vcs, _, _ = k.GetCredentialsByFilter(ctx, sid, f2, &pr)
 	assert.Equal(t, 0, len(vcs))
 }
+
+func TestKeeper_FilterPrefixCollisionDoesNotReturnWrongCredential(t *testing.T) {
+	k, ctx := keeper.DidKeeper(t)
+
+	collidingVC := didtypes.Credential{
+		Did:  "did-b",
+		Sid:  "abc",
+		Hash: "FF000000000000000001",
+		Uri:  "https://www.example.com/b",
+		Data: []byte("credential b"),
+	}
+
+	k.AddFilters(ctx, collidingVC.Did, collidingVC.Sid, [][]byte{[]byte("X")}, collidingVC)
+
+	pr := query.PageRequest{}
+	vcs, _, err := k.GetCredentialsByFilter(ctx, "ab", []byte("cX"), &pr)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(vcs))
+
+	vcs, _, err = k.GetCredentialsByFilter(ctx, "abc", []byte("X"), &pr)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(vcs))
+	assert.Equal(t, collidingVC, vcs[0])
+}

--- a/x/did/keeper/grpc_query.go
+++ b/x/did/keeper/grpc_query.go
@@ -156,20 +156,7 @@ func (k Keeper) Credentials(goCtx context.Context, req *types.QueryCredentials) 
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	var vcs []types.Credential
-
-	store := ctx.KVStore(k.storeKey)
-	filterStore := prefix.NewStore(store, types.GetFilterPrefixBySidAndFilter(req.Sid, req.Filter))
-
-	pageRes, err := query.Paginate(filterStore, req.Pagination, func(key []byte, value []byte) error {
-		var vc types.Credential
-		if err := k.cdc.Unmarshal(value, &vc); err != nil {
-			return err
-		}
-
-		vcs = append(vcs, vc)
-		return nil
-	})
+	vcs, pageRes, err := k.GetCredentialsByFilter(ctx, req.Sid, req.Filter, req.Pagination)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/x/did/types/keys.go
+++ b/x/did/types/keys.go
@@ -1,6 +1,10 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"encoding/binary"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 const (
 	// ModuleName defines the module name
@@ -64,8 +68,25 @@ func GetFilterLoggerKey(did, sid string) []byte {
 	return append(append(FilterLoggerPrefix, did...), sid...)
 }
 
+func appendLengthPrefixed(dst, value []byte) []byte {
+	var lenBz [8]byte
+	binary.BigEndian.PutUint64(lenBz[:], uint64(len(value)))
+	dst = append(dst, lenBz[:]...)
+	return append(dst, value...)
+}
+
+func GetLegacyFilterPrefixBySidAndFilter(sid string, filter []byte) []byte {
+	return append(append(append([]byte{}, FilterPrefix...), sid...), filter...)
+}
+
+func GetLegacyFilterKey(sid, did string, filter []byte) []byte {
+	return append(GetLegacyFilterPrefixBySidAndFilter(sid, filter), did...)
+}
+
 func GetFilterPrefixBySidAndFilter(sid string, filter []byte) []byte {
-	return append(append(FilterPrefix, sid...), filter...)
+	key := append([]byte{}, FilterPrefix...)
+	key = appendLengthPrefixed(key, []byte(sid))
+	return appendLengthPrefixed(key, filter)
 }
 
 func GetFilterKey(sid, did string, filter []byte) []byte {

--- a/x/did/types/keys_test.go
+++ b/x/did/types/keys_test.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterPrefixesUseLengthDelimitedParts(t *testing.T) {
+	legacyA := GetLegacyFilterPrefixBySidAndFilter("ab", []byte("cX"))
+	legacyB := GetLegacyFilterPrefixBySidAndFilter("abc", []byte("X"))
+	require.True(t, bytes.Equal(legacyA, legacyB))
+
+	prefixA := GetFilterPrefixBySidAndFilter("ab", []byte("cX"))
+	prefixB := GetFilterPrefixBySidAndFilter("abc", []byte("X"))
+	require.False(t, bytes.Equal(prefixA, prefixB))
+}


### PR DESCRIPTION
## What

Length-delimits DID credential filter index keys so `QueryCredentials` is scoped by the exact `(sid, filter)` pair instead of raw concatenation.

## Why

The old key shape used `FilterPrefix || sid || filter || did`, so different pairs such as `sid=ab, filter=cX` and `sid=abc, filter=X` shared the same prefix and a query for one service/filter could return credentials from another.

## Changes

- Encodes filter index prefixes as `FilterPrefix || len(sid) || sid || len(filter) || filter`.
- Keeps legacy key helpers only for compatible fallback reads and cleanup deletes.
- Routes the gRPC `Credentials` query through the keeper helper so it uses the same exact filter behavior.
- Filters legacy fallback results against the credential sid and filter logger to avoid returning old colliding entries.
- Adds regression coverage for the reported collision.

## Validation

- `..\..\tools\go\bin\go.exe test .\x\did\types -run TestFilterPrefixesUseLengthDelimitedParts -count=1`
- `..\..\tools\go\bin\go.exe test .\x\did\keeper -run TestKeeper_Filter -count=1`
- `..\..\tools\go\bin\go.exe test .\x\did\keeper .\x\did\types -count=1`
- `git diff --check`

Full `..\..\tools\go\bin\go.exe test .\x\did\... -count=1` is still blocked by the existing `x/did` genesis test panic on an empty `DidInfo.Address` in `TestInitExportGenesis`, before this filter path is reached.

/claim #223
Fixes #223