### PR TITLE
fix(sequencer): clear stale replace proposer

### DIFF
--- a/x/sequencer/keeper/hook_listener.go
+++ b/x/sequencer/keeper/hook_listener.go
@@ -1,7 +1,9 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
@@ -56,6 +58,10 @@ func (hook rollappHook) AfterStateFinalized(ctx sdk.Context, rollappID string, s
 				hook.k.Logger(ctx).Error("forceRemoveUnbondingSequencer error.", "sequencer", val.ReplaceProposer.OldProposer,
 					"rollapp", rollappID, "state_block_info", fmt.Sprintf("%d-%d", stateInfo.StartHeight,
 						stateInfo.StartHeight+stateInfo.NumBlocks-1), "error", err.Error())
+				if errors.Is(err, types.ErrUnknownSequencer) || errors.Is(err, types.ErrInvalidSequencerStatus) {
+					hook.k.DeleteReplaceProposer(ctx, rollappID)
+					return nil
+				}
 				return fmt.Errorf("forceRemoveUnbondingSequencer error in AfterStateFinalized.sequencer=%s,"+
 					" rollapp = %s, err = %s", val.ReplaceProposer.OldProposer, rollappID, err.Error())
 			}

--- a/x/sequencer/keeper/replace_proposer.go
+++ b/x/sequencer/keeper/replace_proposer.go
@@ -146,6 +146,10 @@ func (k Keeper) ProcSequencerByPendingStates(ctx sdk.Context, rollappId, creator
 			)
 			return nil
 		} else {
+			k.Logger(ctx).Info("ProcSequencerByPendingStates cleared stale ReplaceProposer.",
+				"rollapp", rollappId, "old_sequencer", val.ReplaceProposer.OldProposer,
+				"old_status", oldSequencer.Status, "old_proposer", oldSequencer.Proposer)
+			k.DeleteReplaceProposer(ctx, rollappId)
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary
- clear pending `ReplaceProposer` records when the old proposer is already invalid during pending-state processing
- clear the pending record after finalization when force-removal fails because the old sequencer is already unknown or no longer unbonding
- keep returning non-stale force-remove errors, such as bank transfer failures, so real fund-return problems are not hidden

Fixes #228

## Validation
- `..\..\tools\go\bin\go.exe test .\x\sequencer\types -count=1`
- `git diff --check`
- `git diff --cached --check`

## Note
- `..\..\tools\go\bin\go.exe test .\x\sequencer\keeper -run TestSequencerKeeperTestSuite/TestReplaceProposer -count=1 -v` is currently blocked before package tests by the repository dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.