### PR TITLE
fix(delayedack): keep refund failures pending

### DIFF
--- a/x/delayedack/fraud_test.go
+++ b/x/delayedack/fraud_test.go
@@ -1,0 +1,169 @@
+package delayedack_test
+
+import (
+	"errors"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/openmetaearth/me-hub/testutil/keeper"
+	commontypes "github.com/openmetaearth/me-hub/x/common/types"
+	delayedacktypes "github.com/openmetaearth/me-hub/x/delayedack/types"
+)
+
+func TestHandleFraudKeepsOutgoingPacketPendingWhenRefundFails(t *testing.T) {
+	keeper, ctx := keepertest.DelayedackKeeper(t)
+	rollappID := "rollapp-1"
+	rollappPacket := commontypes.RollappPacket{
+		RollappId: rollappID,
+		Packet: &channeltypes.Packet{
+			SourcePort:         "transfer",
+			SourceChannel:      "channel-0",
+			DestinationPort:    "transfer",
+			DestinationChannel: "channel-1",
+			Data:               []byte("packet-data"),
+			Sequence:           1,
+		},
+		Status:      commontypes.Status_PENDING,
+		Type:        commontypes.RollappPacket_ON_TIMEOUT,
+		Relayer:     sdk.AccAddress("relayer"),
+		ProofHeight: 10,
+	}
+	keeper.SetRollappPacket(ctx, rollappPacket)
+
+	ibc := &timeoutFailingIBCModule{err: errors.New("refund failed")}
+	err := keeper.HandleFraud(ctx, rollappID, ibc)
+
+	require.ErrorContains(t, err, "refund reverted packet")
+	require.Equal(t, 1, ibc.timeoutCalls)
+	require.Len(t, keeper.ListRollappPackets(ctx, delayedacktypes.ByRollappIDByStatus(rollappID, commontypes.Status_PENDING)), 1)
+	require.Empty(t, keeper.ListRollappPackets(ctx, delayedacktypes.ByRollappIDByStatus(rollappID, commontypes.Status_REVERTED)))
+}
+
+var _ porttypes.IBCModule = (*timeoutFailingIBCModule)(nil)
+
+type timeoutFailingIBCModule struct {
+	err          error
+	timeoutCalls int
+}
+
+func (m *timeoutFailingIBCModule) OnChanOpenInit(
+	ctx sdk.Context,
+	order channeltypes.Order,
+	connectionHops []string,
+	portID string,
+	channelID string,
+	channelCap *capabilitytypes.Capability,
+	counterparty channeltypes.Counterparty,
+	version string,
+) (string, error) {
+	return version, nil
+}
+
+func (m *timeoutFailingIBCModule) OnChanOpenTry(
+	ctx sdk.Context,
+	order channeltypes.Order,
+	connectionHops []string,
+	portID string,
+	channelID string,
+	channelCap *capabilitytypes.Capability,
+	counterparty channeltypes.Counterparty,
+	counterpartyVersion string,
+) (string, error) {
+	return counterpartyVersion, nil
+}
+
+func (m *timeoutFailingIBCModule) OnChanOpenAck(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+	counterpartyChannelID string,
+	counterpartyVersion string,
+) error {
+	return nil
+}
+
+func (m *timeoutFailingIBCModule) OnChanOpenConfirm(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+) error {
+	return nil
+}
+
+func (m *timeoutFailingIBCModule) OnChanCloseInit(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+) error {
+	return nil
+}
+
+func (m *timeoutFailingIBCModule) OnChanCloseConfirm(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+) error {
+	return nil
+}
+
+func (m *timeoutFailingIBCModule) OnRecvPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) exported.Acknowledgement {
+	return channeltypes.NewResultAcknowledgement([]byte{1})
+}
+
+func (m *timeoutFailingIBCModule) OnAcknowledgementPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	acknowledgement []byte,
+	relayer sdk.AccAddress,
+) error {
+	return nil
+}
+
+func (m *timeoutFailingIBCModule) OnTimeoutPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) error {
+	m.timeoutCalls++
+	return m.err
+}
+
+func (m *timeoutFailingIBCModule) SendPacket(
+	ctx sdk.Context,
+	chanCap *capabilitytypes.Capability,
+	sourcePort string,
+	sourceChannel string,
+	timeoutHeight clienttypes.Height,
+	timeoutTimestamp uint64,
+	data []byte,
+) (uint64, error) {
+	return 0, nil
+}
+
+func (m *timeoutFailingIBCModule) WriteAcknowledgement(
+	ctx sdk.Context,
+	chanCap *capabilitytypes.Capability,
+	packet exported.PacketI,
+	ack exported.Acknowledgement,
+) error {
+	return nil
+}
+
+func (m *timeoutFailingIBCModule) GetAppVersion(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+) (string, bool) {
+	return "", true
+}

