### PR TITLE
fix(rollapp): bound fraud rollback by height

### DIFF
--- a/x/delayedack/keeper/fraud.go
+++ b/x/delayedack/keeper/fraud.go
@@ -9,23 +9,28 @@ import (
 	commontypes "github.com/openmetaearth/me-hub/x/common/types"
 )
 
-func (k Keeper) HandleFraud(ctx sdk.Context, rollappID string, ibc porttypes.IBCModule) error {
+func (k Keeper) HandleFraud(ctx sdk.Context, rollappID string, fraudHeight uint64, ibc porttypes.IBCModule) error {
 	// Get all the pending packets
 	rollappPendingPackets := k.ListRollappPackets(ctx, types.ByRollappIDByStatus(rollappID, commontypes.Status_PENDING))
 	if len(rollappPendingPackets) == 0 {
 		return nil
 	}
 	logger := ctx.Logger().With("module", "DelayedAckMiddleware")
-	logger.Info("reverting IBC rollapp packets", "rollappID", rollappID)
+	logger.Info("reverting IBC rollapp packets", "rollappID", rollappID, "fraudHeight", fraudHeight)
 
 	// Iterate over all the pending packets and revert them
 	for _, rollappPacket := range rollappPendingPackets {
+		if rollappPacket.ProofHeight < fraudHeight {
+			continue
+		}
+
 		logContext := []interface{}{
 			"rollappID", rollappID,
 			"sourceChannel", rollappPacket.Packet.SourceChannel,
 			"destChannel", rollappPacket.Packet.DestinationChannel,
 			"type", rollappPacket.Type,
 			"sequence", rollappPacket.Packet.Sequence,
+			"proofHeight", rollappPacket.ProofHeight,
 		}
 
 		if rollappPacket.Type == commontypes.RollappPacket_ON_ACK || rollappPacket.Type == commontypes.RollappPacket_ON_TIMEOUT {

--- a/x/delayedack/keeper/fraud_test.go
+++ b/x/delayedack/keeper/fraud_test.go
@@ -40,7 +40,7 @@ func (suite *DelayedAckTestSuite) TestHandleFraud() {
 	_, err = keeper.UpdateRollappPacketWithStatus(ctx, pkts2[0], commontypes.Status_FINALIZED)
 	suite.Require().Nil(err)
 
-	err = keeper.HandleFraud(ctx, rollappId, transferStack)
+	err = keeper.HandleFraud(ctx, rollappId, 0, transferStack)
 	suite.Require().Nil(err)
 
 	suite.Require().Equal(0, len(keeper.ListRollappPackets(ctx, prefixPending1)))
@@ -48,6 +48,40 @@ func (suite *DelayedAckTestSuite) TestHandleFraud() {
 	suite.Require().Equal(4, len(keeper.ListRollappPackets(ctx, prefixReverted)))
 	suite.Require().Equal(1, len(keeper.ListRollappPackets(ctx, prefixFinalized)))
 	suite.Require().Equal(1, len(keeper.ListRollappPackets(ctx, prefixFinalized2)))
+}
+
+func (suite *DelayedAckTestSuite) TestHandleFraudKeepsPacketsBeforeFraudHeight() {
+	keeper, ctx := suite.App.DelayedAckKeeper, suite.Ctx
+	transferStack := damodule.NewIBCMiddleware(
+		damodule.WithIBCModule(ibctransfer.NewIBCModule(suite.App.TransferKeeper)),
+		damodule.WithKeeper(keeper),
+		damodule.WithRollappKeeper(suite.App.RollappKeeper),
+	)
+
+	rollappId := "testRollappId"
+	fraudHeight := uint64(3)
+	pkts := generatePackets(rollappId, 5)
+	prefixPending := types.ByRollappIDByStatus(rollappId, commontypes.Status_PENDING)
+	prefixReverted := types.ByRollappIDByStatus(rollappId, commontypes.Status_REVERTED)
+
+	for _, pkt := range pkts {
+		keeper.SetRollappPacket(ctx, pkt)
+	}
+
+	err := keeper.HandleFraud(ctx, rollappId, fraudHeight, transferStack)
+	suite.Require().NoError(err)
+
+	pendingPackets := keeper.ListRollappPackets(ctx, prefixPending)
+	revertedPackets := keeper.ListRollappPackets(ctx, prefixReverted)
+	suite.Require().Len(pendingPackets, 3)
+	suite.Require().Len(revertedPackets, 2)
+
+	for _, pkt := range pendingPackets {
+		suite.Require().True(pkt.ProofHeight < fraudHeight)
+	}
+	for _, pkt := range revertedPackets {
+		suite.Require().True(pkt.ProofHeight >= fraudHeight)
+	}
 }
 
 func (suite *DelayedAckTestSuite) TestDeletionOfRevertedPackets() {
@@ -67,7 +101,7 @@ func (suite *DelayedAckTestSuite) TestDeletionOfRevertedPackets() {
 		keeper.SetRollappPacket(ctx, pkt)
 	}
 
-	err := keeper.HandleFraud(ctx, rollappId, transferStack)
+	err := keeper.HandleFraud(ctx, rollappId, 0, transferStack)
 	suite.Require().Nil(err)
 
 	suite.Require().Equal(10, len(keeper.GetAllRollappPackets(ctx)))

--- a/x/delayedack/keeper/invariants_test.go
+++ b/x/delayedack/keeper/invariants_test.go
@@ -73,7 +73,7 @@ func (suite *DelayedAckTestSuite) TestInvariants() {
 
 	// test fraud
 	for rollapp := range seqPerRollapp {
-		err := suite.App.DelayedAckKeeper.HandleFraud(suite.Ctx, rollapp, transferStack)
+		err := suite.App.DelayedAckKeeper.HandleFraud(suite.Ctx, rollapp, 0, transferStack)
 		suite.Require().NoError(err)
 		break
 	}

--- a/x/delayedack/rollapp_hooks.go
+++ b/x/delayedack/rollapp_hooks.go
@@ -20,7 +20,7 @@ func (w IBCMiddleware) AfterStateFinalized(ctx sdk.Context, rollappID string, st
 }
 
 func (w IBCMiddleware) FraudSubmitted(ctx sdk.Context, rollappID string, height uint64, seqAddr string) error {
-	return w.HandleFraud(ctx, rollappID, w.IBCModule)
+	return w.HandleFraud(ctx, rollappID, height, w.IBCModule)
 }
 
 // RollappCreated implements types.RollappHooks.

--- a/x/rollapp/keeper/fraud_handler.go
+++ b/x/rollapp/keeper/fraud_handler.go
@@ -52,7 +52,7 @@ func (k Keeper) HandleFraud(ctx sdk.Context, rollappID, clientId string, fraudHe
 	rollapp.Frozen = true
 	k.SetRollapp(ctx, rollapp)
 
-	k.RevertPendingStates(ctx, rollappID)
+	k.RevertPendingStates(ctx, rollappID, fraudHeight)
 
 	if rollapp.ChannelId != "" {
 		extractedClientId, _, err := k.channelKeeper.GetChannelClientState(ctx, "transfer", rollapp.ChannelId)
@@ -103,8 +103,8 @@ func (k Keeper) freezeClientState(ctx sdk.Context, clientId string) error {
 	return nil
 }
 
-// revert all pending states of a rollapp
-func (k Keeper) RevertPendingStates(ctx sdk.Context, rollappID string) {
+// revert pending states of a rollapp from the fraudulent height onward.
+func (k Keeper) RevertPendingStates(ctx sdk.Context, rollappID string, fraudHeight uint64) {
 	// TODO (#631): Prefix store by rollappID for efficient querying
 	queuePerHeight := k.GetAllBlockHeightToFinalizationQueue(ctx)
 	for _, queue := range queuePerHeight {
@@ -117,6 +117,11 @@ func (k Keeper) RevertPendingStates(ctx sdk.Context, rollappID string) {
 			}
 
 			stateInfo, _ := k.GetStateInfo(ctx, stateInfoIndex.RollappId, stateInfoIndex.Index)
+			if stateInfo.GetLatestHeight() < fraudHeight {
+				leftPendingStates = append(leftPendingStates, stateInfoIndex)
+				continue
+			}
+
 			stateInfo.Status = common.Status_REVERTED
 			k.SetStateInfo(ctx, stateInfo)
 		}

--- a/x/rollapp/keeper/fraud_handler_test.go
+++ b/x/rollapp/keeper/fraud_handler_test.go
@@ -57,7 +57,7 @@ func (suite *RollappTestSuite) TestHandleFraud() {
 	err = keeper.HandleFraud(*ctx, rollapp, "", fraudHeight, proposer)
 	suite.Require().Nil(err)
 
-	suite.assertFraudHandled(rollapp)
+	suite.assertFraudHandled(rollapp, fraudHeight)
 }
 
 // Fail - Invalid rollapp
@@ -147,7 +147,7 @@ func (suite *RollappTestSuite) TestHandleFraud_AlreadyReverted() {
 	err = keeper.HandleFraud(*ctx, rollapp, "", 11, proposer)
 	suite.Require().Nil(err)
 
-	err = keeper.HandleFraud(*ctx, rollapp, "", 1, proposer)
+	err = keeper.HandleFraud(*ctx, rollapp, "", 11, proposer)
 	suite.Require().NotNil(err)
 }
 
@@ -171,6 +171,49 @@ func (suite *RollappTestSuite) TestHandleFraud_AlreadyFinalized() {
 
 	err = keeper.HandleFraud(*ctx, rollapp, "", 2, proposer)
 	suite.Require().NotNil(err)
+}
+
+func (suite *RollappTestSuite) TestHandleFraudDoesNotRevertPendingStateBeforeFraudHeight() {
+	suite.SetupTest()
+	ctx := &suite.Ctx
+	keeper := suite.App.RollappKeeper
+
+	rollapp := suite.CreateDefaultRollapp()
+	proposer := suite.CreateDefaultSequencer(*ctx, rollapp)
+
+	nextHeight, err := suite.PostStateUpdate(*ctx, rollapp, proposer, 1, 10)
+	suite.Require().NoError(err)
+	_, err = suite.PostStateUpdate(*ctx, rollapp, proposer, nextHeight, 10)
+	suite.Require().NoError(err)
+
+	err = keeper.HandleFraud(*ctx, rollapp, "", 11, proposer)
+	suite.Require().NoError(err)
+
+	stateBeforeFraud, found := keeper.GetStateInfo(*ctx, rollapp, 1)
+	suite.Require().True(found)
+	suite.Require().Equal(common.Status_PENDING, stateBeforeFraud.Status)
+
+	stateAtFraud, found := keeper.GetStateInfo(*ctx, rollapp, 2)
+	suite.Require().True(found)
+	suite.Require().Equal(common.Status_REVERTED, stateAtFraud.Status)
+
+	foundStateBeforeFraudInQueue := false
+	foundStateAtFraudInQueue := false
+	for _, queue := range keeper.GetAllBlockHeightToFinalizationQueue(*ctx) {
+		for _, stateInfoIndex := range queue.FinalizationQueue {
+			if stateInfoIndex.RollappId != rollapp {
+				continue
+			}
+			switch stateInfoIndex.Index {
+			case 1:
+				foundStateBeforeFraudInQueue = true
+			case 2:
+				foundStateAtFraudInQueue = true
+			}
+		}
+	}
+	suite.Require().True(foundStateBeforeFraudInQueue)
+	suite.Require().False(foundStateAtFraudInQueue)
 }
 
 // TODO: test IBC freeze
@@ -211,7 +254,7 @@ func (suite *RollappTestSuite) assertBeforeFraud(rollappId string, height uint64
 	suite.Require().True(found)
 }
 
-func (suite *RollappTestSuite) assertFraudHandled(rollappId string) {
+func (suite *RollappTestSuite) assertFraudHandled(rollappId string, fraudHeight uint64) {
 	rollapp, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, rollappId)
 	suite.Require().True(found)
 	suite.Require().True(rollapp.Frozen)
@@ -231,6 +274,10 @@ func (suite *RollappTestSuite) assertFraudHandled(rollappId string) {
 	for i := start; i <= end; i++ {
 		stateInfo, found := suite.App.RollappKeeper.GetStateInfo(suite.Ctx, rollappId, i)
 		suite.Require().True(found)
+		if stateInfo.GetLatestHeight() < fraudHeight {
+			suite.Require().Equal(common.Status_PENDING, stateInfo.Status, "state info for height %d should remain pending", stateInfo.StartHeight)
+			continue
+		}
 		suite.Require().Equal(common.Status_REVERTED, stateInfo.Status, "state info for height %d is not reverted", stateInfo.StartHeight)
 	}
 
@@ -239,7 +286,12 @@ func (suite *RollappTestSuite) assertFraudHandled(rollappId string) {
 	suite.Greater(len(queue), 0)
 	for _, q := range queue {
 		for _, stateInfoIndex := range q.FinalizationQueue {
-			suite.Require().NotEqual(rollappId, stateInfoIndex.RollappId)
+			if stateInfoIndex.RollappId != rollappId {
+				continue
+			}
+			stateInfo, found := suite.App.RollappKeeper.GetStateInfo(suite.Ctx, rollappId, stateInfoIndex.Index)
+			suite.Require().True(found)
+			suite.Require().True(stateInfo.GetLatestHeight() < fraudHeight)
 		}
 	}
 }


### PR DESCRIPTION
Summary
- Pass fraudHeight into RollApp pending-state rollback so only states intersecting or after the fraudulent height are reverted.
- Pass the same fraudHeight through the DelayedAck rollapp hook and keep earlier pending packets untouched.
- Add regression coverage for preserving pending state and packet entries before the fraud height.

Tests
- ..\..\tools\go\bin\go.exe test .\x\rollapp\types -count=1
- ..\..\tools\go\bin\go.exe test .\x\delayedack\types -count=1
- ..\..\tools\go\bin\go.exe test .\x\rollapp\keeper -run TestRollappKeeperTestSuite/TestHandleFraudDoesNotRevertPendingStateBeforeFraudHeight -count=1 -v (blocked by existing Ethermint secp256k1 compile errors: RecoverPubkey/VerifySignature undefined)
- ..\..\tools\go\bin\go.exe test .\x\delayedack\keeper -run TestDelayedAckTestSuite/TestHandleFraudKeepsPacketsBeforeFraudHeight -count=1 -v (blocked by existing Ethermint secp256k1 compile errors: RecoverPubkey/VerifySignature undefined)
- git diff --check
- git diff --cached --check

Fixes #983