### PR TITLE
fix(megroup): skip duplicate self admin reward

### DIFF
--- a/x/megroup/keeper/msg_server_join_group.go
+++ b/x/megroup/keeper/msg_server_join_group.go
@@ -10,6 +10,10 @@ import (
 	"github.com/openmetaearth/me-hub/x/megroup/types"
 )
 
+func shouldSendAdminJoinReward(applicantAddress, adminAddress string) bool {
+	return adminAddress != "" && adminAddress != applicantAddress
+}
+
 func (k msgServer) JoinGroup(goCtx context.Context, msg *types.MsgJoinGroup) (*types.MsgJoinGroupResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -84,11 +88,13 @@ func (k msgServer) JoinGroup(goCtx context.Context, msg *types.MsgJoinGroup) (*t
 			return nil, errors.Wrap(types.ErrProcData, fmt.Sprintf("transfer rewards coins error. err = %s,fromAddr = %s,toAddr = %s",
 				err.Error(), region.GetRegionTreasureAddr(), msg.ApplicantAddress))
 		}
-		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()),
-			sdk.MustAccAddressFromBech32(groupInfo.Admin), sdk.NewCoins(rewardsCoin), fmt.Sprintf("JoinGroup_SendAdminRewards_%s", region.RegionId))
-		if err != nil {
-			return nil, errors.Wrap(types.ErrProcData, fmt.Sprintf("transfer rewards coins error. err = %s,fromAddr = %s,toAddr = %s",
-				err.Error(), region.GetRegionTreasureAddr(), groupInfo.Admin))
+		if shouldSendAdminJoinReward(msg.ApplicantAddress, groupInfo.Admin) {
+			err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()),
+				sdk.MustAccAddressFromBech32(groupInfo.Admin), sdk.NewCoins(rewardsCoin), fmt.Sprintf("JoinGroup_SendAdminRewards_%s", region.RegionId))
+			if err != nil {
+				return nil, errors.Wrap(types.ErrProcData, fmt.Sprintf("transfer rewards coins error. err = %s,fromAddr = %s,toAddr = %s",
+					err.Error(), region.GetRegionTreasureAddr(), groupInfo.Admin))
+			}
 		}
 		ctx.EventManager().EmitEvent(sdk.NewEvent(types.EvtJoinGroupReward,
 			sdk.NewAttribute("applicant", msg.ApplicantAddress),

--- a/x/megroup/keeper/msg_server_join_group_test.go
+++ b/x/megroup/keeper/msg_server_join_group_test.go
@@ -1,0 +1,41 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldSendAdminJoinReward(t *testing.T) {
+	tests := []struct {
+		name      string
+		applicant string
+		admin     string
+		want      bool
+	}{
+		{
+			name:      "different applicant and admin",
+			applicant: "applicant",
+			admin:     "admin",
+			want:      true,
+		},
+		{
+			name:      "same applicant and admin",
+			applicant: "admin",
+			admin:     "admin",
+			want:      false,
+		},
+		{
+			name:      "empty admin",
+			applicant: "applicant",
+			admin:     "",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldSendAdminJoinReward(tt.applicant, tt.admin))
+		})
+	}
+}


### PR DESCRIPTION
/claim #938

Fixes #938.

## Summary
- Skip the admin reward transfer when the joining applicant is the same address as the group admin.
- Also avoid attempting an admin reward transfer when the stored admin address is empty.
- Keep the applicant reward behavior unchanged.
- Add focused coverage for the admin reward eligibility predicate.

## Validation
- `..\..\tools\go\bin\go.exe test .\x\megroup\keeper -run TestShouldSendAdminJoinReward -count=1`
- `..\..\tools\go\bin\go.exe test .\x\megroup\keeper -count=1`
- `git diff --check`

Full `..\..\tools\go\bin\go.exe test .\x\megroup\... -count=1` is still blocked by an existing `x/megroup/types` test panic in `TestMsgCreateGroup_ValidateBasic/valid_address`, where the test constructs `MsgCreateGroup` without `GroupInfo` before calling `ValidateBasic`. The changed keeper package passes.