### PR TITLE
fix(upgrade): fund initial gravity relayers

### DIFF
--- a/app/upgrades/v2_0_13/upgrade.go
+++ b/app/upgrades/v2_0_13/upgrade.go
@@ -8,6 +8,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	appkeepers "github.com/openmetaearth/me-hub/app/keepers"
+	appparams "github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/app/upgrades"
 	"github.com/openmetaearth/me-hub/utils"
 	bsctypes "github.com/openmetaearth/me-hub/x/bsc/types"
@@ -58,16 +59,10 @@ func CreateUpgradeHandler(
 
 		// delegate total amount to module account
 		delegateAmount := sdk.NewInt(1 * 1e8)
-		//for _, relayerAddr := range proposalRelayers {
-		//if err := keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, sdk.MustAccAddressFromBech32(relayerAddr), bsctypes.ModuleName,
-		//	sdk.NewCoins(sdk.NewCoin(params.BaseDenom, delegateAmount))); err != nil {
-		//	panic(fmt.Sprintf("failed to delegate coins to relayer %s: %s", relayerAddr, err.Error()))
-		//}
-		//if err := keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, sdk.MustAccAddressFromBech32(relayerAddr), trontypes.ModuleName,
-		//	sdk.NewCoins(sdk.NewCoin(params.BaseDenom, delegateAmount))); err != nil {
-		//	panic(fmt.Sprintf("failed to delegate coins to relayer %s: %s", relayerAddr, err.Error()))
-		//}
-		//}
+		delegateCoins := sdk.NewCoins(sdk.NewCoin(appparams.BaseDenom, delegateAmount))
+		if err := fundGravityRelayerModuleAccounts(ctx, keepers.BankKeeper, proposalRelayers, delegateCoins); err != nil {
+			panic(err.Error())
+		}
 
 		bscGenState := GenGravityGenesis(ctx.BlockHeight(), proposalRelayers, bsctypes.DefaultGenesisState(), delegateAmount, bsctypes.ModuleName)
 		gravitykeeper.InitGenesis(ctx, keepers.BscKeeper, bscGenState)
@@ -98,6 +93,23 @@ func CreateUpgradeHandler(
 		logger.Info("upgrade finished successfully.")
 		return mm.RunMigrations(ctx, configurator, fromVM)
 	}
+}
+
+type relayerDelegationBankKeeper interface {
+	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+}
+
+func fundGravityRelayerModuleAccounts(ctx sdk.Context, bankKeeper relayerDelegationBankKeeper, proposalRelayers []string, delegateCoins sdk.Coins) error {
+	for _, relayerAddr := range proposalRelayers {
+		relayer := sdk.MustAccAddressFromBech32(relayerAddr)
+		if err := bankKeeper.SendCoinsFromAccountToModule(ctx, relayer, bsctypes.ModuleName, delegateCoins); err != nil {
+			return fmt.Errorf("failed to delegate coins to BSC relayer %s: %w", relayerAddr, err)
+		}
+		if err := bankKeeper.SendCoinsFromAccountToModule(ctx, relayer, trontypes.ModuleName, delegateCoins); err != nil {
+			return fmt.Errorf("failed to delegate coins to Tron relayer %s: %w", relayerAddr, err)
+		}
+	}
+	return nil
 }
 
 func GenGravityGenesis(height int64, proposalRelayers []string, defaultGenesis *gravitytypes.GenesisState, delegateAmount sdk.Int, moduleName string) *gravitytypes.GenesisState {

--- a/app/upgrades/v2_0_13/upgrade_test.go
+++ b/app/upgrades/v2_0_13/upgrade_test.go
@@ -1,0 +1,65 @@
+package v2_0_13
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/params"
+	bsctypes "github.com/openmetaearth/me-hub/x/bsc/types"
+	trontypes "github.com/openmetaearth/me-hub/x/tron/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFundGravityRelayerModuleAccounts(t *testing.T) {
+	relayers := []string{
+		"me1frjhlw9slyy7mrhmk0r4vytkyldxqtkf326amv",
+		"me1c5zp26c0gq2klk87nrpff3y52u34zn4ydug2yd",
+	}
+	delegateCoins := sdk.NewCoins(sdk.NewInt64Coin(params.BaseDenom, 1e8))
+	bankKeeper := &recordingBankKeeper{}
+
+	err := fundGravityRelayerModuleAccounts(sdk.Context{}, bankKeeper, relayers, delegateCoins)
+
+	require.NoError(t, err)
+	require.Equal(t, []recordedModuleTransfer{
+		{
+			sender: sdk.MustAccAddressFromBech32(relayers[0]),
+			module: bsctypes.ModuleName,
+			coins:  delegateCoins,
+		},
+		{
+			sender: sdk.MustAccAddressFromBech32(relayers[0]),
+			module: trontypes.ModuleName,
+			coins:  delegateCoins,
+		},
+		{
+			sender: sdk.MustAccAddressFromBech32(relayers[1]),
+			module: bsctypes.ModuleName,
+			coins:  delegateCoins,
+		},
+		{
+			sender: sdk.MustAccAddressFromBech32(relayers[1]),
+			module: trontypes.ModuleName,
+			coins:  delegateCoins,
+		},
+	}, bankKeeper.transfers)
+}
+
+type recordingBankKeeper struct {
+	transfers []recordedModuleTransfer
+}
+
+type recordedModuleTransfer struct {
+	sender sdk.AccAddress
+	module string
+	coins  sdk.Coins
+}
+
+func (k *recordingBankKeeper) SendCoinsFromAccountToModule(_ sdk.Context, sender sdk.AccAddress, module string, coins sdk.Coins) error {
+	k.transfers = append(k.transfers, recordedModuleTransfer{
+		sender: sender,
+		module: module,
+		coins:  coins,
+	})
+	return nil
+}


### PR DESCRIPTION
/claim #689

Fixes #689.

## Summary
- restore actual account-to-module delegation transfers for the initial v2.0.13 Gravity relayers before writing their `DelegateAmount` into BSC and Tron genesis state
- use `app/params.BaseDenom` for the delegated `umec` coin so the recorded bridge voting power is backed by module-account funds
- fail the upgrade if any initial relayer cannot fund the BSC or Tron module delegation instead of creating phantom bridge power
- add focused coverage that each configured relayer funds both Gravity module accounts with the exact delegated amount

## Validation
- `..\..\tools\go\bin\go.exe test ./app/upgrades/v2_0_13 -run TestFundGravityRelayerModuleAccounts -count=1`
- `..\..\tools\go\bin\go.exe test ./app/upgrades/v2_0_13 -count=1`
- `git diff --check`
- `git diff --cached --check`