### PR TITLE
fix(wmint): avoid begin blocker mint panics

### DIFF
--- a/x/wmint/abci.go
+++ b/x/wmint/abci.go
@@ -46,25 +46,30 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper, ic mintypes.InflationCalcula
 		} else {
 			mintedAmount.Set(newMinted)
 		}
-		k.SetMintedCoinAmount(ctx, mintedAmount)
 	default:
 		mintingUMECAmount = sdk.ZeroInt()
 	}
 
-	k.SetPerBlockMintCoinAmount(ctx, *mintingUMECAmount.BigInt())
-
 	mintedCoin := sdk.NewCoin(params.BaseDenom, mintingUMECAmount)
 	mintedCoins := sdk.NewCoins(mintedCoin)
-	err := k.MintCoins(ctx, mintedCoins)
+
+	cacheCtx, write := ctx.CacheContext()
+	k.SetMintedCoinAmount(cacheCtx, mintedAmount)
+	k.SetPerBlockMintCoinAmount(cacheCtx, *mintingUMECAmount.BigInt())
+
+	err := k.MintCoins(cacheCtx, mintedCoins)
 	if err != nil {
-		panic(err)
+		logger.Error("mint coins failed", "err", err)
+		return
 	}
 
 	// send the minted coins to me treasury module account
-	err = k.SendCoinsToTreasury(ctx, mintedCoins)
+	err = k.SendCoinsToTreasury(cacheCtx, mintedCoins)
 	if err != nil {
-		panic(err)
+		logger.Error("send minted coins to treasury failed", "err", err)
+		return
 	}
+	write()
 
 	if mintedCoin.Amount.IsInt64() {
 		defer telemetry.ModuleSetGauge(types.ModuleName, float32(mintedCoin.Amount.Int64()), "minted_tokens")

--- a/x/wmint/abci_test.go
+++ b/x/wmint/abci_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmetaearth/me-hub/x/wmint/types"
 	"github.com/openmetaearth/me-hub/x/wmint/types/mock_types"
 	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -176,16 +177,56 @@ func (suite *KeeperTestSuite) TestBeginBlocker() {
 		})
 	}
 }
+
+func (suite *KeeperTestSuite) TestBeginBlockerDoesNotPanicWhenMintFails() {
+	ctx := suite.newContextWith(1)
+	suite.wmintKeeper.SetMintedCoinAmount(ctx, *big.NewInt(0))
+	suite.bankKeeper.EXPECT().
+		MintCoins(testifymock.Anything, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin("umec", sdk.NewInt(79274480000)))).
+		Return(fmt.Errorf("mint failed"))
+
+	suite.NotPanics(func() {
+		BeginBlocker(ctx, suite.wmintKeeper, nil)
+	})
+
+	minted := suite.wmintKeeper.GetMintedCoinAmount(ctx)
+	suite.Equal(int64(0), minted.Int64())
+	perBlock := suite.wmintKeeper.GetPerBlockMintCoinAmount(ctx)
+	suite.Equal(int64(0), perBlock.Int64())
+}
+
+func (suite *KeeperTestSuite) TestBeginBlockerDoesNotCommitWhenTreasurySendFails() {
+	ctx := suite.newContextWith(1)
+	suite.wmintKeeper.SetMintedCoinAmount(ctx, *big.NewInt(0))
+	mintedCoins := sdk.NewCoins(sdk.NewCoin("umec", sdk.NewInt(79274480000)))
+	suite.bankKeeper.EXPECT().
+		MintCoins(testifymock.Anything, minttypes.ModuleName, mintedCoins).
+		Return(nil)
+	suite.bankKeeper.EXPECT().
+		SendCoinsFromModuleToModule(testifymock.Anything, minttypes.ModuleName, "treasury_pool", mintedCoins).
+		Return(fmt.Errorf("send failed"))
+
+	suite.NotPanics(func() {
+		BeginBlocker(ctx, suite.wmintKeeper, nil)
+	})
+
+	minted := suite.wmintKeeper.GetMintedCoinAmount(ctx)
+	suite.Equal(int64(0), minted.Int64())
+	perBlock := suite.wmintKeeper.GetPerBlockMintCoinAmount(ctx)
+	suite.Equal(int64(0), perBlock.Int64())
+}
+
 func (suite *KeeperTestSuite) newContextWith(height int64) sdk.Context {
 	return sdk.NewContext(suite.ctx.MultiStore(), tmproto.Header{Time: tmtime.Now(), Height: height}, false, log.NewNopLogger())
 }
 func (suite *KeeperTestSuite) setMockBankKeeper(ctx sdk.Context, mintAmount int64) {
+	_ = ctx
 
 	suite.bankKeeper.EXPECT().
-		MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin("umec", sdk.NewInt(mintAmount)))).
+		MintCoins(testifymock.Anything, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin("umec", sdk.NewInt(mintAmount)))).
 		Return(nil)
 
 	suite.bankKeeper.EXPECT().
-		SendCoinsFromModuleToModule(ctx, minttypes.ModuleName, "treasury_pool", sdk.NewCoins(sdk.NewCoin("umec", sdk.NewInt(mintAmount)))).
+		SendCoinsFromModuleToModule(testifymock.Anything, minttypes.ModuleName, "treasury_pool", sdk.NewCoins(sdk.NewCoin("umec", sdk.NewInt(mintAmount)))).
 		Return(nil)
 }


### PR DESCRIPTION
## Summary

Addresses the WMINT-NEW-001 portion of #276.

`BeginBlocker` previously panicked if minting or treasury transfer failed. It also wrote minted counters before those bank operations completed. This change runs the minted counters, `MintCoins`, and treasury transfer in a cache context, logs and returns on failure, and commits only after both bank operations succeed. That prevents begin-block failures from halting the chain or leaving partial wmint state behind.

## Tests

Passed:

```bash
..\..\tools\go\bin\go.exe test .\x\wmint -run "TestKeeperTestSuite/TestBeginBlocker(DoesNotPanicWhenMintFails|DoesNotCommitWhenTreasurySendFails)$" -count=1 -v
..\..\tools\go\bin\go.exe test .\x\wmint -count=1
git diff --check
```
