### PR TITLE
fix(wdistri): reject invalid region treasury address

### DIFF
--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -102,14 +102,19 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(totalMintCoin.AmountOf(params.BaseDenom).ToLegacyDec()).Quo(totalRegionShareDec)
 		regionAmount := amount.TruncateInt()
 		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
-		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()), regionCoins)
+		regionTreasureAddr := region.GetRegionTreasureAddr()
+		regionAddr, err := sdk.AccAddressFromBech32(regionTreasureAddr)
+		if err != nil {
+			return fmt.Errorf("invalid region treasury address %s: %w", regionTreasureAddr, err)
+		}
+		err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), regionAddr, regionCoins)
 		if err != nil {
 			return err
 		}
 		ctx.EventManager().EmitEvents(sdk.Events{
 			sdk.NewEvent(
 				types.EventTypeRegionTreasuryReward,
-				sdk.NewAttribute(types.AttributeKeyRegionTreasuryAddress, region.GetRegionTreasureAddr()),
+				sdk.NewAttribute(types.AttributeKeyRegionTreasuryAddress, regionTreasureAddr),
 				sdk.NewAttribute(types.AttributeKeyRegionId, region.GetRegionId()),
 				sdk.NewAttribute(sdk.AttributeKeyAmount, regionCoins.String()),
 			),

--- a/x/wdistri/keeper/keeper_test.go
+++ b/x/wdistri/keeper/keeper_test.go
@@ -237,6 +237,23 @@ func (suite *KeeperTestSuite) TestEndBlocker() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestAllocateBlockRewardReturnsErrorForInvalidRegionTreasuryAddress() {
+	ctx := suite.HelperNewContextWith(types.OneDayTotalBlocks)
+	suite.SetMockGetBalance(ctx, sdk.NewInt(100))
+
+	region := mocks.NewMockRegionI(suite.T())
+	region.EXPECT().GetRegionShare().Return(sdk.NewInt(1))
+	region.EXPECT().GetRegionTreasureAddr().Return("not-a-bech32-address")
+	suite.stakingKeeper.EXPECT().GetAllRegionI(ctx).Return([]wstakingtypes.RegionI{region})
+
+	var err error
+	suite.NotPanics(func() {
+		err = suite.App.DistrKeeper.AllocateBlockReward(ctx)
+	})
+	suite.Error(err)
+	suite.Contains(err.Error(), "invalid region treasury address not-a-bech32-address")
+}
+
 func (suite *KeeperTestSuite) mockGetRegionI(ctx sdk.Context, regionShare ...int) []string {
 	var addrs []string
 	if len(regionShare) == 0 {


### PR DESCRIPTION
## Summary

Addresses the WDISTRI-NEW-002 portion of #276.

`AllocateBlockReward` used `sdk.MustAccAddressFromBech32` for each stored region treasury address. If a corrupted or invalid region treasury address reaches state, daily reward distribution panics and can halt end-block processing. This change parses the treasury address explicitly and returns a normal error instead, so the existing end-block caller logs the failure instead of crashing the chain.

This is distinct from #1021, which fixes large reward amount truncation in the same function.

## Tests

Passed:

```bash
git diff --check
```

Blocked by an unrelated upstream Ethermint compile error:

```bash
..\..\tools\go\bin\go.exe test .\x\wdistri\keeper -run TestKeeperTestSuite/TestAllocateBlockRewardReturnsErrorForInvalidRegionTreasuryAddress -count=1 -v
```

Failure:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```
