### PR TITLE
fix(rollapp): skip missing fraud rollback states

### DIFF
--- a/x/rollapp/keeper/fraud_handler.go
+++ b/x/rollapp/keeper/fraud_handler.go
@@ -116,7 +116,11 @@ func (k Keeper) RevertPendingStates(ctx sdk.Context, rollappID string) {
 				continue
 			}
 
-			stateInfo, _ := k.GetStateInfo(ctx, stateInfoIndex.RollappId, stateInfoIndex.Index)
+			stateInfo, found := k.GetStateInfo(ctx, stateInfoIndex.RollappId, stateInfoIndex.Index)
+			if !found {
+				k.Logger(ctx).Error("pending rollapp state info not found during fraud rollback", "rollapp_id", stateInfoIndex.RollappId, "index", stateInfoIndex.Index)
+				continue
+			}
 			stateInfo.Status = common.Status_REVERTED
 			k.SetStateInfo(ctx, stateInfo)
 		}

--- a/x/rollapp/keeper/fraud_handler_missing_state_test.go
+++ b/x/rollapp/keeper/fraud_handler_missing_state_test.go
@@ -1,0 +1,48 @@
+package keeper_test
+
+import (
+	"testing"
+
+	keepertest "github.com/openmetaearth/me-hub/testutil/keeper"
+	common "github.com/openmetaearth/me-hub/x/common/types"
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRevertPendingStatesSkipsMissingStateInfo(t *testing.T) {
+	k, ctx := keepertest.RollappKeeper(t)
+
+	const (
+		fraudRollappID = "fraud-rollapp"
+		otherRollappID = "other-rollapp"
+		creationHeight = uint64(10)
+	)
+
+	otherState := types.StateInfo{
+		StateInfoIndex: types.StateInfoIndex{RollappId: otherRollappID, Index: 1},
+		Status:         common.Status_PENDING,
+	}
+	k.SetStateInfo(ctx, otherState)
+	k.SetBlockHeightToFinalizationQueue(ctx, types.BlockHeightToFinalizationQueue{
+		CreationHeight: creationHeight,
+		FinalizationQueue: []types.StateInfoIndex{
+			{RollappId: fraudRollappID, Index: 7},
+			otherState.StateInfoIndex,
+		},
+	})
+
+	k.RevertPendingStates(ctx, fraudRollappID)
+
+	_, found := k.GetStateInfo(ctx, fraudRollappID, 7)
+	require.False(t, found)
+	_, found = k.GetStateInfo(ctx, "", 0)
+	require.False(t, found)
+
+	storedOtherState, found := k.GetStateInfo(ctx, otherRollappID, 1)
+	require.True(t, found)
+	require.Equal(t, common.Status_PENDING, storedOtherState.Status)
+
+	queue, found := k.GetBlockHeightToFinalizationQueue(ctx, creationHeight)
+	require.True(t, found)
+	require.Equal(t, []types.StateInfoIndex{otherState.StateInfoIndex}, queue.FinalizationQueue)
+}


### PR DESCRIPTION
Addresses ROLLAPP-NEW-003 in #282.

## Summary
- stops RevertPendingStates from writing a zero-value StateInfo when a finalization queue entry points at missing state info
- logs and skips missing state entries while still removing the stale queue item for the frauded rollapp
- adds regression coverage proving missing rollback state does not create a phantom empty-rollapp/index-0 state and unrelated rollapp queue entries remain pending

## Tests
- git diff --check
- git diff --cached --check
- ..\..\tools\go\bin\go.exe test .\x\rollapp\keeper -run TestRevertPendingStatesSkipsMissingStateInfo -count=1 -v (blocked before package tests by upstream github.com/openmetaearth/ethermint/app/ante/eip712.go: undefined secp256k1.RecoverPubkey and secp256k1.VerifySignature)
