### PR TITLE
fix(sequencer): queue replaced proposers for unbonding

### DIFF
--- a/x/sequencer/keeper/replace_proposer.go
+++ b/x/sequencer/keeper/replace_proposer.go
@@ -117,10 +117,14 @@ func (k Keeper) ProcSequencerByPendingStates(ctx sdk.Context, rollappId, creator
 				oldSequencer.RollappId, rollappId)
 		}
 		if oldSequencer.IsProposer() || oldSequencer.Status == types.Bonded {
+			oldStatus := oldSequencer.Status
+			completionTime := ctx.BlockHeader().Time.Add(k.UnbondingTime(ctx))
 			oldSequencer.Proposer = false
 			oldSequencer.Status = types.Unbonding
 			oldSequencer.UnbondingHeight = ctx.BlockHeight()
-			k.UpdateSequencer(ctx, oldSequencer, types.Bonded)
+			oldSequencer.UnbondTime = completionTime
+			k.UpdateSequencer(ctx, oldSequencer, oldStatus)
+			k.setUnbondingSequencerQueue(ctx, oldSequencer)
 			newSequencer, found := k.GetSequencer(ctx, val.ReplaceProposer.NewProposer)
 			if !found {
 				return fmt.Errorf("can not found new sequencer: %s", val.ReplaceProposer.NewProposer)

--- a/x/sequencer/replace_proposer_test.go
+++ b/x/sequencer/replace_proposer_test.go
@@ -1,0 +1,65 @@
+package sequencer_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	keepertest "github.com/openmetaearth/me-hub/testutil/keeper"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/openmetaearth/me-hub/x/sequencer/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceProposerQueuesOldSequencerForUnbonding(t *testing.T) {
+	keeper, ctx := keepertest.SequencerKeeper(t)
+	now := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	ctx = ctx.WithBlockHeight(42).WithBlockTime(now)
+
+	rollappID := "rollapp-1"
+	oldProposer := "old-proposer"
+	newProposer := "new-proposer"
+	bond := sdk.NewCoins(sdk.NewCoin("dym", sdk.NewInt(100)))
+
+	keeper.SetSequencer(ctx, types.Sequencer{
+		SequencerAddress: oldProposer,
+		RollappId:        rollappID,
+		Proposer:         true,
+		Status:           types.Bonded,
+		Tokens:           bond,
+	})
+	keeper.SetSequencer(ctx, types.Sequencer{
+		SequencerAddress: newProposer,
+		RollappId:        rollappID,
+		Status:           types.Bonded,
+		Tokens:           bond,
+	})
+	require.NoError(t, keeper.SetReplaceProposer(ctx, &types.MsgRepalceProposer{
+		RollappId:   rollappID,
+		OldProposer: oldProposer,
+		NewProposer: newProposer,
+		BlockHeight: 10,
+	}))
+
+	err := keeper.ProcSequencerByPendingStates(ctx, rollappID, newProposer, &rollapptypes.StateInfo{
+		StartHeight: 11,
+		NumBlocks:   1,
+	})
+	require.NoError(t, err)
+
+	oldSeq, found := keeper.GetSequencer(ctx, oldProposer)
+	require.True(t, found)
+	require.False(t, oldSeq.Proposer)
+	require.Equal(t, types.Unbonding, oldSeq.Status)
+	require.Equal(t, int64(42), oldSeq.UnbondingHeight)
+	require.Equal(t, now.Add(keeper.UnbondingTime(ctx)), oldSeq.UnbondTime)
+
+	require.Empty(t, keeper.GetMatureUnbondingSequencers(ctx, oldSeq.UnbondTime.Add(-time.Nanosecond)))
+	matureSequencers := keeper.GetMatureUnbondingSequencers(ctx, oldSeq.UnbondTime)
+	require.Len(t, matureSequencers, 1)
+	require.Equal(t, oldProposer, matureSequencers[0].SequencerAddress)
+
+	newSeq, found := keeper.GetSequencer(ctx, newProposer)
+	require.True(t, found)
+	require.True(t, newSeq.Proposer)
+}


### PR DESCRIPTION
## Summary
- set `UnbondTime` when a replaced proposer is moved to `Unbonding`
- add the replaced proposer to the unbonding queue so the normal mature-unbonding flow can release it later
- use the sequencer's actual prior status when updating indexes
- add a regression test that verifies the old proposer appears in the mature unbonding queue at completion time

Fixes #96.

## Tests
- `..\..\tools\go\bin\go.exe test .\x\sequencer -run TestReplaceProposerQueuesOldSequencerForUnbonding -count=1 -v`
- `..\..\tools\go\bin\go.exe test .\x\sequencer -count=1`
- `git diff --check`
- `git diff --cached --check`

`..\..\tools\go\bin\go.exe test .\x\sequencer\keeper -count=1` is currently blocked in this workspace by upstream `github.com/openmetaearth/ethermint/app/ante/eip712.go` compile errors for missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.