### PR TITLE
fix(upgrades): let module migrations run

### DIFF
--- a/app/upgrades/v2.0.14.patch.2/upgrade.go
+++ b/app/upgrades/v2.0.14.patch.2/upgrade.go
@@ -20,13 +20,6 @@ func CreateUpgradeHandler(
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 		logger.Info("upgrade starting...")
 
-		// Initialize consensus versions for all modules
-		for n, m := range mm.Modules {
-			if mod, ok := m.(module.HasConsensusVersion); ok {
-				fromVM[n] = mod.ConsensusVersion()
-			}
-		}
-
 		evmParams := keepers.EvmKeeper.GetParams(ctx)
 		evmParams.EvmDenom = "umec"
 		if err := keepers.EvmKeeper.SetParams(ctx, evmParams); err != nil {

--- a/app/upgrades/v2_0_13/upgrade.go
+++ b/app/upgrades/v2_0_13/upgrade.go
@@ -30,13 +30,6 @@ func CreateUpgradeHandler(
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 		logger.Info("upgrade starting...")
 
-		// Initialize consensus versions for all modules
-		for n, m := range mm.Modules {
-			if mod, ok := m.(module.HasConsensusVersion); ok {
-				fromVM[n] = mod.ConsensusVersion()
-			}
-		}
-
 		params := keepers.GovKeeper.GetParams(ctx)
 		maxDepositPeriod := 30 * time.Minute
 		params.MaxDepositPeriod = &maxDepositPeriod

--- a/app/upgrades/v2_0_14/upgrade.go
+++ b/app/upgrades/v2_0_14/upgrade.go
@@ -20,13 +20,6 @@ func CreateUpgradeHandler(
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 		logger.Info("upgrade starting...")
 
-		// Initialize consensus versions for all modules
-		for n, m := range mm.Modules {
-			if mod, ok := m.(module.HasConsensusVersion); ok {
-				fromVM[n] = mod.ConsensusVersion()
-			}
-		}
-
 		evmParams := keepers.EvmKeeper.GetParams(ctx)
 		evmParams.EvmDenom = "umec"
 		if err := keepers.EvmKeeper.SetParams(ctx, evmParams); err != nil {


### PR DESCRIPTION
Fixes #100.

## Summary
- stop overwriting every module entry in `fromVM` with the current consensus version before migrations run
- apply the same fix to `v2.0.13`, `v2.0.14`, and `v2.0.14.patch.2` upgrade handlers
- keep the existing upgrade parameter changes intact, then pass the original stored version map to `RunMigrations`

## Why
The Cosmos SDK migration runner uses `fromVM` to decide which module migrations still need to run. Pre-setting each module to its current consensus version makes `RunMigrations` treat all modules as already migrated and silently skip registered store migrations.

## Validation
- `..\..\tools\go\bin\go.exe test .\app\upgrades\v2_0_13 .\app\upgrades\v2_0_14 .\app\upgrades\v2.0.14.patch.2 -count=1`
- `..\..\tools\go\bin\go.exe test .\app\upgrades\... -count=1`
- `git diff --check`
- `git diff --cached --check`