### PR TITLE
fix(wnft): reject invalid signer addresses

### DIFF
--- a/x/wnft/types/msgs.go
+++ b/x/wnft/types/msgs.go
@@ -33,8 +33,7 @@ func (msg MsgNewClass) GetSignBytes() []byte {
 	return sdk.MustSortJSON(bz)
 }
 func (msg MsgNewClass) GetSigners() []sdk.AccAddress {
-	signer, _ := sdk.AccAddressFromBech32(msg.Sender)
-	return []sdk.AccAddress{signer}
+	return []sdk.AccAddress{sdk.MustAccAddressFromBech32(msg.Sender)}
 }
 func (msg MsgNewClass) ValidateBasic() error {
 	if len(msg.ClassId) == 0 {
@@ -102,8 +101,7 @@ func (m MsgMintNFT) ValidateBasic() error {
 
 // GetSigners returns the expected signers for MsgMintNFT.
 func (m MsgMintNFT) GetSigners() []sdk.AccAddress {
-	signer, _ := sdk.AccAddressFromBech32(m.Creator)
-	return []sdk.AccAddress{signer}
+	return []sdk.AccAddress{sdk.MustAccAddressFromBech32(m.Creator)}
 }
 
 // Route implements the sdk.Msg interface.
@@ -153,8 +151,7 @@ func (m MsgSend) ValidateBasic() error {
 
 // GetSigners returns the expected signers for MsgSend.
 func (m MsgSend) GetSigners() []sdk.AccAddress {
-	signer, _ := sdk.AccAddressFromBech32(m.Sender)
-	return []sdk.AccAddress{signer}
+	return []sdk.AccAddress{sdk.MustAccAddressFromBech32(m.Sender)}
 }
 
 // GetSignBytes get the bytes for the message signer to sign on

--- a/x/wnft/types/msgs_test.go
+++ b/x/wnft/types/msgs_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSignersPanicsOnInvalidAddresses(t *testing.T) {
+	require.Panics(t, func() {
+		MsgNewClass{Sender: "not-a-bech32-address"}.GetSigners()
+	})
+
+	require.Panics(t, func() {
+		MsgMintNFT{Creator: "not-a-bech32-address"}.GetSigners()
+	})
+
+	require.Panics(t, func() {
+		MsgSend{Sender: "not-a-bech32-address"}.GetSigners()
+	})
+}


### PR DESCRIPTION
Addresses WNFT-NEW-002 in #282.

## Summary
- updates WNFT MsgNewClass, MsgMintNFT, and MsgSend GetSigners to use MustAccAddressFromBech32
- prevents invalid signer addresses from silently returning an empty/zero signer
- adds focused unit coverage for invalid signer addresses on all three WNFT messages

## Tests
- ..\..\tools\go\bin\go.exe test .\x\wnft\types -count=1 -v
- git diff --check
- git diff --cached --check
