### PR TITLE
fix: reject dangling RollApp genesis state indexes

### DIFF
--- a/x/rollapp/types/genesis.go
+++ b/x/rollapp/types/genesis.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 )
 
 // DefaultIndex is the default capability global index
@@ -52,6 +53,10 @@ func (gs GenesisState) Validate() error {
 			return errors.New("duplicated index for latestStateInfoIndex")
 		}
 		latestStateInfoIndexIndexMap[index] = struct{}{}
+
+		if _, ok := stateInfoIndexMap[string(StateInfoKey(elem))]; !ok {
+			return fmt.Errorf("latestStateInfoIndex references missing stateInfo: rollappId %s index %d", elem.RollappId, elem.Index)
+		}
 	}
 	// Check for duplicated index in latestFinalizedStateIndex
 	latestFinalizedStateIndexIndexMap := make(map[string]struct{})
@@ -62,6 +67,10 @@ func (gs GenesisState) Validate() error {
 			return errors.New("duplicated index for latestFinalizedStateIndex")
 		}
 		latestFinalizedStateIndexIndexMap[index] = struct{}{}
+
+		if _, ok := stateInfoIndexMap[string(StateInfoKey(elem))]; !ok {
+			return fmt.Errorf("latestFinalizedStateIndex references missing stateInfo: rollappId %s index %d", elem.RollappId, elem.Index)
+		}
 	}
 	// Check for duplicated index in blockHeightToFinalizationQueue
 	blockHeightToFinalizationQueueIndexMap := make(map[string]struct{})
@@ -72,6 +81,12 @@ func (gs GenesisState) Validate() error {
 			return errors.New("duplicated index for blockHeightToFinalizationQueue")
 		}
 		blockHeightToFinalizationQueueIndexMap[index] = struct{}{}
+
+		for _, stateInfoIndex := range elem.FinalizationQueue {
+			if _, ok := stateInfoIndexMap[string(StateInfoKey(stateInfoIndex))]; !ok {
+				return fmt.Errorf("finalizationQueue references missing stateInfo: rollappId %s index %d", stateInfoIndex.RollappId, stateInfoIndex.Index)
+			}
+		}
 	}
 	// this line is used by starport scaffolding # genesis/types/validate
 

--- a/x/rollapp/types/genesis_test.go
+++ b/x/rollapp/types/genesis_test.go
@@ -59,6 +59,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 					{
 						RollappId: "1",
+						Index:     1,
 					},
 				},
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
@@ -108,6 +109,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					},
 					{
 						RollappId: "1",
+						Index:     1,
 					},
 				},
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
@@ -201,6 +203,29 @@ func TestGenesisState_Validate(t *testing.T) {
 			valid: false,
 		},
 		{
+			desc: "latestStateInfoIndex references missing stateInfo",
+			genState: &types.GenesisState{
+				Params:                             types.Params{},
+				RollappList:                        []types.Rollapp{},
+				StateInfoList:                      []types.StateInfo{{StateInfoIndex: types.StateInfoIndex{RollappId: "0", Index: 0}}},
+				LatestStateInfoIndexList:           []types.StateInfoIndex{{RollappId: "0", Index: 1}},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},
+			},
+			valid: false,
+		},
+		{
+			desc: "latestFinalizedStateIndex references missing stateInfo",
+			genState: &types.GenesisState{
+				Params:                             types.Params{},
+				RollappList:                        []types.Rollapp{},
+				StateInfoList:                      []types.StateInfo{{StateInfoIndex: types.StateInfoIndex{RollappId: "0", Index: 0}}},
+				LatestStateInfoIndexList:           []types.StateInfoIndex{},
+				LatestFinalizedStateIndexList:      []types.StateInfoIndex{{RollappId: "0", Index: 1}},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{},
+			},
+			valid: false,
+		},
+		{
 			desc: "duplicated blockHeightToFinalizationQueue",
 			genState: &types.GenesisState{
 				Params:                             types.Params{},
@@ -208,6 +233,23 @@ func TestGenesisState_Validate(t *testing.T) {
 				StateInfoList:                      []types.StateInfo{},
 				LatestStateInfoIndexList:           []types.StateInfoIndex{},
 				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{{CreationHeight: 0}, {CreationHeight: 0}},
+			},
+			valid: false,
+		},
+		{
+			desc: "finalizationQueue references missing stateInfo",
+			genState: &types.GenesisState{
+				Params:                        types.Params{},
+				RollappList:                   []types.Rollapp{},
+				StateInfoList:                 []types.StateInfo{{StateInfoIndex: types.StateInfoIndex{RollappId: "0", Index: 0}}},
+				LatestStateInfoIndexList:      []types.StateInfoIndex{},
+				LatestFinalizedStateIndexList: []types.StateInfoIndex{},
+				BlockHeightToFinalizationQueueList: []types.BlockHeightToFinalizationQueue{
+					{
+						CreationHeight:    0,
+						FinalizationQueue: []types.StateInfoIndex{{RollappId: "0", Index: 1}},
+					},
+				},
 			},
 			valid: false,
 		},


### PR DESCRIPTION
/claim #930

## Summary
- build the imported `StateInfo` key set during RollApp genesis validation
- reject `LatestStateInfoIndexList` entries that point to missing `StateInfo`
- reject `LatestFinalizedStateIndexList` entries that point to missing `StateInfo`
- reject finalization queue entries that point to missing `StateInfo`
- update valid genesis fixtures so their latest indexes point at the matching imported state records

## Tests
- `go test ./x/rollapp/types -run TestGenesisState_Validate -count=1`
- `go test ./x/rollapp/types -count=1`
- `go test ./x/rollapp -count=1`
- `git diff --check`

`go test ./x/rollapp/... -count=1` was also attempted. It passed `x/rollapp`, `x/rollapp/transfergenesis`, and `x/rollapp/types`, but `x/rollapp/keeper` is currently blocked before package tests by the upstream dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.