### PR TITLE
fix(gravity): keep observed bridge state monotonic

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -104,13 +104,21 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 
 		k.SetLastObservedEventNonce(ctx, claim.GetEventNonce())
 
-		// in case of web3 event is long time ago, we set the last observed me block height need long enough.
-		k.SetLastObservedBlockHeight(ctx, claim.GetBlockHeight(), uint64(ctx.BlockHeight()))
+		err = k.validateObservedExternalBlockHeight(ctx, claim)
+		if err == nil {
+			// in case of web3 event is long time ago, we set the last observed me block height need long enough.
+			k.SetLastObservedBlockHeight(ctx, claim.GetBlockHeight(), uint64(ctx.BlockHeight()))
+			err = k.processAttestation(ctx, claim)
+		} else {
+			k.Logger(ctx).Error("attestation failed", "cause", err.Error(), "claim type", claim.GetType(),
+				"id", hex.EncodeToString(types.GetAttestationKey(claim.GetEventNonce(), claim.ClaimHash())),
+				"nonce", fmt.Sprint(claim.GetEventNonce()),
+			)
+		}
 
 		att.Observed = true
 		k.SetAttestation(ctx, claim.GetEventNonce(), claim.ClaimHash(), att)
 
-		err = k.processAttestation(ctx, claim)
 		ctx.EventManager().EmitEvent(sdk.NewEvent(
 			types.EventTypeContractEvent,
 			sdk.NewAttribute(sdk.AttributeKeyModule, k.moduleName),
@@ -125,6 +133,19 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 		k.PruneAttestations(ctx)
 		break
 	}
+}
+
+func (k Keeper) validateObservedExternalBlockHeight(ctx sdk.Context, claim types.ExternalClaim) error {
+	lastObserved := k.GetLastObservedBlockHeight(ctx)
+	if lastObserved.ExternalBlockHeight != 0 && claim.GetBlockHeight() < lastObserved.ExternalBlockHeight {
+		return errorsmod.Wrapf(
+			types.ErrInvalid,
+			"external block height regression: got %d, observed %d",
+			claim.GetBlockHeight(),
+			lastObserved.ExternalBlockHeight,
+		)
+	}
+	return nil
 }
 
 // processAttestation actually applies the attestation to the consensus state

--- a/x/gravity/keeper/attestation_handler.go
+++ b/x/gravity/keeper/attestation_handler.go
@@ -102,23 +102,27 @@ func (k Keeper) AttestationHandler(ctx sdk.Context, externalClaim types.External
 			Members: claim.Members,
 		}
 		// check the contents of the validator set against the store
