### PR TITLE
fix(wstaking): ignore inactive unrelated fixed terms

### DIFF
--- a/x/wstaking/keeper/fixed_deposit_transfer.go
+++ b/x/wstaking/keeper/fixed_deposit_transfer.go
@@ -1,0 +1,30 @@
+package keeper
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func fixedDepositConfigByTerm(configs []types.FixedDepositCfg) map[int64]types.FixedDepositCfg {
+	configByTerm := make(map[int64]types.FixedDepositCfg, len(configs))
+	for _, cfg := range configs {
+		configByTerm[cfg.Term] = cfg
+	}
+	return configByTerm
+}
+
+func validateFixedDepositTransferConfig(configs map[int64]types.FixedDepositCfg, fixed types.FixedDeposit) error {
+	cfg, exists := configs[fixed.Term]
+	if !exists {
+		return fmt.Errorf("deposit cfg not found.fixed.Rate=%s,fixed.Term=%v", fixed.Rate.String(), fixed.Term)
+	}
+	if cfg.Status == types.RegionFixedDepositCfgStatusInactive {
+		return errors.New("fixed deposit cfg status is inactive")
+	}
+	if !cfg.Rate.Equal(fixed.Rate) {
+		return fmt.Errorf("deposit cfg not same.rate=%s,fixed.Rate=%s,exists=%v,fixed.Term=%v", cfg.Rate.String(), fixed.Rate.String(), exists, fixed.Term)
+	}
+	return nil
+}

--- a/x/wstaking/keeper/fixed_deposit_transfer_test.go
+++ b/x/wstaking/keeper/fixed_deposit_transfer_test.go
@@ -1,0 +1,43 @@
+package keeper
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func TestValidateFixedDepositTransferConfigIgnoresInactiveUnrelatedTerms(t *testing.T) {
+	rate := sdk.MustNewDecFromStr("0.1")
+	configs := fixedDepositConfigByTerm([]types.FixedDepositCfg{
+		{Term: 30, Rate: rate, Status: types.RegionFixedDepositCfgStatusActive},
+		{Term: 180, Rate: sdk.MustNewDecFromStr("0.2"), Status: types.RegionFixedDepositCfgStatusInactive},
+	})
+
+	err := validateFixedDepositTransferConfig(configs, types.FixedDeposit{
+		Term: 30,
+		Rate: rate,
+	})
+	if err != nil {
+		t.Fatalf("expected unrelated inactive term to be ignored, got %v", err)
+	}
+}
+
+func TestValidateFixedDepositTransferConfigRejectsInactiveMatchingTerm(t *testing.T) {
+	rate := sdk.MustNewDecFromStr("0.1")
+	configs := fixedDepositConfigByTerm([]types.FixedDepositCfg{
+		{Term: 30, Rate: rate, Status: types.RegionFixedDepositCfgStatusInactive},
+	})
+
+	err := validateFixedDepositTransferConfig(configs, types.FixedDeposit{
+		Term: 30,
+		Rate: rate,
+	})
+	if err == nil {
+		t.Fatal("expected inactive matching term to be rejected")
+	}
+	if !strings.Contains(err.Error(), "fixed deposit cfg status is inactive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -294,22 +294,15 @@ func (k Keeper) transferDeposit(ctx sdk.Context, fromRegion, toRegion *types.Reg
 	}
 	//It is a regional rule used to define parameters such as fixed deposit term and interest rate for a certain region.
 	depositConfig := k.GetAllFixedDepositCfg(ctx, toRegion.RegionId)
-	depositConfigMap := make(map[int64]sdk.Dec)
-	for _, cfg := range depositConfig {
-		if cfg.Status == types.RegionFixedDepositCfgStatusInactive {
-			return errors.New("fixed deposit cfg status is inactive")
-		}
-		depositConfigMap[cfg.Term] = cfg.Rate
-	}
+	depositConfigMap := fixedDepositConfigByTerm(depositConfig)
 	totalFixedDepositByAcc := sdk.ZeroInt()
 	totalFixedInterestCoin := sdk.ZeroInt()
 	for _, fixed := range fixedDeposits {
 		totalFixedDepositByAcc = totalFixedDepositByAcc.Add(fixed.Principal.Amount)
 		totalFixedInterestCoin = totalFixedInterestCoin.Add(fixed.Interest.Amount)
 		//check toRegion deposit config is exist and deposit rate is equal
-		rate, exists := depositConfigMap[fixed.Term]
-		if !exists || !rate.Equal(fixed.Rate) {
-			return errors.New(fmt.Sprintf("deposit cfg not same.rate=%s,fixed.Rate=%s,exists=%v,fixed.Term=%v", rate.String(), fixed.Rate.String(), exists, fixed.Term))
+		if err := validateFixedDepositTransferConfig(depositConfigMap, fixed); err != nil {
+			return err
 		}
 
 		err := k.IncreaseFixedDepositCountOfCfg(ctx, toRegion.RegionId, fixed.Term)


### PR DESCRIPTION
## Summary
- build target-region fixed-deposit config lookup by term during KYC region transfer
- validate only the config for each fixed deposit the migrating user actually owns
- keep rejecting missing, inactive, or rate-mismatched matching terms while ignoring unrelated inactive terms

Fixes #1009

## Tests
- `..\..\tools\go\bin\go.exe test .\x\wstaking\keeper\fixed_deposit_transfer.go .\x\wstaking\keeper\fixed_deposit_transfer_test.go -run TestValidateFixedDepositTransferConfig -count=1 -v`
- `git diff --check`
- `git diff --cached --check`

`..\..\tools\go\bin\go.exe test .\x\wstaking\keeper -run TestKeeperTestSuite/TestTransferKycRegion -count=1 -v` is blocked before repository tests run by the existing Ethermint compile error:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```