### PR TITLE
fix(gravity): avoid double counting pending withdrawals

### DIFF
--- a/x/gravity/keeper/outgoing_tx_pool.go
+++ b/x/gravity/keeper/outgoing_tx_pool.go
@@ -26,12 +26,6 @@ func (k Keeper) AddToOutgoingPool(ctx sdk.Context, sender sdk.AccAddress, receiv
 			totalInVouchers.Amount.String(), bridgeToken.Supply.String(), k.moduleName)
 	}
 
-	totalPending := k.GetOutgoingPendingTxTotal(ctx, k.moduleName, bridgeToken)
-	if totalInVouchers.Amount.Add(totalPending).GT(bridgeToken.Supply) {
-		return 0, errorsmod.Wrapf(types.ErrInvalid, "total pending amount %s plus current amount %s exceeds bridge token supply %s in %s chain",
-			totalPending.String(), totalInVouchers.Amount.String(), bridgeToken.Supply.String(), k.moduleName)
-	}
-
 	sendCoins := sdk.NewCoins(totalInVouchers)
 	// If it is an external blockchain asset we burn it send coins to module in prep for burn
 	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, k.moduleName, sendCoins); err != nil {

--- a/x/gravity/keeper/outgoing_tx_pool_test.go
+++ b/x/gravity/keeper/outgoing_tx_pool_test.go
@@ -39,3 +39,40 @@ func (s *KeeperTestSuite) TestKeeper_OutgoingAncCancel() {
 	s.Equal(s.App.BankKeeper.GetAllBalances(s.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 	s.Equal(sendAmount, s.App.BankKeeper.GetSupply(s.Ctx, denom))
 }
+
+func (s *KeeperTestSuite) TestAddToOutgoingPoolAllowsMultipleWithdrawalsAfterBurnedPendingSupply() {
+	sender := helpers.GenerateAddress().Bytes()
+	denom := "testpending"
+	initialAmount := sdk.NewCoin(denom, sdkmath.NewInt(100))
+	bridgeToken := s.NewBridgeToken(sender, initialAmount)
+	receiver := helpers.GenerateAddress().Hex()
+
+	_, err := s.Keeper().AddToOutgoingPool(
+		s.Ctx,
+		sender,
+		receiver,
+		sdk.NewCoin(denom, sdkmath.NewInt(30)),
+		sdk.NewCoin(denom, sdkmath.NewInt(10)),
+	)
+	s.Require().NoError(err)
+
+	tokenAfterFirst, err := s.Keeper().GetBridgeTokenByContract(s.Ctx, bridgeToken.ContractAddress)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewInt(60), tokenAfterFirst.Supply)
+	s.Require().Equal(sdkmath.NewInt(60), s.App.BankKeeper.GetBalance(s.Ctx, sender, denom).Amount)
+
+	_, err = s.Keeper().AddToOutgoingPool(
+		s.Ctx,
+		sender,
+		receiver,
+		sdk.NewCoin(denom, sdkmath.NewInt(20)),
+		sdk.NewCoin(denom, sdkmath.NewInt(5)),
+	)
+	s.Require().NoError(err)
+
+	tokenAfterSecond, err := s.Keeper().GetBridgeTokenByContract(s.Ctx, bridgeToken.ContractAddress)
+	s.Require().NoError(err)
+	s.Require().Equal(sdkmath.NewInt(35), tokenAfterSecond.Supply)
+	s.Require().Equal(sdkmath.NewInt(35), s.App.BankKeeper.GetBalance(s.Ctx, sender, denom).Amount)
+	s.Require().Len(s.Keeper().GetUnbatchedTransactions(s.Ctx), 2)
+}


### PR DESCRIPTION
## Summary

Fixes #1049.

`BridgeToken.Supply` is decremented as soon as `AddToOutgoingPool` accepts and burns a withdrawal. The pending outgoing txs are therefore already excluded from supply. The later `totalPending + current > supply` check double-counted those burned pending withdrawals and rejected otherwise valid follow-up withdrawals.

This removes that second pending-against-supply check and adds regression coverage for two pending withdrawals where the second spends only part of the remaining circulating vouchers.

## Tests

Passed:

```bash
git diff --check
```

Blocked by an unrelated upstream Ethermint compile error:

```bash
..\..\tools\go\bin\go.exe test .\x\gravity\keeper -run TestGravityKeeperTestSuite/TestAddToOutgoingPoolAllowsMultipleWithdrawalsAfterBurnedPendingSupply -count=1 -v
```

Failure:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```
