### PR TITLE
fix(bridgingfee): skip fees above transfer amount

### DIFF
--- a/x/bridgingfee/ibc_module.go
+++ b/x/bridgingfee/ibc_module.go
@@ -80,7 +80,12 @@ func (w *IBCModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 
 	// Use the packet as a basis for a fee transfer
 	feeData := transfer
-	fee := w.delayedAckKeeper.BridgingFeeFromAmt(ctx, transfer.MustAmountInt())
+	amount := transfer.MustAmountInt()
+	rawFee := w.delayedAckKeeper.BridgingFeeFromAmt(ctx, amount)
+	fee := chargeableBridgingFee(amount, rawFee)
+	if rawFee.GT(amount) {
+		l.Error("Bridging fee exceeds transfer amount.", "amount", amount.String(), "fee", rawFee.String())
+	}
 	if fee.IsZero() {
 		return w.IBCModule.OnRecvPacket(ctx, packet, relayer)
 	}
@@ -107,7 +112,14 @@ func (w *IBCModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 	}
 
 	// transfer the rest to the original recipient
-	transfer.Amount = transfer.MustAmountInt().Sub(fee).String()
+	transfer.Amount = amount.Sub(fee).String()
 	packet.Data = transfer.GetBytes()
 	return w.IBCModule.OnRecvPacket(ctx, packet, relayer)
+}
+
+func chargeableBridgingFee(amount sdk.Int, fee sdk.Int) sdk.Int {
+	if !fee.IsPositive() || fee.GT(amount) {
+		return sdk.ZeroInt()
+	}
+	return fee
 }

--- a/x/bridgingfee/ibc_module_test.go
+++ b/x/bridgingfee/ibc_module_test.go
@@ -1,0 +1,50 @@
+package bridgingfee
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChargeableBridgingFee(t *testing.T) {
+	amount := sdk.NewInt(10)
+
+	testCases := []struct {
+		name string
+		fee  sdk.Int
+		want sdk.Int
+	}{
+		{
+			name: "zero fee",
+			fee:  sdk.ZeroInt(),
+			want: sdk.ZeroInt(),
+		},
+		{
+			name: "negative fee",
+			fee:  sdk.NewInt(-1),
+			want: sdk.ZeroInt(),
+		},
+		{
+			name: "fee below amount",
+			fee:  sdk.NewInt(3),
+			want: sdk.NewInt(3),
+		},
+		{
+			name: "fee equal amount",
+			fee:  sdk.NewInt(10),
+			want: sdk.NewInt(10),
+		},
+		{
+			name: "fee above amount",
+			fee:  sdk.NewInt(11),
+			want: sdk.ZeroInt(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, tc.want.Equal(chargeableBridgingFee(amount, tc.fee)))
+		})
+	}
+}


### PR DESCRIPTION
Addresses the BRIDGINGFEE-NEW-001 underflow/panic portion of #276.

## Summary
- computes the transfer amount once before charging the bridging fee
- skips fee charging when the computed bridging fee is non-positive or greater than the packet amount
- avoids calling `amount.Sub(fee)` with `fee > amount`, preventing an SDK `Int` underflow panic in `OnRecvPacket`
- adds focused unit coverage for zero, negative, valid, equal, and above-amount fee cases

## Tests
- `..\..\tools\go\bin\go.exe test .\x\bridgingfee -count=1 -v`
- `git diff --check`
- `git diff --cached --check`