### PR TITLE
fix(wstaking): dedupe validator updates

### DIFF
--- a/x/wstaking/keeper/val_state_change.go
+++ b/x/wstaking/keeper/val_state_change.go
@@ -163,5 +163,5 @@ func (k Keeper) BlockValidatorUpdates(ctx sdk.Context) []abci.ValidatorUpdate {
 		)
 	}
 
-	return validatorUpdates
+	return deduplicateValidatorUpdates(validatorUpdates)
 }

--- a/x/wstaking/keeper/val_state_change_test.go
+++ b/x/wstaking/keeper/val_state_change_test.go
@@ -1,0 +1,40 @@
+package keeper
+
+import (
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	ed25519 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeduplicateValidatorUpdatesKeepsFinalPubKeyPower(t *testing.T) {
+	oldPubKey, err := cryptocodec.ToTmProtoPublicKey(ed25519.GenPrivKey().PubKey())
+	require.NoError(t, err)
+	newPubKey, err := cryptocodec.ToTmProtoPublicKey(ed25519.GenPrivKey().PubKey())
+	require.NoError(t, err)
+
+	updates := []abci.ValidatorUpdate{
+		{
+			PubKey: oldPubKey,
+			Power:  200,
+		},
+		{
+			PubKey: oldPubKey,
+			Power:  0,
+		},
+		{
+			PubKey: newPubKey,
+			Power:  200,
+		},
+	}
+
+	deduplicated := deduplicateValidatorUpdates(updates)
+
+	require.Len(t, deduplicated, 2)
+	require.Equal(t, oldPubKey, deduplicated[0].PubKey)
+	require.EqualValues(t, 0, deduplicated[0].Power)
+	require.Equal(t, newPubKey, deduplicated[1].PubKey)
+	require.EqualValues(t, 200, deduplicated[1].Power)
+}

--- a/x/wstaking/keeper/validator_update_dedupe.go
+++ b/x/wstaking/keeper/validator_update_dedupe.go
@@ -1,0 +1,38 @@
+package keeper
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+)
+
+func deduplicateValidatorUpdates(validatorUpdates []abci.ValidatorUpdate) []abci.ValidatorUpdate {
+	if len(validatorUpdates) < 2 {
+		return validatorUpdates
+	}
+
+	indexByPubKey := make(map[string]int, len(validatorUpdates))
+	deduplicated := make([]abci.ValidatorUpdate, 0, len(validatorUpdates))
+	for _, update := range validatorUpdates {
+		pubKey := validatorUpdatePubKeyID(update)
+		if index, found := indexByPubKey[pubKey]; found {
+			deduplicated[index] = update
+			continue
+		}
+
+		indexByPubKey[pubKey] = len(deduplicated)
+		deduplicated = append(deduplicated, update)
+	}
+	return deduplicated
+}
+
+func validatorUpdatePubKeyID(update abci.ValidatorUpdate) string {
+	if pubKey := update.PubKey.GetEd25519(); len(pubKey) > 0 {
+		return "ed25519:" + hex.EncodeToString(pubKey)
+	}
+	if pubKey := update.PubKey.GetSecp256K1(); len(pubKey) > 0 {
+		return "secp256k1:" + hex.EncodeToString(pubKey)
+	}
+	return fmt.Sprintf("%v", update.PubKey)
+}


### PR DESCRIPTION
## Summary

- Deduplicate EndBlock validator updates by CometBFT public key before returning them.
- Keep the final update for a duplicated pubkey, so a same-block consensus key replacement can replace an old-key power update with the final old-key `Power: 0` update.
- Add a focused unit test covering the duplicate old-key update plus new-key update sequence.

Fixes #293.

## Validation

- Passed: `..\\..\\tools\\go\\bin\\go.exe test .\\x\\wstaking\\keeper\\validator_update_dedupe.go .\\x\\wstaking\\keeper\\val_state_change_test.go -run TestDeduplicateValidatorUpdatesKeepsFinalPubKeyPower -count=1 -v`
- Passed: `git diff --check`
- Passed: `git diff --cached --check`
- Attempted: `..\\..\\tools\\go\\bin\\go.exe test ./x/wstaking/keeper -run TestDeduplicateValidatorUpdatesKeepsFinalPubKeyPower -count=1 -v`
  - Blocked before package tests ran by the current upstream dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`:
    - `undefined: secp256k1.RecoverPubkey`
    - `undefined: secp256k1.VerifySignature`