### PR TITLE
fix(app): allow bridge fee pool receipts

### DIFF
--- a/app/keepers/modules.go
+++ b/app/keepers/modules.go
@@ -142,6 +142,9 @@ func (a *AppKeepers) SetupModules(
 func (*AppKeepers) ModuleAccountAddrs() map[string]bool {
 	modAccAddrs := make(map[string]bool)
 	for acc := range MaccPerms {
+		if acc == wstakingtypes.BridgeFeePool {
+			continue
+		}
 		modAccAddrs[authtypes.NewModuleAddress(acc).String()] = true
 	}
 	return modAccAddrs

--- a/app/keepers/modules_test.go
+++ b/app/keepers/modules_test.go
@@ -1,0 +1,26 @@
+package keepers
+
+import (
+	"testing"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func TestModuleAccountAddrsAllowsBridgeFeePoolReceives(t *testing.T) {
+	blockedAddrs := (&AppKeepers{}).ModuleAccountAddrs()
+	bridgeFeePoolAddr := authtypes.NewModuleAddress(types.BridgeFeePool).String()
+
+	if blockedAddrs[bridgeFeePoolAddr] {
+		t.Fatalf("bridge fee pool must be able to receive configured bridge fees")
+	}
+
+	feeCollectorAddr := authtypes.NewModuleAddress(authtypes.FeeCollectorName).String()
+	if !blockedAddrs[feeCollectorAddr] {
+		t.Fatalf("unrelated module accounts should remain blocked")
+	}
+
+	if _, ok := MaccPerms[types.BridgeFeePool]; !ok {
+		t.Fatalf("bridge fee pool should remain a module account")
+	}
+}


### PR DESCRIPTION
## Summary
- keep `bridge_fee_pool` as a module account while excluding it from the bank blocked-address map
- allow configured rollapp bridge-fee transfers to credit the production fee-pool receiver instead of being rejected and silently waived
- add a regression test proving `bridge_fee_pool` can receive while unrelated module accounts remain blocked

Fixes #196

## Validation
- `..\..\tools\go\bin\go.exe test .\app\keepers -run TestModuleAccountAddrsAllowsBridgeFeePoolReceives -count=1 -v`
- `..\..\tools\go\bin\go.exe test .\x\bridgingfee -count=1`
- `git diff --check`
- `git diff --cached --check`