### PR TITLE
fix(gravity): preserve confirmed timed out batches

### DIFF
--- a/x/gravity/keeper/abci.go
+++ b/x/gravity/keeper/abci.go
@@ -145,6 +145,10 @@ func (k Keeper) cleanupTimedOutBatches(ctx sdk.Context) {
 	externalBlockHeight := k.GetLastObservedBlockHeight(ctx).ExternalBlockHeight
 	k.IterateOutgoingTxBatches(ctx, func(batch *types.OutgoingTxBatch) bool {
 		if batch.BatchTimeout < externalBlockHeight {
+			if k.HasBatchConfirmQuorum(ctx, batch.BatchNonce, batch.TokenContract) {
+				k.Logger(ctx).Info("skip canceling timed out confirmed batch", "tokenContract", batch.TokenContract, "nonce", batch.BatchNonce)
+				return false
+			}
 			if err := k.CancelOutgoingTxBatch(ctx, batch.TokenContract, batch.BatchNonce); err != nil {
 				k.Logger(ctx).Error("failed to cancel timed out batch", "tokenContract", batch.TokenContract, "nonce", batch.BatchNonce, "error", err)
 			}

--- a/x/gravity/keeper/attestation_handler.go
+++ b/x/gravity/keeper/attestation_handler.go
@@ -38,7 +38,9 @@ func (k Keeper) AttestationHandler(ctx sdk.Context, externalClaim types.External
 		k.SetBridgeToken(ctx, bridgeToken)
 
 	case *types.MsgSendToExternalClaim:
-		k.OutgoingTxBatchExecuted(ctx, claim.TokenContract, claim.BatchNonce)
+		if err := k.OutgoingTxBatchExecuted(ctx, claim.TokenContract, claim.BatchNonce); err != nil {
+			return err
+		}
 
 	case *types.MsgBridgeTokenClaim:
 		// Check if it already exists

--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -105,26 +105,32 @@ func (k Keeper) GetBatchTimeoutHeight(ctx sdk.Context) (uint64, uint64) {
 
 // OutgoingTxBatchExecuted is run when the Cosmos chain detects that a batch has been executed on Ethereum
 // It frees all the transactions in the batch, then cancels all earlier batches
-func (k Keeper) OutgoingTxBatchExecuted(ctx sdk.Context, contractAddress string, batchNonce uint64) {
+func (k Keeper) OutgoingTxBatchExecuted(ctx sdk.Context, contractAddress string, batchNonce uint64) error {
 	batch := k.GetOutgoingTxBatch(ctx, contractAddress, batchNonce)
 	if batch == nil {
-		panic(fmt.Sprintf("unknown batch nonce for outgoing tx batch %s %d", contractAddress, batchNonce))
+		return errorsmod.Wrapf(types.ErrUnknown, "unknown batch nonce for outgoing tx batch %s %d", contractAddress, batchNonce)
 	}
 
+	var cancelErr error
 	// Iterate through remaining batches
 	k.IterateOutgoingTxBatches(ctx, func(iterBatch *types.OutgoingTxBatch) bool {
 		// If the iterated batches nonce is lower than the one that was just executed, cancel it
 		if iterBatch.BatchNonce < batch.BatchNonce && iterBatch.TokenContract == contractAddress {
 			if err := k.CancelOutgoingTxBatch(ctx, contractAddress, iterBatch.BatchNonce); err != nil {
-				panic(fmt.Sprintf("Failed cancel out batch %s-%d while trying to execute failed: %s", batch.TokenContract, batch.BatchNonce, err))
+				cancelErr = errorsmod.Wrapf(err, "failed cancel out batch %s-%d while trying to execute", batch.TokenContract, batch.BatchNonce)
+				return true
 			}
 		}
 		return false
 	})
+	if cancelErr != nil {
+		return cancelErr
+	}
 
 	// Delete batch since it is finished
 	k.DeleteBatch(ctx, batch)
 	k.DeleteBatchConfirm(ctx, batch.BatchNonce, batch.TokenContract)
+	return nil
 }
 
 // StoreBatch stores a transaction batch

--- a/x/gravity/keeper/batch_confirm.go
+++ b/x/gravity/keeper/batch_confirm.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 )
@@ -40,6 +41,32 @@ func (k Keeper) IterateBatchConfirmByNonceAndTokenContract(ctx sdk.Context, batc
 			break
 		}
 	}
+}
+
+func (k Keeper) HasBatchConfirmQuorum(ctx sdk.Context, batchNonce uint64, tokenContract string) bool {
+	totalPower := k.GetLastTotalPower(ctx)
+	if totalPower.IsZero() {
+		return false
+	}
+
+	requiredPower := types.AttestationVotesPowerThreshold.Mul(totalPower).Quo(sdk.NewIntFromUint64(types.PowerBase))
+	confirmPower := sdkmath.ZeroInt()
+	k.IterateBatchConfirmByNonceAndTokenContract(ctx, batchNonce, tokenContract, func(confirm *types.MsgConfirmBatch) bool {
+		relayerAddr, err := sdk.AccAddressFromBech32(confirm.RelayerAddress)
+		if err != nil {
+			k.Logger(ctx).Error("HasBatchConfirmQuorum", "invalid relayer address", confirm.RelayerAddress, "error", err)
+			return false
+		}
+
+		relayer, found := k.GetRelayer(ctx, relayerAddr)
+		if !found || !relayer.Online {
+			return false
+		}
+
+		confirmPower = confirmPower.Add(relayer.GetPower())
+		return confirmPower.GTE(requiredPower)
+	})
+	return confirmPower.GTE(requiredPower)
 }
 
 func (k Keeper) DeleteBatchConfirm(ctx sdk.Context, batchNonce uint64, tokenContract string) {

--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -110,12 +111,75 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteBatchConfirm() {
 		msgConfirmBatch.ExternalAddress = crypto.PubkeyToAddress(suite.externalPris[i].PublicKey).String()
 		suite.Keeper().SetBatchConfirm(suite.Ctx, relayer, msgConfirmBatch)
 	}
-	suite.Keeper().OutgoingTxBatchExecuted(suite.Ctx, batch.TokenContract, batch.BatchNonce)
+	suite.NoError(suite.Keeper().OutgoingTxBatchExecuted(suite.Ctx, batch.TokenContract, batch.BatchNonce))
 
 	for _, relayer := range suite.relayerAddrs {
 		suite.Nil(suite.Keeper().GetBatchConfirm(suite.Ctx, batch.TokenContract, batch.BatchNonce, relayer))
 	}
 	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, batch.TokenContract, batch.BatchNonce))
+}
+
+func (suite *KeeperTestSuite) TestCleanupTimedOutBatchesPreservesConfirmedBatch() {
+	tokenContract := helpers.GenerateAddress().Hex()
+	for i := range suite.relayerAddrs {
+		suite.Keeper().SetRelayer(suite.Ctx, suite.relayerAddrs[i], types.Relayer{
+			RelayerAddress:  suite.relayerAddrs[i].String(),
+			ExternalAddress: crypto.PubkeyToAddress(suite.externalPris[i].PublicKey).String(),
+			DelegateAmount:  sdk.NewInt(10 * 1e8),
+			Online:          true,
+		})
+	}
+	suite.Keeper().SetLastTotalPower(suite.Ctx)
+
+	batch := &types.OutgoingTxBatch{
+		BatchNonce:   1,
+		BatchTimeout: 10,
+		Transactions: []*types.OutgoingTransferTx{
+			{
+				Id:          1,
+				Sender:      sdk.AccAddress(helpers.GenerateAddress().Bytes()).String(),
+				DestAddress: helpers.GenerateAddress().Hex(),
+				Token: types.ERC20Token{
+					Contract: tokenContract,
+					Amount:   sdkmath.NewInt(1),
+				},
+				Fee: types.ERC20Token{
+					Contract: tokenContract,
+					Amount:   sdkmath.NewInt(1),
+				},
+			},
+		},
+		TokenContract: tokenContract,
+		Block:         uint64(suite.Ctx.BlockHeight()),
+		FeeReceive:    helpers.GenerateAddress().Hex(),
+	}
+	suite.NoError(suite.Keeper().StoreBatch(suite.Ctx, batch))
+
+	msgConfirmBatch := &types.MsgConfirmBatch{
+		Nonce:         batch.BatchNonce,
+		TokenContract: tokenContract,
+		ChainName:     suite.chainName,
+	}
+	for i := 0; i < 7; i++ {
+		msgConfirmBatch.RelayerAddress = suite.relayerAddrs[i].String()
+		msgConfirmBatch.ExternalAddress = crypto.PubkeyToAddress(suite.externalPris[i].PublicKey).String()
+		suite.Keeper().SetBatchConfirm(suite.Ctx, suite.relayerAddrs[i], msgConfirmBatch)
+		if i == 0 {
+			suite.False(suite.Keeper().HasBatchConfirmQuorum(suite.Ctx, batch.BatchNonce, batch.TokenContract))
+		}
+	}
+	suite.True(suite.Keeper().HasBatchConfirmQuorum(suite.Ctx, batch.BatchNonce, batch.TokenContract))
+
+	suite.Keeper().SetLastObservedBlockHeight(suite.Ctx, batch.BatchTimeout+1, uint64(suite.Ctx.BlockHeight()))
+	suite.App.EndBlock(abci.RequestEndBlock{Height: suite.Ctx.BlockHeight()})
+
+	suite.NotNil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, batch.TokenContract, batch.BatchNonce))
+	suite.NotNil(suite.Keeper().GetBatchConfirm(suite.Ctx, batch.TokenContract, batch.BatchNonce, suite.relayerAddrs[0]))
+}
+
+func (suite *KeeperTestSuite) TestOutgoingTxBatchExecutedReturnsErrorForMissingBatch() {
+	err := suite.Keeper().OutgoingTxBatchExecuted(suite.Ctx, helpers.GenerateAddress().Hex(), 99)
+	suite.Error(err)
 }
 
 func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {


### PR DESCRIPTION
## Summary

- Do not cancel a timed-out outgoing batch once stored batch confirmations reach the current Gravity quorum.
- Require quorum-confirmed batch signatures, not just a single confirmation, before skipping timeout cleanup so one low-power confirm cannot freeze a batch forever.
- Return an error instead of panicking when a send-to-external claim references a missing batch, and propagate that error through `AttestationHandler`.
- Add regression coverage for preserving a quorum-confirmed timed-out batch and for the missing-batch error path.

Fixes #285.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Attempted: `..\\..\\tools\\go\\bin\\go.exe test ./x/gravity/keeper -run TestGravityKeeperTestSuite/(TestCleanupTimedOutBatchesPreservesConfirmedBatch|TestOutgoingTxBatchExecutedReturnsErrorForMissingBatch|TestKeeper_DeleteBatchConfirm) -count=1 -v`
  - Blocked before repository tests ran by the current upstream dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`:
    - `undefined: secp256k1.RecoverPubkey`
    - `undefined: secp256k1.VerifySignature`