-		if claim.RelayerSetNonce != 0 {
-			trustedRelayerSet := k.GetRelayerSet(ctx, claim.RelayerSetNonce)
-			if trustedRelayerSet == nil {
-				ctx.Logger().Error("Received attestation for a relayer set which does not exist in store", "relayerSetNonce", claim.RelayerSetNonce, "claim", claim)
-				return errorsmod.Wrapf(types.ErrInvalid, "attested relayerSet (%v) does not exist in store", claim.RelayerSetNonce)
-			}
+		if claim.RelayerSetNonce == 0 {
+			return errorsmod.Wrap(types.ErrInvalid, "zero relayer set nonce")
+		}
+		trustedRelayerSet := k.GetRelayerSet(ctx, claim.RelayerSetNonce)
+		if trustedRelayerSet == nil {
+			ctx.Logger().Error("Received attestation for a relayer set which does not exist in store", "relayerSetNonce", claim.RelayerSetNonce, "claim", claim)
+			return errorsmod.Wrapf(types.ErrInvalid, "attested relayerSet (%v) does not exist in store", claim.RelayerSetNonce)
+		}
+		if lastObserved := k.GetLastObservedRelayerSet(ctx); lastObserved != nil && claim.RelayerSetNonce < lastObserved.Nonce {
+			return errorsmod.Wrapf(types.ErrInvalid, "relayer set nonce regression: got %d, observed %d", claim.RelayerSetNonce, lastObserved.Nonce)
+		}
 
-			// overwrite the height, since it's not part of the claim
-			observedRelayerSet.Height = trustedRelayerSet.Height
-			match, err := trustedRelayerSet.Equal(observedRelayerSet)
-			if err != nil {
-				// this indicates that the members of the two sets are not equal
-				return errorsmod.Wrapf(types.ErrInvalid, "potential bridge hijacking: observed relayerSet (%+v) does not match stored relayerSet (%+v)! %s", observedRelayerSet, trustedRelayerSet, err.Error())
-			}
-			if !match {
-				return errorsmod.Wrapf(types.ErrInvalid, "potential bridge hijacking: observed relayerSet (%d) does not match stored relayerSet (%d)", observedRelayerSet.Nonce, trustedRelayerSet.Nonce)
-			}
+		// overwrite the height, since it's not part of the claim
+		observedRelayerSet.Height = trustedRelayerSet.Height
+		match, err := trustedRelayerSet.Equal(observedRelayerSet)
+		if err != nil {
+			// this indicates that the members of the two sets are not equal
+			return errorsmod.Wrapf(types.ErrInvalid, "potential bridge hijacking: observed relayerSet (%+v) does not match stored relayerSet (%+v)! %s", observedRelayerSet, trustedRelayerSet, err.Error())
+		}
+		if !match {
+			return errorsmod.Wrapf(types.ErrInvalid, "potential bridge hijacking: observed relayerSet (%d) does not match stored relayerSet (%d)", observedRelayerSet.Nonce, trustedRelayerSet.Nonce)
 		}
 		k.SetLastObservedRelayerSet(ctx, observedRelayerSet)
 	default:

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -229,6 +229,9 @@ func (s MsgServer) RelayerSetConfirm(c context.Context, msg *types.MsgRelayerSet
 // RelayerSetUpdateClaim handles claims for executing a relayer set update on Ethereum
 func (s MsgServer) RelayerSetUpdateClaim(c context.Context, msg *types.MsgRelayerSetUpdateClaim) (*types.MsgRelayerSetUpdateClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
+	if msg.RelayerSetNonce == 0 {
+		return nil, errorsmod.Wrap(types.ErrInvalid, "zero relayer set nonce")
+	}
 	relayerAddress := sdk.MustAccAddressFromBech32(msg.RelayerAddress)
 	err := s.checkIsRelayer(ctx, relayerAddress)
 	if err != nil {

--- a/x/gravity/keeper/observed_state_test.go
+++ b/x/gravity/keeper/observed_state_test.go
@@ -1,0 +1,99 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/testutil/helpers"
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+)
+
+func (s *KeeperTestSuite) TestTryAttestationRejectsExternalBlockHeightRegression() {
+	k := s.Keeper()
+	relayer := s.relayerAddrs[0]
+	k.SetRelayer(s.Ctx, relayer, types.Relayer{
+		RelayerAddress: relayer.String(),
+		DelegateAmount: sdk.DefaultPowerReduction,
+		Online:         true,
+	})
+	k.SetLastTotalPower(s.Ctx)
+	k.SetLastObservedEventNonce(s.Ctx, 1)
+	k.SetLastObservedBlockHeight(s.Ctx, 1000, uint64(s.Ctx.BlockHeight()))
+
+	claim := &types.MsgBridgeTokenClaim{
+		EventNonce:     2,
+		BlockHeight:    1,
+		TokenContract:  helpers.GenerateAddress().Hex(),
+		Name:           "LowHeight",
+		Symbol:         "LOW",
+		Decimals:       6,
+		RelayerAddress: relayer.String(),
+		ChainName:      s.chainName,
+	}
+	att := &types.Attestation{
+		Observed: false,
+		Votes:    []string{relayer.String()},
+	}
+
+	k.TryAttestation(s.Ctx, att, claim)
+
+	lastObservedHeight := k.GetLastObservedBlockHeight(s.Ctx)
+	s.Require().EqualValues(1000, lastObservedHeight.ExternalBlockHeight)
+	s.Require().False(k.HasBridgeToken(s.Ctx, claim.TokenContract))
+
+	storedAtt := k.GetAttestation(s.Ctx, claim.GetEventNonce(), claim.ClaimHash())
+	s.Require().NotNil(storedAtt)
+	s.Require().True(storedAtt.Observed)
+}
+
+func (s *KeeperTestSuite) TestAttestationHandlerRejectsRelayerSetNonceRegression() {
+	k := s.Keeper()
+	members := types.BridgeValidators{
+		{
+			Power:           types.PowerBase,
+			ExternalAddress: helpers.GenerateAddress().Hex(),
+		},
+	}
+	nonce1Set := &types.RelayerSet{
+		Nonce:   1,
+		Height:  10,
+		Members: members,
+	}
+	nonce2Set := &types.RelayerSet{
+		Nonce:   2,
+		Height:  20,
+		Members: members,
+	}
+	k.StoreRelayerSet(s.Ctx, nonce1Set)
+	k.StoreRelayerSet(s.Ctx, nonce2Set)
+	k.SetLastObservedRelayerSet(s.Ctx, nonce2Set)
+
+	err := k.AttestationHandler(s.Ctx, &types.MsgRelayerSetUpdateClaim{
+		EventNonce:      3,
+		BlockHeight:     30,
+		RelayerSetNonce: 1,
+		Members:         members,
+		RelayerAddress:  s.relayerAddrs[0].String(),
+		ChainName:       s.chainName,
+	})
+
+	s.Require().ErrorContains(err, "relayer set nonce regression")
+	s.Require().EqualValues(2, k.GetLastObservedRelayerSet(s.Ctx).Nonce)
+}
+
+func (s *KeeperTestSuite) TestAttestationHandlerRejectsZeroRelayerSetNonce() {
+	k := s.Keeper()
+	err := k.AttestationHandler(s.Ctx, &types.MsgRelayerSetUpdateClaim{
+		EventNonce:      2,
+		BlockHeight:     20,
+		RelayerSetNonce: 0,
+		Members: types.BridgeValidators{
+			{
+				Power:           1,
+				ExternalAddress: helpers.GenerateAddress().Hex(),
+			},
+		},
+		RelayerAddress: s.relayerAddrs[0].String(),
+		ChainName:      s.chainName,
+	})
+
+	s.Require().ErrorContains(err, "zero relayer set nonce")
+}

--- a/x/gravity/types/msg_claim.go
+++ b/x/gravity/types/msg_claim.go
@@ -239,6 +239,9 @@ func (m *MsgRelayerSetUpdateClaim) ValidateBasic() (err error) {
 	if len(m.Members) == 0 {
 		return errortypes.ErrInvalidRequest.Wrap("empty members")
 	}
+	if m.RelayerSetNonce == 0 {
+		return errortypes.ErrInvalidRequest.Wrap("zero relayer set nonce")
+	}
 	for _, member := range m.Members {
 		if err = ValidateExternalAddr(m.ChainName, member.ExternalAddress); err != nil {
 			return errortypes.ErrInvalidAddress.Wrapf("invalid external address: %s", err)

--- a/x/gravity/types/msg_claim_test.go
+++ b/x/gravity/types/msg_claim_test.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	_ "github.com/openmetaearth/me-hub/app/params"
+	"github.com/stretchr/testify/require"
+)
+
+const testRelayerSetClaimChain = "testchain942"
+
+func init() {
+	RegisterExternalAddress(testRelayerSetClaimChain, EthereumAddress{})
+}
+
+func TestMsgRelayerSetUpdateClaimValidateBasicRejectsZeroNonce(t *testing.T) {
+	relayer := sdk.AccAddress(bytes.Repeat([]byte{0x01}, 20)).String()
+	msg := &MsgRelayerSetUpdateClaim{
+		EventNonce:      1,
+		BlockHeight:     1,
+		RelayerSetNonce: 0,
+		Members: BridgeValidators{
+			{
+				Power:           1,
+				ExternalAddress: "0x0000000000000000000000000000000000000001",
+			},
+		},
+		RelayerAddress: relayer,
+		ChainName:      testRelayerSetClaimChain,
+	}
+
+	require.ErrorContains(t, msg.ValidateBasic(), "zero relayer set nonce")
+
+	msg.RelayerSetNonce = 1
+	require.NoError(t, msg.ValidateBasic())
+}


### PR DESCRIPTION
/claim #942
/claim #943
/claim #944

Fixes #942.
Fixes #943.
Fixes #944.

## Summary
- reject `RelayerSetUpdateClaim` with nonce 0 in stateless validation, msg server handling, and attestation handling
- require observed relayer-set claims to reference an existing stored set and reject nonce regressions below the current `LastObservedRelayerSet`
- reject threshold-observed claims whose external block height would rewind `LastObservedBlockHeight`, while preserving the existing event-nonce advancement behavior for invalid observed attestations
- add regression coverage for external block-height regression, relayer-set nonce regression, handler nonce-zero rejection, and `ValidateBasic` nonce-zero rejection

## Validation
- `..\..\tools\go\bin\go.exe test .\x\gravity\types -count=1`
- `git diff --check`
- `git diff --cached --check`

## Note
- Targeted keeper regression tests were added, but `..\..\tools\go\bin\go.exe test .\x\gravity\keeper -run TestGravityKeeperTestSuite/Test(TryAttestationRejectsExternalBlockHeightRegression|AttestationHandlerRejectsRelayerSetNonceRegression|AttestationHandlerRejectsZeroRelayerSetNonce) -count=1` is currently blocked before package tests by the repository dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.