### PR TITLE
fix(gravity): scope batch block index by token

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -132,10 +132,10 @@ func (k Keeper) StoreBatch(ctx sdk.Context, batch *types.OutgoingTxBatch) error 
 	store := ctx.KVStore(k.storeKey)
 	key := types.GetOutgoingTxBatchKey(batch.TokenContract, batch.BatchNonce)
 
-	blockKey := types.GetOutgoingTxBatchBlockKey(batch.Block)
-	// Note: Only one OutgoingTxBatch can be submitted in a block
+	blockKey := types.GetOutgoingTxBatchBlockKey(batch.Block, batch.TokenContract)
+	// Note: only one OutgoingTxBatch per token contract can be submitted in a block.
 	if store.Has(blockKey) {
-		return errorsmod.Wrap(types.ErrInvalid, fmt.Sprintf("block:[%v] has batch request", batch.Block))
+		return errorsmod.Wrap(types.ErrInvalid, fmt.Sprintf("block:[%v] token:[%s] has batch request", batch.Block, batch.TokenContract))
 	}
 
 	value := k.cdc.MustMarshal(batch)
@@ -148,7 +148,7 @@ func (k Keeper) StoreBatch(ctx sdk.Context, batch *types.OutgoingTxBatch) error 
 func (k Keeper) DeleteBatch(ctx sdk.Context, batch *types.OutgoingTxBatch) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.GetOutgoingTxBatchKey(batch.TokenContract, batch.BatchNonce))
-	store.Delete(types.GetOutgoingTxBatchBlockKey(batch.Block))
+	store.Delete(types.GetOutgoingTxBatchBlockKey(batch.Block, batch.TokenContract))
 }
 
 // pickUnBatchedTx find Tx in pool and remove from "available" second index

--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -118,6 +118,57 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteBatchConfirm() {
 	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, batch.TokenContract, batch.BatchNonce))
 }
 
+func (suite *KeeperTestSuite) TestKeeper_StoreBatchAllowsDifferentTokensInSameBlock() {
+	blockHeight := uint64(200)
+	tokenA := helpers.GenerateAddress().Hex()
+	tokenB := helpers.GenerateAddress().Hex()
+	feeReceiver := helpers.GenerateAddress().Hex()
+
+	newBatch := func(tokenContract string, nonce uint64) *types.OutgoingTxBatch {
+		return &types.OutgoingTxBatch{
+			BatchNonce:   nonce,
+			BatchTimeout: 0,
+			Transactions: []*types.OutgoingTransferTx{
+				{
+					Id:          nonce,
+					Sender:      sdk.AccAddress(helpers.GenerateAddress().Bytes()).String(),
+					DestAddress: helpers.GenerateAddress().Hex(),
+					Token: types.ERC20Token{
+						Contract: tokenContract,
+						Amount:   sdkmath.NewInt(1),
+					},
+					Fee: types.ERC20Token{
+						Contract: tokenContract,
+						Amount:   sdkmath.NewInt(1),
+					},
+				},
+			},
+			TokenContract: tokenContract,
+			Block:         blockHeight,
+			FeeReceive:    feeReceiver,
+		}
+	}
+
+	batchA := newBatch(tokenA, 1)
+	batchB := newBatch(tokenB, 2)
+
+	suite.NoError(suite.Keeper().StoreBatch(suite.Ctx, batchA))
+	suite.NoError(suite.Keeper().StoreBatch(suite.Ctx, batchB))
+	suite.Error(suite.Keeper().StoreBatch(suite.Ctx, newBatch(tokenA, 3)))
+
+	var batches []*types.OutgoingTxBatch
+	suite.Keeper().IterateBatchByBlockHeight(suite.Ctx, blockHeight, blockHeight+1,
+		func(batch *types.OutgoingTxBatch) bool {
+			batches = append(batches, batch)
+			return false
+		},
+	)
+	suite.Len(batches, 2)
+
+	suite.Keeper().DeleteBatch(suite.Ctx, batchA)
+	suite.NoError(suite.Keeper().StoreBatch(suite.Ctx, newBatch(tokenA, 3)))
+}
+
 func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {
 	index := tmrand.Intn(100)
 	for i := 1; i <= index; i++ {

--- a/x/gravity/types/keys.go
+++ b/x/gravity/types/keys.go
@@ -156,8 +156,8 @@ func GetOutgoingTxBatchKey(tokenContract string, batchNonce uint64) []byte {
 }
 
 // GetOutgoingTxBatchBlockKey returns the following key format
-func GetOutgoingTxBatchBlockKey(blockHeight uint64) []byte {
-	return append(OutgoingTxBatchBlockKey, sdk.Uint64ToBigEndian(blockHeight)...)
+func GetOutgoingTxBatchBlockKey(blockHeight uint64, tokenContract string) []byte {
+	return append(append(OutgoingTxBatchBlockKey, sdk.Uint64ToBigEndian(blockHeight)...), []byte(tokenContract)...)
 }
 
 // GetBatchConfirmKey returns the following key format


### PR DESCRIPTION
/claim #989

Fixes #989.

## Summary
- scope the outgoing batch block index by both ME block height and token contract
- keep duplicate batch protection for the same token within the same block
- preserve block-height iteration so slash/cleanup paths still see every token batch in the height range
- add a regression test covering two token contracts in one block and deletion of one token's block index

## Validation
- `..\..\tools\go\bin\go.exe test .\x\gravity\types -count=1`
- `git diff --check`

## Note
- `..\..\tools\go\bin\go.exe test .\x\gravity\keeper -run TestKeeperTestSuite/TestKeeper_StoreBatchAllowsDifferentTokensInSameBlock -count=1` is currently blocked before package tests by the repository dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.