### PR TITLE
fix(kyc): clear stale DID address mappings

### DIFF
--- a/x/kyc/keeper/did.go
+++ b/x/kyc/keeper/did.go
@@ -23,6 +23,10 @@ func (k *Keeper) SetDID(ctx sdk.Context, addr sdk.AccAddress, did string) {
 	k.didKeeper.SetDID(ctx, addr, did)
 }
 
+func (k *Keeper) DeleteDID(ctx sdk.Context, addr sdk.AccAddress) {
+	k.didKeeper.DeleteDID(ctx, addr)
+}
+
 func (k *Keeper) HasDidInfo(ctx sdk.Context, did string) bool {
 	return k.didKeeper.HasDidInfo(ctx, did)
 }

--- a/x/kyc/keeper/msg_server.go
+++ b/x/kyc/keeper/msg_server.go
@@ -67,6 +67,12 @@ func (m msgServer) Approve(goCtx context.Context, msg *types.MsgApprove) (*types
 		// notice: holder must have not DID
 		return &types.MsgApproveResponse{}, didtypes.ErrHolderExists
 	}
+	if holderInfo.Address != "" && holderInfo.Address != msg.Address {
+		oldAddress := sdk.MustAccAddressFromBech32(holderInfo.Address)
+		if oldDID, found := m.GetDID(ctx, oldAddress); found && oldDID == msg.Did {
+			m.DeleteDID(ctx, oldAddress)
+		}
+	}
 
 	// create DID
 	m.SetDID(ctx, address, msg.Did)
@@ -223,6 +229,10 @@ func (m msgServer) Remove(goCtx context.Context, msg *types.MsgRemove) (*types.M
 	didInfo.KycLevel = 0
 	didInfo.Status = didtypes.DID_STATUS_INACTIVE
 	m.SetDidInfo(ctx, msg.Did, didInfo)
+	address := sdk.MustAccAddressFromBech32(didInfo.Address)
+	if did, found := m.GetDID(ctx, address); found && did == msg.Did {
+		m.DeleteDID(ctx, address)
+	}
 
 	// delete KYC
 	kyc, found := m.GetKYC(ctx, msg.Did)
@@ -236,7 +246,6 @@ func (m msgServer) Remove(goCtx context.Context, msg *types.MsgRemove) (*types.M
 	m.DeleteFilters(ctx, msg.Did, filters)
 
 	// cancel reward
-	address := sdk.MustAccAddressFromBech32(didInfo.Address)
 	if err := m.DeleteApproveReward(ctx, address.String(), string(kyc.Data)); err != nil {
 		return &types.MsgRemoveResponse{}, errors.Wrap(err, "delete reward failed")
 	}

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -112,6 +112,64 @@ func (s *KeeperTestSuite) TestRemove() {
 	// check kyc
 	_, f = s.Keeper().GetKYC(s.Ctx, did)
 	s.Require().False(f)
+
+	// check address mapping
+	_, f = s.Keeper().GetDID(s.Ctx, kycAccount)
+	s.Require().False(f)
+}
+
+func (s *KeeperTestSuite) TestApproveClearsStaleAddressMappingOnReapproval() {
+	s.SetupTest()
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	did := "1111111111111111"
+	oldAccount, oldPubkey := s.NewAccount()
+	inviter, _ := s.NewAccount()
+	_, err := s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: strings.ToLower(wstakingtypes.MeEarthRegionName),
+		Address:  oldAccount.String(),
+		Pubkey:   oldPubkey,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "aaaa",
+		Inviter:  inviter.String(),
+		Level:    2,
+	})
+	s.Require().NoError(err)
+
+	_, err = s.msgServer.Remove(s.Ctx, &types.MsgRemove{
+		Issuer: s.Dao.GlobalDao,
+		Did:    did,
+	})
+	s.Require().NoError(err)
+	s.Keeper().SetDID(s.Ctx, oldAccount, did)
+	staleDID, found := s.Keeper().GetDID(s.Ctx, oldAccount)
+	s.Require().True(found)
+	s.Require().Equal(did, staleDID)
+
+	newAccount, newPubkey := s.NewAccount()
+	_, err = s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+		Issuer:   s.Dao.GlobalDao,
+		Did:      did,
+		RegionId: strings.ToLower(wstakingtypes.MeEarthRegionName),
+		Address:  newAccount.String(),
+		Pubkey:   newPubkey,
+		Uri:      "http://127.0.0.1/8001",
+		Hash:     "bbbb",
+		Inviter:  inviter.String(),
+		Level:    2,
+	})
+	s.Require().NoError(err)
+
+	_, found = s.Keeper().GetDID(s.Ctx, oldAccount)
+	s.Require().False(found)
+	approvedDID, found := s.Keeper().GetDID(s.Ctx, newAccount)
+	s.Require().True(found)
+	s.Require().Equal(did, approvedDID)
 }
 
 func (s *KeeperTestSuite) TestUpdate() {


### PR DESCRIPTION
## Summary
- delete the old address -> DID index when a KYC holder is removed
- clear a legacy stale address mapping before re-approving an inactive DID to a new address
- add regression coverage for Remove and inactive-DID re-approval

Fixes #269.

## Tests
- `git diff --check`
- `git diff --cached --check`
- `go test ./x/kyc/keeper -run TestKeeperTestSuite/(TestRemove|TestApproveClearsStaleAddressMappingOnReapproval)$ -count=1 -v` (blocked by upstream `github.com/openmetaearth/ethermint/app/ante/eip712.go` compile errors: undefined `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`)