### PR TITLE
fix(wdistri): preserve large reward amounts

### DIFF
--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -101,7 +101,7 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		// calculate every region coins: RegionShare * totalMintCoins / totalRegionShare
 		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(totalMintCoin.AmountOf(params.BaseDenom).ToLegacyDec()).Quo(totalRegionShareDec)
 		regionAmount := amount.TruncateInt()
-		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
+		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, regionAmount))
 		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()), regionCoins)
 		if err != nil {
 			return err

--- a/x/wdistri/keeper/keeper_test.go
+++ b/x/wdistri/keeper/keeper_test.go
@@ -9,6 +9,7 @@ import (
 	wbanktypes "github.com/openmetaearth/me-hub/x/wbank/types"
 	"github.com/openmetaearth/me-hub/x/wdistri/types"
 	"github.com/openmetaearth/me-hub/x/wdistri/types/mock"
+	"math/big"
 	"testing"
 
 	"github.com/openmetaearth/me-hub/app/params"
@@ -215,7 +216,7 @@ func (suite *KeeperTestSuite) TestEndBlocker() {
 		totalWantReward := 0
 		for i, addr := range addrs {
 			wantReward = append(wantReward, coinAndAddr{
-				num:  int64(testcase.regionWantGetReward[i]),
+				num:  sdk.NewInt(int64(testcase.regionWantGetReward[i])),
 				addr: addr,
 			})
 			totalWantReward += testcase.regionWantGetReward[i]
@@ -235,6 +236,22 @@ func (suite *KeeperTestSuite) TestEndBlocker() {
 			runCase(i)
 		})
 	}
+}
+
+func (suite *KeeperTestSuite) TestAllocateBlockRewardHandlesLargeTreasuryAmount() {
+	ctx := suite.HelperNewContextWith(types.OneDayTotalBlocks)
+	addrs := suite.mockGetRegionI(ctx, 1)
+	largeAmount := sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(19), nil))
+
+	suite.SetMockGetBalance(ctx, largeAmount)
+	suite.setMockSendCoinsFromModuleToAccountExpect(ctx, coinAndAddr{
+		num:  largeAmount,
+		addr: addrs[0],
+	})
+
+	err := suite.App.DistrKeeper.AllocateBlockReward(ctx)
+	suite.Require().NoError(err)
+	suite.Require().Len(ctx.EventManager().ABCIEvents(), 1)
 }
 
 func (suite *KeeperTestSuite) mockGetRegionI(ctx sdk.Context, regionShare ...int) []string {
@@ -267,7 +284,7 @@ func (suite *KeeperTestSuite) HelperNewContextWith(height int64) sdk.Context {
 }
 
 type coinAndAddr struct {
-	num  int64
+	num  sdkmath.Int
 	addr string
 }
 
@@ -279,7 +296,7 @@ func (suite *KeeperTestSuite) setMockSendCoinsFromModuleToAccountExpect(ctx sdk.
 				ctx,
 				suite.App.DistrKeeper.GetTreasuryModuleAccount(),
 				sdk.MustAccAddressFromBech32(w.addr),
-				sdk.NewCoins(sdk.NewCoin(baseDenom, sdk.NewInt(w.num))),
+				sdk.NewCoins(sdk.NewCoin(baseDenom, w.num)),
 			).Return(nil)
 	}
 }


### PR DESCRIPTION
## Summary
- avoid narrowing `regionAmount` through `Int64()` during wdistri block-reward allocation
- send the truncated SDK integer amount directly as the region reward coin
- extend the reward expectation helper and add a regression test for a treasury balance above `math.MaxInt64`

## Validation
- `..\..\tools\go\bin\go.exe test .\x\wdistri\keeper -run TestKeeperTestSuite/TestAllocateBlockRewardHandlesLargeTreasuryAmount -count=1 -v` was attempted, but package compilation is currently blocked by the upstream Ethermint dependency error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`
- `git diff --check`
- `git diff --cached --check`

Fixes #165