### PR TITLE
fix(rollapp): reject frozen state updates

### DIFF
--- a/x/rollapp/keeper/msg_server_update_state.go
+++ b/x/rollapp/keeper/msg_server_update_state.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/openmetaearth/me-hub/x/rollapp/types"
+	sequencertypes "github.com/openmetaearth/me-hub/x/sequencer/types"
 )
 
 func (k msgServer) UpdateState(goCtx context.Context, msg *types.MsgUpdateState) (*types.MsgUpdateStateResponse, error) {
@@ -24,6 +25,9 @@ func (k msgServer) UpdateState(goCtx context.Context, msg *types.MsgUpdateState)
 	rollapp, isFound := k.GetRollapp(ctx, msg.RollappId)
 	if !isFound {
 		return nil, types.ErrUnknownRollappID
+	}
+	if rollapp.Frozen {
+		return nil, sequencertypes.ErrRollappJailed
 	}
 
 	// check rollapp version

--- a/x/rollapp/keeper/msg_server_update_state_test.go
+++ b/x/rollapp/keeper/msg_server_update_state_test.go
@@ -249,6 +249,44 @@ func (suite *RollappTestSuite) TestUpdateStateUnknownSequencer() {
 	suite.ErrorIs(err, sequencertypes.ErrUnknownSequencer)
 }
 
+func (suite *RollappTestSuite) TestFrozenRollappRejectsUpdateState() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollapp := types.Rollapp{
+		RollappId:     "rollapp1",
+		Creator:       alice,
+		Version:       3,
+		MaxSequencers: 1,
+		Frozen:        true,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	sequencer := sequencertypes.Sequencer{
+		SequencerAddress: bob,
+		RollappId:        rollapp.GetRollappId(),
+		Status:           sequencertypes.Bonded,
+		Proposer:         true,
+	}
+	suite.App.SequencerKeeper.SetSequencer(suite.Ctx, sequencer)
+
+	updateState := types.MsgUpdateState{
+		Creator:     bob,
+		RollappId:   rollapp.GetRollappId(),
+		StartHeight: 1,
+		NumBlocks:   3,
+		DAPath:      "",
+		Version:     3,
+		BDs:         types.BlockDescriptors{BD: []types.BlockDescriptor{{Height: 1}, {Height: 2}, {Height: 3}}},
+	}
+
+	_, err := suite.msgServer.UpdateState(goCtx, &updateState)
+	suite.ErrorIs(err, sequencertypes.ErrRollappJailed)
+
+	_, found := suite.App.RollappKeeper.GetLatestStateInfoIndex(suite.Ctx, rollapp.GetRollappId())
+	suite.Require().False(found)
+}
+
 func (suite *RollappTestSuite) TestUpdateStateSequencerRollappMismatch() {
 	suite.SetupTest()
 	goCtx := sdk.WrapSDKContext(suite.Ctx)


### PR DESCRIPTION
## Summary
- reject `MsgUpdateState` when the target RollApp is already frozen
- return the existing `ErrRollappJailed` used by sequencer frozen-RollApp entry points
- add regression coverage proving frozen RollApps do not write latest state index data

Fixes #1012

## Tests
- `git diff --check`
- `git diff --cached --check`

`..\..\tools\go\bin\go.exe test .\x\rollapp\keeper -run TestRollappKeeperTestSuite/TestFrozenRollappRejectsUpdateState -count=1 -v` is blocked before repository tests run by the existing Ethermint compile error:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```