### PR TITLE
fix(wstaking): export pending consensus key replacements

### DIFF
--- a/proto/metaearth/wstaking/genesis.proto
+++ b/proto/metaearth/wstaking/genesis.proto
@@ -70,6 +70,8 @@ message GenesisState {
   repeated FixedDeposit fixedDepositList = 11 [(gogoproto.nullable) = false];
   uint64 fixedDepositCount = 12;
   bool exported = 13;
+  // replace_consensus_pubkey stores a pending consensus-key replacement plan.
+  bytes replace_consensus_pubkey = 14;
 }
 
 // LastValidatorPower required for validator set update logic.

--- a/x/wstaking/keeper/genesis.go
+++ b/x/wstaking/keeper/genesis.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"cosmossdk.io/math"
+	"encoding/json"
 	"fmt"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -29,6 +30,16 @@ func (k Keeper) InitGenesis(ctx sdk.Context, data *wstakingtypes.GenesisState) (
 		panic(err)
 	}
 	k.SetLastTotalPower(ctx, data.LastTotalPower)
+
+	if len(data.ReplaceConsensusPubKey) > 0 {
+		updateInfo := wstakingtypes.UpdatePubKeyInfo{}
+		if err := json.Unmarshal(data.ReplaceConsensusPubKey, &updateInfo); err != nil {
+			panic(fmt.Sprintf("unmarshal replace consensus pubkey genesis data: %s", err))
+		}
+		if err := k.SetReplacePubKeyInfo(ctx, &updateInfo); err != nil {
+			panic(err)
+		}
+	}
 
 	for _, validator := range data.Validators {
 		k.SetValidator(ctx, validator)
@@ -182,19 +193,32 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *wstakingtypes.GenesisState {
 		return false
 	})
 
+	updateInfo, err := k.GetReplaceConsensusPubKeyInfo(ctx)
+	if err != nil {
+		panic(err)
+	}
+	var replaceConsensusPubKey []byte
+	if updateInfo != nil {
+		replaceConsensusPubKey, err = json.Marshal(updateInfo)
+		if err != nil {
+			panic(fmt.Sprintf("marshal replace consensus pubkey genesis data: %s", err))
+		}
+	}
+
 	return &wstakingtypes.GenesisState{
-		Params:               k.GetParams(ctx),
-		LastTotalPower:       k.GetLastTotalPower(ctx),
-		LastValidatorPowers:  lastValidatorPowers,
-		Validators:           k.GetAllValidators(ctx),
-		Delegations:          k.GetAllDelegations(ctx),
-		UnbondingDelegations: unbondingDelegations,
-		Redelegations:        redelegations,
-		Stakes:               k.GetAllStakes(ctx),
-		UnbondingStakes:      unbondingStakes,
-		Regions:              k.GetAllRegion(ctx),
-		FixedDepositList:     k.GetAllFixedDeposit(ctx),
-		FixedDepositCount:    k.GetFixedDepositCount(ctx),
-		Exported:             true,
+		Params:                 k.GetParams(ctx),
+		LastTotalPower:         k.GetLastTotalPower(ctx),
+		LastValidatorPowers:    lastValidatorPowers,
+		Validators:             k.GetAllValidators(ctx),
+		Delegations:            k.GetAllDelegations(ctx),
+		UnbondingDelegations:   unbondingDelegations,
+		Redelegations:          redelegations,
+		Stakes:                 k.GetAllStakes(ctx),
+		UnbondingStakes:        unbondingStakes,
+		Regions:                k.GetAllRegion(ctx),
+		FixedDepositList:       k.GetAllFixedDeposit(ctx),
+		FixedDepositCount:      k.GetFixedDepositCount(ctx),
+		Exported:               true,
+		ReplaceConsensusPubKey: replaceConsensusPubKey,
 	}
 }

