### PR TITLE
fix(wasm): block stargate gravity bypass

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -398,7 +398,7 @@ func (a *AppKeepers) InitKeepers(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	availableCapabilities := strings.Join(wasmapp.AllCapabilities(), ",")
+	availableCapabilities := strings.Join(filterWasmCapabilities(wasmapp.AllCapabilities(), "stargate"), ",")
 	a.WasmKeeper = wasmkeeper.NewKeeper(
 		appCodec,
 		a.keys[wasmtypes.StoreKey],

--- a/app/keepers/wasm_capabilities.go
+++ b/app/keepers/wasm_capabilities.go
@@ -1,0 +1,17 @@
+package keepers
+
+func filterWasmCapabilities(capabilities []string, disabled ...string) []string {
+	disabledSet := make(map[string]struct{}, len(disabled))
+	for _, capability := range disabled {
+		disabledSet[capability] = struct{}{}
+	}
+
+	filtered := make([]string, 0, len(capabilities))
+	for _, capability := range capabilities {
+		if _, ok := disabledSet[capability]; ok {
+			continue
+		}
+		filtered = append(filtered, capability)
+	}
+	return filtered
+}

--- a/app/keepers/wasm_capabilities_test.go
+++ b/app/keepers/wasm_capabilities_test.go
@@ -1,0 +1,19 @@
+package keepers
+
+import "testing"
+
+func TestFilterWasmCapabilitiesRemovesDisabledCapabilities(t *testing.T) {
+	capabilities := []string{"iterator", "staking", "stargate", "cosmwasm_1_4"}
+
+	filtered := filterWasmCapabilities(capabilities, "stargate")
+
+	expected := []string{"iterator", "staking", "cosmwasm_1_4"}
+	if len(filtered) != len(expected) {
+		t.Fatalf("expected %d capabilities, got %d: %v", len(expected), len(filtered), filtered)
+	}
+	for i := range expected {
+		if filtered[i] != expected[i] {
+			t.Fatalf("capability %d: expected %q, got %q", i, expected[i], filtered[i])
+		}
+	}
+}

--- a/app/keepers/wasm_me_msg.go
+++ b/app/keepers/wasm_me_msg.go
@@ -62,6 +62,7 @@ func (a *AppKeepers) SetupCustomMsgs() wasmkeeper.Option {
 	// Create KYC custom querier
 
 	return wasmkeeper.WithMessageEncoders(&wasmkeeper.MessageEncoders{
+		Stargate: rejectStargateMsg,
 		Custom: func(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {
 			var meMsg MeMsg
 			if err := json.Unmarshal(msg, &meMsg); err != nil {

--- a/app/keepers/wasm_stargate_policy.go
+++ b/app/keepers/wasm_stargate_policy.go
@@ -1,0 +1,12 @@
+package keepers
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func rejectStargateMsg(_ sdk.AccAddress, _ *wasmvmtypes.StargateMsg) ([]sdk.Msg, error) {
+	return nil, errorsmod.Wrap(wasmtypes.ErrUnknownMsg, "stargate messages are disabled")
+}

--- a/app/keepers/wasm_stargate_policy_test.go
+++ b/app/keepers/wasm_stargate_policy_test.go
@@ -1,0 +1,18 @@
+package keepers
+
+import (
+	"strings"
+	"testing"
+
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+)
+
+func TestRejectStargateMsg(t *testing.T) {
+	_, err := rejectStargateMsg(nil, &wasmvmtypes.StargateMsg{TypeURL: "/metaearth.gravity.v1.MsgSendToExternal"})
+	if err == nil {
+		t.Fatal("expected stargate message to be rejected")
+	}
+	if !strings.Contains(err.Error(), "stargate messages are disabled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/x/gravity/keeper/batch_fee.go
+++ b/x/gravity/keeper/batch_fee.go
@@ -87,6 +87,9 @@ func (k Keeper) AddUnbatchedTxBridgeFee(ctx sdk.Context, txId uint64, sender sdk
 	if err != nil {
 		return errorsmod.Wrapf(types.ErrInvalid, "txId %d not in unbatched index! Must be in a batch!", txId)
 	}
+	if tx.Sender != sender.String() {
+		return errorsmod.Wrapf(types.ErrInvalid, "sender %s did not create bridge tx %d", sender.String(), txId)
+	}
 
 	bridgeToken, err := k.GetBridgeTokenByDenom(ctx, addBridgeFee.Denom)
 	if err != nil {

--- a/x/gravity/keeper/outgoing_tx_pool_test.go
+++ b/x/gravity/keeper/outgoing_tx_pool_test.go
@@ -39,3 +39,33 @@ func (s *KeeperTestSuite) TestKeeper_OutgoingAncCancel() {
 	s.Equal(s.App.BankKeeper.GetAllBalances(s.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 	s.Equal(sendAmount, s.App.BankKeeper.GetSupply(s.Ctx, denom))
 }
+
+func (s *KeeperTestSuite) TestKeeper_AddUnbatchedTxBridgeFeeRequiresTxSender() {
+	sender := helpers.GenerateAddress().Bytes()
+	attacker := helpers.GenerateAddress().Bytes()
+	denom := "test"
+
+	sendAmount := sdk.NewCoin(denom, sdkmath.NewInt(1_000))
+	bridgeFee := sdk.NewCoin(denom, sdkmath.NewInt(100))
+	addBridgeFee := sdk.NewCoin(denom, sdkmath.NewInt(50))
+
+	s.NewBridgeToken(sender, sendAmount.Add(bridgeFee))
+	err := s.App.BankKeeper.MintCoins(s.Ctx, s.chainName, sdk.NewCoins(addBridgeFee))
+	s.NoError(err)
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, s.chainName, attacker, sdk.NewCoins(addBridgeFee))
+	s.NoError(err)
+
+	txID, err := s.Keeper().AddToOutgoingPool(s.Ctx, sender, helpers.GenerateAddress().Hex(), sendAmount, bridgeFee)
+	s.NoError(err)
+	txBefore, err := s.Keeper().GetUnbatchedTxById(s.Ctx, txID)
+	s.NoError(err)
+
+	err = s.Keeper().AddUnbatchedTxBridgeFee(s.Ctx, txID, attacker, addBridgeFee)
+	s.Error(err)
+
+	txAfter, err := s.Keeper().GetUnbatchedTxById(s.Ctx, txID)
+	s.NoError(err)
+	s.Equal(txBefore.Sender, txAfter.Sender)
+	s.Equal(txBefore.Fee, txAfter.Fee)
+	s.Equal(addBridgeFee.Amount.String(), s.App.BankKeeper.GetAllBalances(s.Ctx, attacker).AmountOf(denom).String())
+}


### PR DESCRIPTION
## Summary
- remove the CosmWasm `stargate` capability from the app's available Wasm capabilities
- reject any CosmWasm Stargate message at the message encoder layer before it can reach the SDK router
- require `MsgIncreaseBridgeFee` callers to own the unbatched Gravity bridge transaction before its fee can be increased

Fixes #310

## Tests
- `..\..\tools\go\bin\go.exe test .\app\keepers\wasm_capabilities.go .\app\keepers\wasm_capabilities_test.go -run TestFilterWasmCapabilitiesRemovesDisabledCapabilities -count=1 -v`
- `..\..\tools\go\bin\go.exe test .\app\keepers\wasm_stargate_policy.go .\app\keepers\wasm_stargate_policy_test.go -run TestRejectStargateMsg -count=1 -v`
- `git diff --cached --check`

`..\..\tools\go\bin\go.exe test .\x\gravity\keeper -run TestGravityKeeperTestSuite/TestKeeper_AddUnbatchedTxBridgeFeeRequiresTxSender -count=1 -v` is blocked by the existing Ethermint compile error:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```