### PR TITLE
fix(wstaking): return unbond pool transfer errors

### DIFF
--- a/x/wstaking/keeper/delegation.go
+++ b/x/wstaking/keeper/delegation.go
@@ -34,7 +34,9 @@ func (k Keeper) Undelegate(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.
 	completionTime := ctx.BlockHeader().Time
 	// transfer the validator tokens to the not bonded pool
 	if !isMeid {
-		k.bondedTokensToNotBonded(ctx, returnAmount)
+		if err = k.bondedTokensToNotBonded(ctx, returnAmount); err != nil {
+			return completionTime, returnAmount, err
+		}
 		completionTime = ctx.BlockHeader().Time.Add(unbondingTime)
 		ubd := k.SetUnbondingDelegationEntry(ctx, delAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
 		k.InsertUBDQueue(ctx, ubd, completionTime)
@@ -99,11 +101,12 @@ func (k Keeper) Unbond(ctx sdk.Context, delAmount math.Int, isMeid bool, delegat
 }
 
 // bondedTokensToNotBonded transfers coins from the bonded to the not bonded pool within staking
-func (k Keeper) bondedTokensToNotBonded(ctx sdk.Context, tokens math.Int) {
+func (k Keeper) bondedTokensToNotBonded(ctx sdk.Context, tokens math.Int) error {
 	coins := sdk.NewCoins(sdk.NewCoin(k.BondDenom(ctx), tokens))
 	if err := k.bankKeeper.Extend().SendCoinsFromModuleToModuleWithTag(ctx, stakingtypes.BondedPoolName, stakingtypes.NotBondedPoolName, coins, "BondedTokensToNotBonded"); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // Delegate performs a delegation, set/update everything necessary within the store.


### PR DESCRIPTION
## Summary

Addresses the WStaking FINDING-6 portion of #276.

Regular undelegation moved returned tokens from the bonded pool to the not-bonded pool through `bondedTokensToNotBonded`, but that helper panicked on bank transfer errors. The outer `Undelegate` path already returns errors, so this changes the helper to return the bank error and propagates it to the caller instead of crashing the chain.

## Tests

Passed:

```bash
git diff --check
```

Blocked by an unrelated upstream Ethermint compile error:

```bash
..\..\tools\go\bin\go.exe test .\x\wstaking\keeper -run TestKeeperTestSuite/TestUndelegate -count=1 -v
```

Failure:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```
