### PR TITLE
fix(eibc): filter demand orders by fulfiller

### DIFF
--- a/x/eibc/keeper/grpc_query.go
+++ b/x/eibc/keeper/grpc_query.go
@@ -108,7 +108,7 @@ func isOrderType(orderType ...commontypes.RollappPacket_Type) filterOption {
 
 func isFulfiller(fulfiller string) filterOption {
 	return func(order types.DemandOrder) bool {
-		return order.Recipient == fulfiller
+		return order.FulfillerAddress == fulfiller
 	}
 }
 

--- a/x/eibc/keeper/grpc_query_test.go
+++ b/x/eibc/keeper/grpc_query_test.go
@@ -97,6 +97,15 @@ func (suite *KeeperTestSuite) TestQueryDemandOrdersByStatus() {
 	suite.Require().NotNil(res.DemandOrders)
 	suite.Require().Equal(true, res.DemandOrders[0].IsFulfilled(), "Expected 0 demand orders with fulfillment state fulfilled")
 
+	res, err = suite.queryClient.DemandOrdersByStatus(sdk.WrapSDKContext(suite.Ctx), &types.QueryDemandOrdersByStatusRequest{Status: commontypes.Status_FINALIZED, Fulfiller: demandOrderAddresses[0].String()})
+	suite.Require().NoError(err)
+	suite.Require().Len(res.DemandOrders, 1)
+	suite.Require().Equal(demandOrderAddresses[0].String(), res.DemandOrders[0].FulfillerAddress)
+
+	res, err = suite.queryClient.DemandOrdersByStatus(sdk.WrapSDKContext(suite.Ctx), &types.QueryDemandOrdersByStatusRequest{Status: commontypes.Status_FINALIZED, Fulfiller: demandOrderAddresses[2].String()})
+	suite.Require().NoError(err)
+	suite.Require().Empty(res.DemandOrders)
+
 	// Query by fulfillment status: UNFULFILLED
 	res, err = suite.queryClient.DemandOrdersByStatus(sdk.WrapSDKContext(suite.Ctx), &types.QueryDemandOrdersByStatusRequest{Status: commontypes.Status_PENDING, FulfillmentState: types.FulfillmentState_UNFULFILLED})
 	suite.Require().NoError(err)


### PR DESCRIPTION
/claim #912

Fixes #912.

## Summary
- make the `DemandOrdersByStatus` fulfiller filter compare against `DemandOrder.FulfillerAddress` instead of `Recipient`
- add regression coverage proving the real fulfiller address returns the fulfilled order while the recipient address no longer false-positives as a fulfiller

## Validation
- `git diff --check`
- `git diff --cached --check`

## Note
- `..\..\tools\go\bin\go.exe test .\x\eibc\keeper -run TestKeeperTestSuite/TestQueryDemandOrdersByStatus -count=1` and `..\..\tools\go\bin\go.exe test .\x\eibc\keeper -count=1` are currently blocked before package tests by the repository dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.