--- a/x/delayedack/keeper/fraud.go
+++ b/x/delayedack/keeper/fraud.go
@@ -1,7 +1,10 @@
 package keeper
 
 import (
+	"fmt"
+
 	"github.com/openmetaearth/me-hub/x/delayedack/types"
+	"github.com/osmosis-labs/osmosis/v15/osmoutils"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
@@ -28,18 +31,24 @@ func (k Keeper) HandleFraud(ctx sdk.Context, rollappID string, ibc porttypes.IBC
 			"sequence", rollappPacket.Packet.Sequence,
 		}
 
-		if rollappPacket.Type == commontypes.RollappPacket_ON_ACK || rollappPacket.Type == commontypes.RollappPacket_ON_TIMEOUT {
-			// refund all pending outgoing packets
-			// we don't have access directly to `refundPacketToken` function, so we'll use the `OnTimeoutPacket` function
-			err := ibc.OnTimeoutPacket(ctx, *rollappPacket.Packet, rollappPacket.Relayer)
-			if err != nil {
-				logger.Error("failed to refund reverted packet", append(logContext, "error", err.Error())...)
+		err := osmoutils.ApplyFuncIfNoError(ctx, func(cacheCtx sdk.Context) error {
+			if rollappPacket.Type == commontypes.RollappPacket_ON_ACK || rollappPacket.Type == commontypes.RollappPacket_ON_TIMEOUT {
+				// refund all pending outgoing packets
+				// we don't have access directly to `refundPacketToken` function, so we'll use the `OnTimeoutPacket` function
+				err := ibc.OnTimeoutPacket(cacheCtx, *rollappPacket.Packet, rollappPacket.Relayer)
+				if err != nil {
+					logger.Error("failed to refund reverted packet", append(logContext, "error", err.Error())...)
+					return fmt.Errorf("refund reverted packet: sequence %d: %w", rollappPacket.Packet.Sequence, err)
+				}
 			}
-		}
-		// Update status to reverted
-		_, err := k.UpdateRollappPacketWithStatus(ctx, rollappPacket, commontypes.Status_REVERTED)
+			// Update status to reverted
+			_, err := k.UpdateRollappPacketWithStatus(cacheCtx, rollappPacket, commontypes.Status_REVERTED)
+			if err != nil {
+				logger.Error("error reverting IBC rollapp packet", append(logContext, "error", err.Error())...)
+			}
+			return err
+		})
 		if err != nil {
-			logger.Error("error reverting IBC rollapp packet", append(logContext, "error", err.Error())...)
 			return err
 		}
 


### PR DESCRIPTION
## Summary
- keep delayed-ack fraud reversion atomic for outgoing packets that need refunds
- run the refund callback and `REVERTED` status update in the same cached function
- return the refund error instead of logging and continuing, leaving the packet pending when refund fails
- add a regression test for failed refund behavior

Fixes #101.

## Tests
- `..\..\tools\go\bin\go.exe test .\x\delayedack -run TestHandleFraudKeepsOutgoingPacketPendingWhenRefundFails -count=1 -v`
- `..\..\tools\go\bin\go.exe test .\x\delayedack -count=1`
- `git diff --check`
- `git diff --cached --check`

`..\..\tools\go\bin\go.exe test .\x\delayedack\keeper -count=1` is currently blocked in this workspace by upstream `github.com/openmetaearth/ethermint/app/ante/eip712.go` compile errors for missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.