### PR TITLE
fix: reject empty EVM bank contract denom query

### DIFF
--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -1,0 +1,22 @@
+package keeper
+
+import (
+	"context"
+
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// VirtualFrontierBankContractByDenom guards the upstream query from empty input.
+func (k Keeper) VirtualFrontierBankContractByDenom(ctx context.Context, request *evmtypes.QueryVirtualFrontierBankContractByDenomRequest) (*evmtypes.QueryVirtualFrontierBankContractByDenomResponse, error) {
+	if request == nil {
+		return nil, status.Error(codes.InvalidArgument, "empty request")
+	}
+
+	if request.MinDenom == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty min denom")
+	}
+
+	return k.Keeper.VirtualFrontierBankContractByDenom(ctx, request)
+}

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -1,0 +1,27 @@
+package keeper
+
+import (
+	"context"
+	"testing"
+
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestVirtualFrontierBankContractByDenomRejectsEmptyRequest(t *testing.T) {
+	var k Keeper
+
+	_, err := k.VirtualFrontierBankContractByDenom(context.Background(), nil)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestVirtualFrontierBankContractByDenomRejectsEmptyMinDenom(t *testing.T) {
+	var k Keeper
+
+	_, err := k.VirtualFrontierBankContractByDenom(context.Background(), &evmtypes.QueryVirtualFrontierBankContractByDenomRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/evmos/ethermint/x/evm"
+	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/openmetaearth/me-hub/x/evm/keeper"
@@ -78,7 +79,17 @@ func NewAppModule(k *keeper.Keeper, accountKeeper evmtypes.AccountKeeper, bankKe
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	am.AppModule.RegisterServices(cfg)
+	evmtypes.RegisterMsgServer(cfg.MsgServer(), am.keeper.Keeper)
+	evmtypes.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+
+	m := evmkeeper.NewMigrator(*am.keeper.Keeper, am.legacySubspace)
+	if err := cfg.RegisterMigration(evmtypes.ModuleName, 3, m.Migrate3to4); err != nil {
+		panic(err)
+	}
+
+	if err := cfg.RegisterMigration(evmtypes.ModuleName, 4, m.Migrate4to5); err != nil {
+		panic(err)
+	}
 }
 
 func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {


### PR DESCRIPTION
/claim #897

## Summary
- reject nil `VirtualFrontierBankContractByDenom` requests with `InvalidArgument`
- reject empty `min_denom` before calling the upstream keeper helper that panics on empty input
- register the wrapped EVM keeper as the query server so the local guard handles public query requests while keeping the upstream msg server and migrations intact

## Tests
- `go test ./x/evm/... -count=1`
- `git diff --check`