### PR TITLE
fix(wstaking): route ibc treasury transfers to receiver

### DIFF
--- a/proto/metaearth/wstaking/tx.proto
+++ b/proto/metaearth/wstaking/tx.proto
@@ -316,7 +316,7 @@ message MsgIbcTransferFromRegionTreasure {
   cosmos.base.v1beta1.Coin token = 4 [(gogoproto.nullable) = false];
 
   // the recipient address on the destination chain
-  // string receiver = 5;
+  string receiver = 5;
   // Timeout height relative to the current block height.
   // The timeout is disabled when set to 0.
   Height timeout_height = 6 [

--- a/x/wstaking/client/cli/tx_ibc_transfer_from_region_treasure.go
+++ b/x/wstaking/client/cli/tx_ibc_transfer_from_region_treasure.go
@@ -32,16 +32,16 @@ const (
 // NewTransferTxCmd returns the command to create a NewMsgTransfer transaction
 func NewIbcTransferFromRegionTreasureCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ibc-transfer-from-region-treasure [src-port] [src-channel] [region] [amount]",
-		Short: "Transfer tokens from the region's treasure to a same receiver on another chain",
+		Use:   "ibc-transfer-from-region-treasure [src-port] [src-channel] [region] [receiver] [amount]",
+		Short: "Transfer tokens from the region's treasure to a receiver on another chain",
 		Long: strings.TrimSpace(`Transfer a fungible token through IBC. Timeouts can be specified
 as absolute or relative using the "absolute-timeouts" flag. Timeout height can be set by passing in the height string
 in the form {revision}-{height} using the "packet-timeout-height" flag. Relative timeout height is added to the block
 height queried from the latest consensus state corresponding to the counterparty channel. Relative timeout timestamp 
 is added to the greater value of the local clock time and the block timestamp queried from the latest consensus state 
 corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
-		Example: fmt.Sprintf("%s tx ibc-transfer-from-region-treasure transfer [src-port] [src-channel] [region] [amount]", version.AppName),
-		Args:    cobra.ExactArgs(4),
+		Example: fmt.Sprintf("%s tx ibc-transfer-from-region-treasure transfer [src-port] [src-channel] [region] [receiver] [amount]", version.AppName),
+		Args:    cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -51,8 +51,9 @@ corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
 			srcPort := args[0]
 			srcChannel := args[1]
 			region := args[2]
+			receiver := args[3]
 
-			coin, err := sdk.ParseCoinNormalized(args[3])
+			coin, err := sdk.ParseCoinNormalized(args[4])
 			if err != nil {
 				return err
 			}
@@ -152,6 +153,7 @@ corresponding to the counterparty channel. Any timeout set to 0 is disabled.`),
 				srcPort,
 				srcChannel,
 				region,
+				receiver,
 				coin,
 				types.Height{RevisionNumber: timeoutHeight.RevisionNumber, RevisionHeight: timeoutHeight.RevisionHeight},
 				timeoutTimestamp,

--- a/x/wstaking/keeper/msg_server_ibc_transfer_from_region_treasure.go
+++ b/x/wstaking/keeper/msg_server_ibc_transfer_from_region_treasure.go
@@ -30,7 +30,7 @@ func (k MsgServer) IbcTransferFromRegionTreasure(goCtx context.Context, msg *typ
 		msg.SourceChannel,
 		msg.Token,
 		treasureAddress,
-		treasureAddress,
+		msg.Receiver,
 		ibcclienttypes.Height{RevisionNumber: msg.TimeoutHeight.RevisionNumber, RevisionHeight: msg.TimeoutHeight.RevisionHeight},
 		msg.TimeoutTimestamp,
 		msg.Memo,

--- a/x/wstaking/types/message_ibc_transfer_from_region_treasure.go
+++ b/x/wstaking/types/message_ibc_transfer_from_region_treasure.go
@@ -15,12 +15,13 @@ const TypeMsgIbcTransferFromRegionTreasure = "ibc_transfer_from_region_treasure"
 
 var _ sdk.Msg = &MsgIbcTransferFromRegionTreasure{}
 
-func NewMsgIbcTransferFromRegionTreasure(sourcePort, sourceChannel, regionId string, amount sdk.Coin, timeoutHeight Height, timeoutTimestamp uint64, momo, creator string) *MsgIbcTransferFromRegionTreasure {
+func NewMsgIbcTransferFromRegionTreasure(sourcePort, sourceChannel, regionId, receiver string, amount sdk.Coin, timeoutHeight Height, timeoutTimestamp uint64, momo, creator string) *MsgIbcTransferFromRegionTreasure {
 	return &MsgIbcTransferFromRegionTreasure{
 		SourcePort:       sourcePort,
 		SourceChannel:    sourceChannel,
 		RegionId:         regionId,
 		Token:            amount,
+		Receiver:         receiver,
 		TimeoutHeight:    timeoutHeight,
 		TimeoutTimestamp: timeoutTimestamp,
 		Memo:             momo,
@@ -64,6 +65,9 @@ func (msg *MsgIbcTransferFromRegionTreasure) ValidateBasic() error {
 	}
 	if !msg.Token.IsPositive() {
 		return sdkerrors.Wrap(sdkerrors.ErrInsufficientFunds, msg.Token.String())
+	}
+	if strings.TrimSpace(msg.Receiver) == "" {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "receiver address cannot be empty")
 	}
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {

--- a/x/wstaking/types/message_ibc_transfer_from_region_treasure_test.go
+++ b/x/wstaking/types/message_ibc_transfer_from_region_treasure_test.go
@@ -3,7 +3,9 @@ package types
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
@@ -17,13 +19,33 @@ func TestMsgIbcTransferFromRegionTreasure_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgIbcTransferFromRegionTreasure{
-				Creator: "invalid_address",
+				SourcePort:    "transfer",
+				SourceChannel: "channel-0",
+				RegionId:      MeEarthRegionName,
+				Token:         sdk.NewCoin(params.BaseDenom, sdk.NewInt(1)),
+				Receiver:      "cosmos1destination",
+				Creator:       "invalid_address",
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		}, {
-			name: "valid address",
+			name: "empty receiver",
 			msg: MsgIbcTransferFromRegionTreasure{
-				Creator: sample.AccAddress(),
+				SourcePort:    "transfer",
+				SourceChannel: "channel-0",
+				RegionId:      MeEarthRegionName,
+				Token:         sdk.NewCoin(params.BaseDenom, sdk.NewInt(1)),
+				Creator:       sample.AccAddress(),
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		}, {
+			name: "valid message",
+			msg: MsgIbcTransferFromRegionTreasure{
+				SourcePort:    "transfer",
+				SourceChannel: "channel-0",
+				RegionId:      MeEarthRegionName,
+				Token:         sdk.NewCoin(params.BaseDenom, sdk.NewInt(1)),
+				Receiver:      "cosmos1destination",
+				Creator:       sample.AccAddress(),
 			},
 		},
 	}
@@ -37,4 +59,25 @@ func TestMsgIbcTransferFromRegionTreasure_ValidateBasic(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestMsgIbcTransferFromRegionTreasureMarshalPreservesReceiver(t *testing.T) {
+	msg := NewMsgIbcTransferFromRegionTreasure(
+		"transfer",
+		"channel-0",
+		MeEarthRegionName,
+		"cosmos1destination",
+		sdk.NewCoin(params.BaseDenom, sdk.NewInt(1)),
+		Height{},
+		0,
+		"",
+		sample.AccAddress(),
+	)
+
+	bz, err := msg.Marshal()
+	require.NoError(t, err)
+
+	var decoded MsgIbcTransferFromRegionTreasure
+	require.NoError(t, decoded.Unmarshal(bz))
+	require.Equal(t, msg.Receiver, decoded.Receiver)
 }

--- a/x/wstaking/types/tx.pb.go
+++ b/x/wstaking/types/tx.pb.go
@@ -1879,7 +1879,7 @@ type MsgIbcTransferFromRegionTreasure struct {
 	// the tokens to be transferred
 	Token types1.Coin `protobuf:"bytes,4,opt,name=token,proto3" json:"token"`
 	// the recipient address on the destination chain
-	// string receiver = 5;
+	Receiver string `protobuf:"bytes,5,opt,name=receiver,proto3" json:"receiver,omitempty"`
 	// Timeout height relative to the current block height.
 	// The timeout is disabled when set to 0.
 	TimeoutHeight Height `protobuf:"bytes,6,opt,name=timeout_height,json=timeoutHeight,proto3" json:"timeout_height" yaml:"timeout_height"`
@@ -4951,6 +4951,13 @@ func (m *MsgIbcTransferFromRegionTreasure) MarshalToSizedBuffer(dAtA []byte) (in
 	}
 	i--
 	dAtA[i] = 0x32
+	if len(m.Receiver) > 0 {
+		i -= len(m.Receiver)
+		copy(dAtA[i:], m.Receiver)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Receiver)))
+		i--
+		dAtA[i] = 0x2a
+	}
 	{
 		size, err := m.Token.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
@@ -5985,6 +5992,10 @@ func (m *MsgIbcTransferFromRegionTreasure) Size() (n int) {
 	}
 	l = m.Token.Size()
 	n += 1 + l + sovTx(uint64(l))
+	l = len(m.Receiver)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
 	l = m.TimeoutHeight.Size()
 	n += 1 + l + sovTx(uint64(l))
 	if m.TimeoutTimestamp != 0 {
@@ -10421,6 +10432,38 @@ func (m *MsgIbcTransferFromRegionTreasure) Unmarshal(dAtA []byte) error {
 			if err := m.Token.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Receiver", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Receiver = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 6:
 			if wireType != 2 {


### PR DESCRIPTION
## Summary
- restore the `receiver` field on `MsgIbcTransferFromRegionTreasure`
- make the treasury IBC transfer send from the region treasury to the caller-specified destination-chain receiver instead of sending back to the treasury address
- update the CLI to require `[receiver]`, reject empty receivers in `ValidateBasic`, and add receiver marshal/unmarshal regression coverage

Fixes #220

## Validation
- `..\..\tools\go\bin\go.exe test .\x\wstaking\types -run TestMsgIbcTransferFromRegionTreasure -count=1 -v`
- `..\..\tools\go\bin\go.exe test .\x\wstaking\types -count=1`
- `..\..\tools\go\bin\go.exe test .\x\wstaking\client\cli -count=1`
- `git diff --check`
- `git diff --cached --check`

## Note
- `..\..\tools\go\bin\go.exe test .\x\wstaking\keeper -run TestKeeperTestSuite/TestIbcTransferFromRegionTreasure -count=1 -v` is currently blocked before package tests by the repository dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.