### PR TITLE
fix(eibc): require positive fulfill fees

### DIFF
--- a/ts-client/dymensionxyz.dymension.eibc/module.ts
+++ b/ts-client/dymensionxyz.dymension.eibc/module.ts
@@ -45,6 +45,13 @@ const defaultFee = {
   gas: "200000",
 };
 
+function validateMsgFulfillOrder(value: MsgFulfillOrder): void {
+	const expectedFee = value.expectedFee?.trim() ?? "";
+	if (!/^[0-9]+$/.test(expectedFee) || /^0+$/.test(expectedFee)) {
+		throw new Error('expectedFee must be a positive integer')
+	}
+}
+
 interface TxClientOptions {
   addr: string
 	prefix: string
@@ -72,7 +79,9 @@ export const txClient = ({ signer, prefix, addr }: TxClientOptions = { addr: "ht
 		
 		msgFulfillOrder({ value }: msgFulfillOrderParams): EncodeObject {
 			try {
-				return { typeUrl: "/dymensionxyz.dymension.eibc.MsgFulfillOrder", value: MsgFulfillOrder.fromPartial( value ) }  
+				const msg = MsgFulfillOrder.fromPartial( value )
+				validateMsgFulfillOrder(msg)
+				return { typeUrl: "/dymensionxyz.dymension.eibc.MsgFulfillOrder", value: msg }
 			} catch (e: any) {
 				throw new Error('TxClient:MsgFulfillOrder: Could not create message: ' + e.message)
 			}

--- a/x/eibc/keeper/msg_server_test.go
+++ b/x/eibc/keeper/msg_server_test.go
@@ -33,12 +33,13 @@ func (suite *KeeperTestSuite) TestMsgFulfillOrder() {
 			expectedDemandOrdefFulfillmentStatus: true,
 		},
 		{
-			name:                                 "order with zero fee - success",
+			name:                                 "order with zero expected fee - rejected",
 			demandOrderPrice:                     150,
 			demandOrderFee:                       0,
 			fulfillmentExpectedFee:               "0",
+			expectedFulfillmentError:             sdkerrors.ErrInvalidRequest,
 			eIBCdemandAddrBalance:                math.NewInt(1000),
-			expectedDemandOrdefFulfillmentStatus: true,
+			expectedDemandOrdefFulfillmentStatus: false,
 		},
 		{
 			name:                                 "Test demand order fulfillment - wrong expected fee",

--- a/x/eibc/types/errors.go
+++ b/x/eibc/types/errors.go
@@ -21,4 +21,5 @@ var (
 	ErrNegativeFee                  = errorsmod.Register(ModuleName, 13, "Fee must be greater than or equal to 0")
 	ErrMultipleDenoms               = errorsmod.Register(ModuleName, 15, "Multiple denoms not allowed")
 	ErrEmptyPrice                   = errorsmod.Register(ModuleName, 16, "Price must be greater than 0")
+	ErrNonPositiveFee               = errorsmod.Register(ModuleName, 17, "Fee must be greater than 0")
 )

--- a/x/eibc/types/tx.go
+++ b/x/eibc/types/tx.go
@@ -49,6 +49,9 @@ func (m *MsgFulfillOrder) ValidateBasic() error {
 	if err != nil {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
+	if err := validatePositiveFee(m.ExpectedFee); err != nil {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
+	}
 	return nil
 }
 
@@ -104,14 +107,29 @@ func validateCommon(orderId, address, fee string) error {
 		return err
 	}
 
+	_, err = validateFee(fee)
+	return err
+}
+
+func validateFee(fee string) (sdk.Int, error) {
 	feeInt, ok := sdk.NewIntFromString(fee)
 	if !ok {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, fmt.Sprintf("parse fee: %s", fee))
+		return sdk.Int{}, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, fmt.Sprintf("parse fee: %s", fee))
 	}
-
 	if feeInt.IsNegative() {
-		return ErrNegativeFee
+		return sdk.Int{}, ErrNegativeFee
 	}
 
+	return feeInt, nil
+}
+
+func validatePositiveFee(fee string) error {
+	feeInt, err := validateFee(fee)
+	if err != nil {
+		return err
+	}
+	if !feeInt.IsPositive() {
+		return ErrNonPositiveFee
+	}
 	return nil
 }

--- a/x/eibc/types/tx_test.go
+++ b/x/eibc/types/tx_test.go
@@ -1,0 +1,60 @@
+package types_test
+
+import (
+	"strings"
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmetaearth/me-hub/x/eibc/types"
+)
+
+func TestMsgFulfillOrderValidateBasicRequiresPositiveExpectedFee(t *testing.T) {
+	validAddress := "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88yqg82a"
+	validOrderID := strings.Repeat("a", 64)
+
+	tests := []struct {
+		name      string
+		fee       string
+		expectErr string
+	}{
+		{
+			name: "positive fee",
+			fee:  "1",
+		},
+		{
+			name:      "zero fee",
+			fee:       "0",
+			expectErr: types.ErrNonPositiveFee.Error(),
+		},
+		{
+			name:      "negative fee",
+			fee:       "-1",
+			expectErr: types.ErrNegativeFee.Error(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := types.NewMsgFulfillOrder(validAddress, validOrderID, tc.fee)
+
+			err := msg.ValidateBasic()
+			if tc.expectErr != "" {
+				require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
+				require.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestMsgUpdateDemandOrderValidateBasicAllowsZeroFee(t *testing.T) {
+	validAddress := "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88yqg82a"
+	validOrderID := strings.Repeat("a", 64)
+
+	msg := types.NewMsgUpdateDemandOrder(validAddress, validOrderID, "0")
+
+	require.NoError(t, msg.ValidateBasic())
+}


### PR DESCRIPTION
/claim #899

Fixes #899.

## Summary
- require `MsgFulfillOrder.ExpectedFee` to be a positive integer in chain-side `ValidateBasic`
- keep `MsgUpdateDemandOrder` zero-fee updates allowed so existing order-owner behavior is unchanged
- add a TS SDK guard in `msgFulfillOrder`, which is also used by `sendMsgFulfillOrder`, so zero/negative/non-integer expected fees fail before broadcast
- update fulfillment tests so zero expected fee is rejected instead of marking the order fulfilled

## Validation
- `..\..\tools\go\bin\go.exe test ./x/eibc/types -run TestMsgFulfillOrderValidateBasicRequiresPositiveExpectedFee -count=1`
- `..\..\tools\go\bin\go.exe test ./x/eibc/types -count=1`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `..\..\tools\go\bin\go.exe test ./x/eibc/keeper -run TestKeeperTestSuite/TestMsgFulfillOrder -count=1` was attempted, but the keeper package is currently blocked before package tests by the repository dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.
- TypeScript compile was not run because this checkout does not have `ts-client/node_modules` installed and the package defines no npm test/build script.