### PR TITLE
fix(gravity): reject duplicate unbatched tx ids

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -155,19 +155,35 @@ func (k Keeper) DeleteBatch(ctx sdk.Context, batch *types.OutgoingTxBatch) {
 func (k Keeper) pickUnBatchedTx(ctx sdk.Context, contractAddress string, maxElements uint, baseFee sdkmath.Int) ([]*types.OutgoingTransferTx, error) {
 	var selectedTx []*types.OutgoingTransferTx
 	var err error
+	selectedIDs := make(map[uint64]struct{})
+
 	k.IterateUnbatchedTransactions(ctx, contractAddress, func(tx *types.OutgoingTransferTx) bool {
 		if tx.Fee.Amount.LT(baseFee) {
 			return true
 		}
+		if _, found := selectedIDs[tx.Id]; found {
+			err = errorsmod.Wrapf(types.ErrDuplicate, "transaction id %d appears more than once in the unbatched pool", tx.Id)
+			return true
+		}
+		selectedIDs[tx.Id] = struct{}{}
 		selectedTx = append(selectedTx, tx)
+		return uint(len(selectedTx)) == maxElements
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tx := range selectedTx {
 		err = k.DelUnbatchedTx(ctx, tx.Fee, tx.Id)
+		if err != nil {
+			return nil, err
+		}
 		oldTx, oldTxErr := k.GetUnbatchedTxByFeeAndId(ctx, tx.Fee, tx.Id)
 		if oldTx != nil || oldTxErr == nil {
-			panic("picked a duplicate transaction from the pool, duplicates should never exist!")
+			return nil, errorsmod.Wrapf(types.ErrDuplicate, "transaction id %d was not removed from the unbatched pool", tx.Id)
 		}
-		return err != nil || uint(len(selectedTx)) == maxElements
-	})
-	return selectedTx, err
+	}
+	return selectedTx, nil
 }
 
 // GetOutgoingTxBatch loads a batch object. Returns nil when not exists.

--- a/x/gravity/keeper/outgoing_tx_pool.go
+++ b/x/gravity/keeper/outgoing_tx_pool.go
@@ -150,6 +150,10 @@ func (k Keeper) RemoveFromOutgoingPoolAndRefund(ctx sdk.Context, txId uint64, se
 
 // AddUnbatchedTx creates a new transaction in the pool
 func (k Keeper) AddUnbatchedTx(ctx sdk.Context, outgoingTransferTx *types.OutgoingTransferTx) error {
+	if existingTx, err := k.GetUnbatchedTxById(ctx, outgoingTransferTx.Id); err == nil && existingTx != nil {
+		return errorsmod.Wrapf(types.ErrDuplicate, "transaction id %d already in pool", outgoingTransferTx.Id)
+	}
+
 	store := ctx.KVStore(k.storeKey)
 	idxKey := types.GetOutgoingTxPoolKey(outgoingTransferTx.Fee, outgoingTransferTx.Id)
 	if store.Has(idxKey) {

--- a/x/gravity/keeper/outgoing_tx_pool_test.go
+++ b/x/gravity/keeper/outgoing_tx_pool_test.go
@@ -39,3 +39,38 @@ func (s *KeeperTestSuite) TestKeeper_OutgoingAncCancel() {
 	s.Equal(s.App.BankKeeper.GetAllBalances(s.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 	s.Equal(sendAmount, s.App.BankKeeper.GetSupply(s.Ctx, denom))
 }
+
+func (s *KeeperTestSuite) TestAddUnbatchedTxRejectsDuplicateTxIDWithDifferentFee() {
+	tokenContract := helpers.GenerateAddress().Hex()
+	sender := sdk.AccAddress(helpers.GenerateAddress().Bytes()).String()
+	dest := helpers.GenerateAddress().Hex()
+
+	first := &types.OutgoingTransferTx{
+		Id:          7,
+		Sender:      sender,
+		DestAddress: dest,
+		Token: types.ERC20Token{
+			Contract: tokenContract,
+			Amount:   sdkmath.NewInt(100),
+		},
+		Fee: types.ERC20Token{
+			Contract: tokenContract,
+			Amount:   sdkmath.NewInt(1),
+		},
+	}
+	duplicate := *first
+	duplicate.Fee = types.ERC20Token{
+		Contract: tokenContract,
+		Amount:   sdkmath.NewInt(2),
+	}
+
+	s.NoError(s.Keeper().AddUnbatchedTx(s.Ctx, first))
+	err := s.Keeper().AddUnbatchedTx(s.Ctx, &duplicate)
+	s.Error(err)
+	s.Contains(err.Error(), "transaction id 7 already in pool")
+
+	unbatched := s.Keeper().GetUnbatchedTransactions(s.Ctx)
+	s.Len(unbatched, 1)
+	s.Equal(uint64(7), unbatched[0].Id)
+	s.Equal(sdkmath.NewInt(1), unbatched[0].Fee.Amount)
+}


### PR DESCRIPTION
## Summary

Addresses the Gravity FINDING-3 portion of #276.

Unbatched outgoing tx pool keys include fee + tx id, so the same outgoing tx id could be inserted more than once when the fee differs. This makes later batch construction operate on an inconsistent pool. The fix rejects duplicate tx ids at `AddUnbatchedTx` time and changes `pickUnBatchedTx` to return a duplicate-pool error instead of panicking if already-corrupted state is encountered.

## Tests

Passed:

```bash
git diff --check
```

Blocked by an unrelated upstream Ethermint compile error:

```bash
..\..\tools\go\bin\go.exe test .\x\gravity\keeper -run TestGravityKeeperTestSuite/TestAddUnbatchedTxRejectsDuplicateTxIDWithDifferentFee -count=1 -v
```

Failure:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```
