### PR TITLE
fix(gravity): bound bridge token decimals

### DIFF
--- a/x/gravity/keeper/attestation_handler.go
+++ b/x/gravity/keeper/attestation_handler.go
@@ -41,6 +41,9 @@ func (k Keeper) AttestationHandler(ctx sdk.Context, externalClaim types.External
 		k.OutgoingTxBatchExecuted(ctx, claim.TokenContract, claim.BatchNonce)
 
 	case *types.MsgBridgeTokenClaim:
+		if claim.Decimals > types.MaxBridgeTokenDecimals {
+			return errorsmod.Wrapf(types.ErrInvalid, "bridge token decimals %d exceeds max %d", claim.Decimals, types.MaxBridgeTokenDecimals)
+		}
 		// Check if it already exists
 		exists := k.HasBridgeToken(ctx, claim.TokenContract)
 		if exists {

--- a/x/gravity/keeper/bridge_token_decimal_test.go
+++ b/x/gravity/keeper/bridge_token_decimal_test.go
@@ -1,0 +1,25 @@
+package keeper_test
+
+import (
+	"github.com/openmetaearth/me-hub/testutil/helpers"
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+)
+
+func (s *KeeperTestSuite) TestAttestationHandlerRejectsOversizedBridgeTokenDecimals() {
+	k := s.Keeper()
+	tokenContract := helpers.GenerateAddress().Hex()
+
+	err := k.AttestationHandler(s.Ctx, &types.MsgBridgeTokenClaim{
+		EventNonce:     1,
+		BlockHeight:    1,
+		TokenContract:  tokenContract,
+		Name:           "Oversized",
+		Symbol:         "USDT",
+		Decimals:       types.MaxBridgeTokenDecimals + 1,
+		RelayerAddress: s.relayerAddrs[0].String(),
+		ChainName:      s.chainName,
+	})
+
+	s.Require().ErrorContains(err, "bridge token decimals")
+	s.Require().False(k.HasBridgeToken(s.Ctx, tokenContract))
+}

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -250,6 +250,9 @@ func (s MsgServer) RelayerSetUpdateClaim(c context.Context, msg *types.MsgRelaye
 
 func (s MsgServer) BridgeTokenClaim(c context.Context, msg *types.MsgBridgeTokenClaim) (*types.MsgBridgeTokenClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
+	if msg.Decimals > types.MaxBridgeTokenDecimals {
+		return nil, errorsmod.Wrapf(types.ErrInvalid, "bridge token decimals %d exceeds max %d", msg.Decimals, types.MaxBridgeTokenDecimals)
+	}
 	if err := s.claimHandlerCommon(ctx, msg); err != nil {
 		return nil, err
 	}

--- a/x/gravity/types/convert.go
+++ b/x/gravity/types/convert.go
@@ -12,6 +12,9 @@ func CheckBscUsdtUsdc(symbol, chainName string) bool {
 
 func GetDecimals(claim *MsgBridgeTokenClaim) (decimals uint32) {
 	decimals = uint32(claim.Decimals)
+	if claim.Decimals > MaxBridgeTokenDecimals {
+		decimals = uint32(MaxBridgeTokenDecimals)
+	}
 	if CheckBscUsdtUsdc(claim.Symbol, claim.ChainName) {
 		decimals = uint32(6)
 	}
@@ -25,17 +28,24 @@ func GetMintCoin(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk
 }
 
 func GetMintAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
-	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
-		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
+	if exponent, ok := bscStablecoinConversionExponent(chainName, bridgeToken); ok {
+		convert := sdk.NewDec(10).Power(exponent).TruncateInt()
 		amount = amount.Quo(convert)
 	}
 	return amount
 }
 
 func GetExternalUnlockAmount(amount sdk.Int, chainName string, bridgeToken *BridgeToken) sdk.Int {
-	if CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) && bridgeToken.Decimal > 6 {
-		convert := sdk.NewDec(10).Power(bridgeToken.Decimal - 6).TruncateInt()
+	if exponent, ok := bscStablecoinConversionExponent(chainName, bridgeToken); ok {
+		convert := sdk.NewDec(10).Power(exponent).TruncateInt()
 		amount = amount.Mul(convert)
 	}
 	return amount
+}
+
+func bscStablecoinConversionExponent(chainName string, bridgeToken *BridgeToken) (uint64, bool) {
+	if !CheckBscUsdtUsdc(bridgeToken.Symbol, chainName) || bridgeToken.Decimal <= 6 || bridgeToken.Decimal > MaxBridgeTokenDecimals {
+		return 0, false
+	}
+	return bridgeToken.Decimal - 6, true
 }

--- a/x/gravity/types/convert_test.go
+++ b/x/gravity/types/convert_test.go
@@ -89,3 +89,20 @@ func TestGetExternalUnlockAmount(t *testing.T) {
 		})
 	}
 }
+
+func TestBscStablecoinConversionDoesNotPanicOnOversizedDecimals(t *testing.T) {
+	amount := sdkmath.NewInt(1_000_000)
+	bridgeToken := &BridgeToken{
+		Symbol:  "USDT",
+		Decimal: MaxBridgeTokenDecimals + 1,
+	}
+
+	require.NotPanics(t, func() {
+		result := GetMintAmount(amount, "bsc", bridgeToken)
+		require.Equal(t, amount, result)
+	})
+	require.NotPanics(t, func() {
+		result := GetExternalUnlockAmount(amount, "bsc", bridgeToken)
+		require.Equal(t, amount, result)
+	})
+}

--- a/x/gravity/types/msg_claim.go
+++ b/x/gravity/types/msg_claim.go
@@ -191,6 +191,9 @@ func (m *MsgBridgeTokenClaim) ValidateBasic() (err error) {
 	if len(m.Symbol) == 0 {
 		return errortypes.ErrInvalidRequest.Wrap("empty token symbol")
 	}
+	if m.Decimals > MaxBridgeTokenDecimals {
+		return errortypes.ErrInvalidRequest.Wrapf("bridge token decimals %d exceeds max %d", m.Decimals, MaxBridgeTokenDecimals)
+	}
 	if m.EventNonce == 0 {
 		return errortypes.ErrInvalidRequest.Wrap("zero event nonce")
 	}

--- a/x/gravity/types/msg_claim_test.go
+++ b/x/gravity/types/msg_claim_test.go
@@ -1,0 +1,35 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	_ "github.com/openmetaearth/me-hub/app/params"
+	"github.com/stretchr/testify/require"
+)
+
+const testBridgeTokenClaimChain = "testchain941"
+
+func init() {
+	RegisterExternalAddress(testBridgeTokenClaimChain, EthereumAddress{})
+}
+
+func TestMsgBridgeTokenClaimValidateBasicRejectsOversizedDecimals(t *testing.T) {
+	relayer := sdk.AccAddress(bytes.Repeat([]byte{0x01}, 20)).String()
+	msg := &MsgBridgeTokenClaim{
+		EventNonce:     1,
+		BlockHeight:    1,
+		TokenContract:  "0x0000000000000000000000000000000000000001",
+		Name:           "Token",
+		Symbol:         "TOK",
+		Decimals:       MaxBridgeTokenDecimals + 1,
+		RelayerAddress: relayer,
+		ChainName:      testBridgeTokenClaimChain,
+	}
+
+	require.ErrorContains(t, msg.ValidateBasic(), "bridge token decimals")
+
+	msg.Decimals = MaxBridgeTokenDecimals
+	require.NoError(t, msg.ValidateBasic())
+}

--- a/x/gravity/types/params.go
+++ b/x/gravity/types/params.go
@@ -9,11 +9,12 @@ import (
 )
 
 const (
-	OutgoingTxBatchSize        = 100
-	MaxKeepEventSize           = 20
-	MaxGasLimit                = 30_000_000
-	MaxResults                 = 100
-	PowerBase           uint64 = 10000
+	OutgoingTxBatchSize           = 100
+	MaxKeepEventSize              = 20
+	MaxGasLimit                   = 30_000_000
+	MaxResults                    = 100
+	PowerBase              uint64 = 10000
+	MaxBridgeTokenDecimals        = 18
 )
 
 var (


### PR DESCRIPTION
/claim #941

Fixes #941.

## Summary
- add a conservative `MaxBridgeTokenDecimals` bound of 18
- reject oversized `MsgBridgeTokenClaim.Decimals` in `ValidateBasic`, msg server handling, and attestation handling before the value can be stored as a `BridgeToken`
- guard BSC USDT/USDC conversion helpers so historical oversized decimals no longer trigger `sdk.Dec.Power()` overflow panics
- add regression coverage for oversized-decimal validation, conversion no-panic behavior, and direct keeper handler rejection

## Validation
- `..\..\tools\go\bin\go.exe test .\x\gravity\types -run Test(BscStablecoinConversionDoesNotPanicOnOversizedDecimals|MsgBridgeTokenClaimValidateBasicRejectsOversizedDecimals) -count=1`
- `..\..\tools\go\bin\go.exe test .\x\gravity\types -count=1`
- `git diff --check`
- `git diff --cached --check`

## Note
- `..\..\tools\go\bin\go.exe test .\x\gravity\keeper -run TestGravityKeeperTestSuite/TestAttestationHandlerRejectsOversizedBridgeTokenDecimals -count=1` is currently blocked before package tests by the repository dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.