### PR TITLE
fix(app): validate gentx message shapes

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -46,6 +46,7 @@ import (
 	"github.com/openmetaearth/me-hub/x/wmint"
 	"github.com/openmetaearth/me-hub/x/wnft"
 	"github.com/openmetaearth/me-hub/x/wstaking"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
 
 	rollappmoduleclient "github.com/openmetaearth/me-hub/x/rollapp/client"
 	"github.com/openmetaearth/me-hub/x/sequencer"
@@ -110,10 +111,31 @@ var ModuleBasics = module.NewBasicManager(
 
 func GenTxMessageValidator(msgs []sdk.Msg) error {
 	if len(msgs) == 0 {
-		return fmt.Errorf("unexpected number of GenTx messages; got: %d, expected great than 0", len(msgs))
+		return fmt.Errorf("unexpected number of GenTx messages; got: %d, expected 1 or 2", len(msgs))
 	}
-	if _, ok := msgs[0].(*stakingtypes.MsgCreateValidator); !ok {
+	if len(msgs) > 2 {
+		return fmt.Errorf("unexpected number of GenTx messages; got: %d, expected 1 or 2", len(msgs))
+	}
+
+	createValidator, ok := msgs[0].(*stakingtypes.MsgCreateValidator)
+	if !ok || createValidator == nil {
 		return fmt.Errorf("unexpected GenTx message type; expected: MsgCreateValidator, got: %T", msgs[0])
 	}
+	if err := createValidator.ValidateBasic(); err != nil {
+		return fmt.Errorf("invalid GenTx MsgCreateValidator: %w", err)
+	}
+
+	if len(msgs) == 1 {
+		return nil
+	}
+
+	newRegion, ok := msgs[1].(*wstakingtypes.MsgNewRegion)
+	if !ok || newRegion == nil {
+		return fmt.Errorf("unexpected GenTx message type at index 1; expected: MsgNewRegion, got: %T", msgs[1])
+	}
+	if err := newRegion.ValidateBasic(); err != nil {
+		return fmt.Errorf("invalid GenTx MsgNewRegion: %w", err)
+	}
+
 	return nil
 }

--- a/app/modules_test.go
+++ b/app/modules_test.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/openmetaearth/me-hub/app/params"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenTxMessageValidator(t *testing.T) {
+	createValidator := validCreateValidatorMsg(t)
+	newRegion := wstakingtypes.NewMsgNewRegion(createValidator.DelegatorAddress, "usa", createValidator.ValidatorAddress)
+
+	tests := []struct {
+		name    string
+		msgs    []sdk.Msg
+		wantErr bool
+	}{
+		{
+			name:    "empty gentx",
+			msgs:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "single valid create validator",
+			msgs:    []sdk.Msg{createValidator},
+			wantErr: false,
+		},
+		{
+			name:    "valid create validator and region",
+			msgs:    []sdk.Msg{createValidator, newRegion},
+			wantErr: false,
+		},
+		{
+			name:    "malformed create validator",
+			msgs:    []sdk.Msg{&stakingtypes.MsgCreateValidator{}},
+			wantErr: true,
+		},
+		{
+			name:    "first message is not create validator",
+			msgs:    []sdk.Msg{validMsgSend()},
+			wantErr: true,
+		},
+		{
+			name:    "arbitrary second message",
+			msgs:    []sdk.Msg{createValidator, validMsgSend()},
+			wantErr: true,
+		},
+		{
+			name:    "malformed second region message",
+			msgs:    []sdk.Msg{createValidator, wstakingtypes.NewMsgNewRegion("", "usa", createValidator.ValidatorAddress)},
+			wantErr: true,
+		},
+		{
+			name:    "too many gentx messages",
+			msgs:    []sdk.Msg{createValidator, newRegion, validMsgSend()},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := GenTxMessageValidator(tc.msgs)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func validCreateValidatorMsg(t *testing.T) *stakingtypes.MsgCreateValidator {
+	t.Helper()
+
+	privKey := secp256k1.GenPrivKey()
+	valAddr := sdk.ValAddress(privKey.PubKey().Address())
+
+	msg, err := stakingtypes.NewMsgCreateValidator(
+		valAddr,
+		privKey.PubKey(),
+		sdk.NewCoin(params.BaseDenom, math.NewInt(100_000_000)),
+		stakingtypes.Description{Moniker: "validator"},
+		stakingtypes.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
+		math.OneInt(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, msg.ValidateBasic())
+
+	return msg
+}
+
+func validMsgSend() *banktypes.MsgSend {
+	from := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+	to := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+
+	return banktypes.NewMsgSend(from, to, sdk.NewCoins(sdk.NewInt64Coin(params.BaseDenom, 1)))
+}


### PR DESCRIPTION
/claim #902

Fixes #902.

## Summary
- restrict gentx validation to either one valid `MsgCreateValidator` or `MsgCreateValidator` followed by one valid `wstaking.MsgNewRegion`
- run `ValidateBasic()` on both accepted gentx messages so malformed validator or region messages are rejected during collect-gentxs validation
- reject arbitrary extra messages and gentxs with more than two messages
- add focused tests for the valid single-message path, valid region path, malformed create-validator, arbitrary second message, malformed region, and overlong gentx cases

## Validation
- `..\..\tools\go\bin\go.exe test ./app/modules.go ./app/modules_test.go -run TestGenTxMessageValidator -count=1`
- `git diff --check`
- `git diff --cached --check`

## Note
- `..\..\tools\go\bin\go.exe test ./app -run TestGenTxMessageValidator -count=1` was attempted, but the full app package is currently blocked before package tests by the repository dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.