### PR TITLE
fix(ante): reject oversized gas limits

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -345,6 +345,9 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 
 	feeCoins := feeTx.GetFee()
 	gas := feeTx.GetGas()
+	if gas > uint64(math.MaxInt64) {
+		return nil, 0, sdkerrors.Wrapf(sdkerrors.ErrInvalidGasLimit, "tx gas limit %d exceeds max supported gas %d", gas, uint64(math.MaxInt64))
+	}
 
 	// Ensure that the provided fees meet a minimum threshold for the validator,
 	// if this is a CheckTx. This is only for local mempool purposes, and thus

--- a/app/ante/fee_deduct_internal_test.go
+++ b/app/ante/fee_deduct_internal_test.go
@@ -1,0 +1,41 @@
+package ante
+
+import (
+	"math"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/stretchr/testify/require"
+)
+
+type feeCheckerTestTx struct {
+	fee sdk.Coins
+	gas uint64
+}
+
+func (tx feeCheckerTestTx) GetMsgs() []sdk.Msg       { return nil }
+func (tx feeCheckerTestTx) ValidateBasic() error     { return nil }
+func (tx feeCheckerTestTx) GetGas() uint64           { return tx.gas }
+func (tx feeCheckerTestTx) GetFee() sdk.Coins        { return tx.fee }
+func (tx feeCheckerTestTx) FeePayer() sdk.AccAddress { return nil }
+func (tx feeCheckerTestTx) FeeGranter() sdk.AccAddress {
+	return nil
+}
+
+func TestCheckTxFeeRejectsGasAboveMaxInt64(t *testing.T) {
+	ctx := sdk.Context{}.
+		WithIsCheckTx(true).
+		WithMinGasPrices(sdk.NewDecCoins(sdk.NewDecCoin(params.BaseDenom, sdk.OneInt())))
+	tx := feeCheckerTestTx{
+		fee: sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(10_000))),
+		gas: uint64(math.MaxInt64) + 1,
+	}
+
+	var err error
+	require.NotPanics(t, func() {
+		_, _, err = checkTxFeeWithValidatorMinGasPrices(ctx, tx)
+	})
+	require.ErrorIs(t, err, sdkerrors.ErrInvalidGasLimit)
+}


### PR DESCRIPTION
## Summary
- reject fee tx gas limits above `math.MaxInt64` before narrowing `uint64` gas to `int64`
- return `ErrInvalidGasLimit` instead of allowing negative required-fee coin construction to panic
- add an internal fee-checker regression test for `math.MaxInt64 + 1`

Fixes #417

## Tests
- `..\..\tools\go\bin\go.exe test .\app\ante\fee_deduct.go .\app\ante\expected_keepers.go .\app\ante\fee_deduct_internal_test.go -run TestCheckTxFeeRejectsGasAboveMaxInt64 -count=1 -v`
- `git diff --check`
- `git diff --cached --check`

`..\..\tools\go\bin\go.exe test .\app\ante -run TestCheckTxFeeRejectsGasAboveMaxInt64 -count=1 -v` is blocked before repository tests run by the existing Ethermint compile error:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```