### PR TITLE
fix(ante): account multisend inputs separately

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -285,12 +285,10 @@ func (dfd DeductFeeDecorator) CheckFunds(ctx sdk.Context, tx sdk.Tx, feePayer st
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "denom is empty")
 	}
 
-	fromAddress := ""
 	userSendAmount := make(map[string]sdk.Coins)
 	for _, msg := range tx.GetMsgs() {
 		switch txMsg := msg.(type) {
 		case *banktypes.MsgSend:
-			fromAddress = txMsg.FromAddress
 			sendAmount := userSendAmount[txMsg.FromAddress]
 			sendAmount = sendAmount.Add(txMsg.Amount...)
 			userSendAmount[txMsg.FromAddress] = sendAmount
@@ -298,32 +296,23 @@ func (dfd DeductFeeDecorator) CheckFunds(ctx sdk.Context, tx sdk.Tx, feePayer st
 			if len(txMsg.Inputs) == 0 {
 				return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "no input coins provided")
 			}
-			fromAddress = txMsg.Inputs[0].Address
-			sendAmount := userSendAmount[fromAddress]
-			for _, output := range txMsg.Outputs {
-				sendAmount = sendAmount.Add(output.Coins...)
+			for _, input := range txMsg.Inputs {
+				sendAmount := userSendAmount[input.Address]
+				sendAmount = sendAmount.Add(input.Coins...)
+				userSendAmount[input.Address] = sendAmount
 			}
-			userSendAmount[fromAddress] = sendAmount
 		case *stakingtypes.MsgDelegate:
-			fromAddress = txMsg.DelegatorAddress
 			sendAmount := userSendAmount[txMsg.DelegatorAddress]
 			sendAmount = sendAmount.Add(txMsg.Amount)
 			userSendAmount[txMsg.DelegatorAddress] = sendAmount
 		case *wstakingtypes.MsgDoFixedDeposit:
-			fromAddress = txMsg.Account
 			sendAmount := userSendAmount[txMsg.Account]
 			sendAmount = sendAmount.Add(txMsg.Principal)
 			userSendAmount[txMsg.Account] = sendAmount
 		}
 	}
 
-	if _, exists := userSendAmount[feePayer]; !exists {
-		userSendAmount[feePayer] = fees
-	} else {
-		if fromAddress == feePayer {
-			userSendAmount[feePayer] = userSendAmount[feePayer].Add(fees...)
-		}
-	}
+	userSendAmount[feePayer] = userSendAmount[feePayer].Add(fees...)
 
 	for address, sendAmount := range userSendAmount {
 		balance := dfd.BankKeeper.GetAllBalances(ctx, sdk.MustAccAddressFromBech32(address))

--- a/app/ante/fee_deduct_test.go
+++ b/app/ante/fee_deduct_test.go
@@ -75,6 +75,7 @@ func TestCheckFunds(t *testing.T) {
 	feePayer := NewAccount()
 	receiver := NewAccount()
 	sender := NewAccount()
+	secondSender := NewAccount()
 
 	tests := []struct {
 		name         string
@@ -295,6 +296,37 @@ func TestCheckFunds(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:     "MsgMultiSend with multiple inputs and separate fee payer",
+			feePayer: feePayer.Address,
+			fees:     sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(10))),
+			balances: map[string]sdk.Coins{
+				feePayer.Address:     sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(10))),
+				sender.Address:       sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(100))),
+				secondSender.Address: sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(100))),
+			},
+			messages: []sdk.Msg{
+				&banktypes.MsgMultiSend{
+					Inputs: []banktypes.Input{
+						{
+							Address: sender.Address,
+							Coins:   sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(100))),
+						},
+						{
+							Address: secondSender.Address,
+							Coins:   sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(100))),
+						},
+					},
+					Outputs: []banktypes.Output{
+						{
+							Address: receiver.Address,
+							Coins:   sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(200))),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
 			name:     "MsgMultiSend with insufficient funds",
 			feePayer: feePayer.Address,
 			fees:     sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(100))),
@@ -322,7 +354,7 @@ func TestCheckFunds(t *testing.T) {
 				},
 			},
 			expectError:  true,
-			expectAmount: 400,
+			expectAmount: 300,
 		},
 		{
 			name:     "MsgMultiSend with insufficient funds, not enough for fees",


### PR DESCRIPTION
## Summary
- account `MsgMultiSend` funds from each input address and its own input coins instead of charging all outputs to `Inputs[0]`
- always include the fee amount in the fee payer's required balance, independent of which message was processed last
- add a regression case where two multisend inputs fund one output while a separate fee payer covers fees

Fixes #1033.

## Tests
- `git diff --check`
- `git diff --cached --check`

Attempted but blocked in this workspace:
- `..\..\tools\go\bin\go.exe test .\app\ante -run TestCheckFunds -count=1 -v`

The test command currently fails before app/ante tests run because upstream `github.com/openmetaearth/ethermint/app/ante/eip712.go` does not compile here: missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.