--- a/x/wstaking/types/genesis.pb.go
+++ b/x/wstaking/types/genesis.pb.go
@@ -53,6 +53,8 @@ type GenesisState struct {
 	FixedDepositList  []FixedDeposit   `protobuf:"bytes,11,rep,name=fixedDepositList,proto3" json:"fixedDepositList"`
 	FixedDepositCount uint64           `protobuf:"varint,12,opt,name=fixedDepositCount,proto3" json:"fixedDepositCount,omitempty"`
 	Exported          bool             `protobuf:"varint,13,opt,name=exported,proto3" json:"exported,omitempty"`
+	// replace_consensus_pubkey stores a pending consensus-key replacement plan.
+	ReplaceConsensusPubKey []byte `protobuf:"bytes,14,opt,name=replace_consensus_pubkey,json=replaceConsensusPubkey,proto3" json:"replace_consensus_pubkey,omitempty"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -172,6 +174,13 @@ func (m *GenesisState) GetExported() bool {
 	return false
 }
 
+func (m *GenesisState) GetReplaceConsensusPubKey() []byte {
+	if m != nil {
+		return m.ReplaceConsensusPubKey
+	}
+	return nil
+}
+
 // LastValidatorPower required for validator set update logic.
 type LastValidatorPower struct {
 	// address is the address of the validator.
@@ -286,6 +295,13 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.ReplaceConsensusPubKey) > 0 {
+		i -= len(m.ReplaceConsensusPubKey)
+		copy(dAtA[i:], m.ReplaceConsensusPubKey)
+		i = encodeVarintGenesis(dAtA, i, uint64(len(m.ReplaceConsensusPubKey)))
+		i--
+		dAtA[i] = 0x72
+	}
 	if m.Exported {
 		i--
 		if m.Exported {
@@ -565,6 +581,10 @@ func (m *GenesisState) Size() (n int) {
 	}
 	if m.Exported {
 		n += 2
+	}
+	if len(m.ReplaceConsensusPubKey) > 0 {
+		l = len(m.ReplaceConsensusPubKey)
+		n += 1 + l + sovGenesis(uint64(l))
 	}
 	return n
 }
@@ -1031,6 +1051,40 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Exported = bool(v != 0)
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplaceConsensusPubKey", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ReplaceConsensusPubKey = append(m.ReplaceConsensusPubKey[:0], dAtA[iNdEx:postIndex]...)
+			if m.ReplaceConsensusPubKey == nil {
+				m.ReplaceConsensusPubKey = []byte{}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenesis(dAtA[iNdEx:])

--- a/x/wstaking/types/genesis_test.go
+++ b/x/wstaking/types/genesis_test.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisStateMarshalPreservesReplaceConsensusPubKey(t *testing.T) {
+	pendingReplace := []byte(`{"operator_address":"meta1operator","old_cons_address":"b2xkLWtleQ==","pub_key":"bmV3LWtleQ==","update_at_height":42}`)
+	genesis := DefaultGenesisState()
+	genesis.LastTotalPower = sdk.ZeroInt()
+	genesis.ReplaceConsensusPubKey = pendingReplace
+
+	bz, err := genesis.Marshal()
+	require.NoError(t, err)
+
+	var got GenesisState
+	require.NoError(t, got.Unmarshal(bz))
+	require.Equal(t, pendingReplace, got.GetReplaceConsensusPubKey())
+
+	protoBz, err := proto.Marshal(genesis)
+	require.NoError(t, err)
+
+	var protoGot GenesisState
+	require.NoError(t, proto.Unmarshal(protoBz, &protoGot))
+	require.Equal(t, pendingReplace, protoGot.GetReplaceConsensusPubKey())
+}


### PR DESCRIPTION
Summary
- Add a genesis field for the pending ReplaceConsensusPubKey plan so export/import preserves it.
- Restore the pending plan during InitGenesis and populate it during ExportGenesis using the keeper's existing JSON representation.
- Add a regression test covering GenesisState marshal/unmarshal and gogo proto marshal/unmarshal preservation.

Tests
- ..\..\tools\go\bin\go.exe test .\x\wstaking\types -run TestGenesisStateMarshalPreservesReplaceConsensusPubKey -count=1 -v
- ..\..\tools\go\bin\go.exe test .\x\wstaking\types -count=1 (fails on existing MsgIbcTransferFromRegionTreasure test: missing source port/channel/region/token fields)
- ..\..\tools\go\bin\go.exe test .\x\wstaking\keeper -run TestGenesisStateMarshalPreservesReplaceConsensusPubKey -count=1 -v (blocked by existing Ethermint secp256k1 compile errors: RecoverPubkey/VerifySignature undefined)
- git diff --check
- git diff --cached --check

Fixes #1022