### PR TITLE
fix(gravity): count attestations by observed relayer set

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -78,8 +78,10 @@ func (k Keeper) Attest(ctx sdk.Context, relayerAddr sdk.AccAddress, claim types.
 func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim types.ExternalClaim) {
 	// If the attestation has not yet been Observed, sum up the votes and see if it is ready to apply to the state.
 	// This conditional stops the attestation from accidentally being applied twice.
-	// Sum the current powers of all validators who have voted and see if it passes the current threshold
-	totalPower := k.GetLastTotalPower(ctx)
+	// Sum the powers of all relayers who have voted and see if it passes the current threshold.
+	// Once the external bridge has observed a relayer set, external-event claims must be
+	// counted against that observed set instead of the immediately updated local relayer set.
+	observedPowers, totalPower := k.attestationPowerByExternalAddress(ctx)
 	requiredPower := types.AttestationVotesPowerThreshold.Mul(totalPower).Quo(sdk.NewIntFromUint64(types.PowerBase))
 	attestationPower := sdkmath.NewInt(0)
 
@@ -96,6 +98,15 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 			continue
 		}
 		relayerPower := relayer.GetPower()
+		if observedPowers != nil {
+			observedPower, ok := observedPowers[relayer.ExternalAddress]
+			if !ok {
+				k.Logger(ctx).Info("TryAttestation", "relayer not in last observed relayer set", relayerAddr.String(), "externalAddress", relayer.ExternalAddress, "claimEventNonce",
+					claim.GetEventNonce(), "claimType", claim.GetType(), "claimHeight", claim.GetBlockHeight())
+				continue
+			}
+			relayerPower = observedPower
+		}
 		// Add it to the attestation power's sum
 		attestationPower = attestationPower.Add(relayerPower)
 		if attestationPower.LT(requiredPower) {
@@ -125,6 +136,28 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 		k.PruneAttestations(ctx)
 		break
 	}
+}
+
+func (k Keeper) attestationPowerByExternalAddress(ctx sdk.Context) (map[string]sdkmath.Int, sdkmath.Int) {
+	lastObserved := k.GetLastObservedRelayerSet(ctx)
+	if lastObserved == nil || len(lastObserved.Members) == 0 {
+		return nil, k.GetLastTotalPower(ctx)
+	}
+
+	powers := make(map[string]sdkmath.Int, len(lastObserved.Members))
+	totalPower := sdkmath.ZeroInt()
+	for _, member := range lastObserved.Members {
+		memberPower := sdkmath.NewIntFromUint64(member.Power)
+		if memberPower.IsZero() {
+			continue
+		}
+		powers[member.ExternalAddress] = memberPower
+		totalPower = totalPower.Add(memberPower)
+	}
+	if totalPower.IsZero() {
+		return nil, k.GetLastTotalPower(ctx)
+	}
+	return powers, totalPower
 }
 
 // processAttestation actually applies the attestation to the consensus state

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -18,6 +18,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/testutil/helpers"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 	trontypes "github.com/openmetaearth/me-hub/x/tron/types"
 )
@@ -193,6 +194,86 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 				"handler failed; retries are now impossible",
 			probeClaim.GetEventNonce())
 	}
+}
+
+func (s *KeeperTestSuite) TestNewRelayerVotesDoNotCountBeforeExternalSetObservesIt() {
+	k := s.Keeper()
+	bondRelayer := func(index int) {
+		msg := &types.MsgBondedRelayer{
+			RelayerAddress:  s.relayerAddrs[index].String(),
+			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[index].PublicKey),
+			DelegateAmount:  sdk.NewCoin(params.BaseDenom, sdkmath.NewInt(1_000_000_000)),
+			ChainName:       s.chainName,
+		}
+		_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msg)
+		s.Require().NoError(err)
+	}
+
+	for _, index := range []int{0, 1, 2} {
+		bondRelayer(index)
+	}
+
+	k.SetLastObservedRelayerSet(s.Ctx, &types.RelayerSet{
+		Nonce:  1,
+		Height: uint64(s.Ctx.BlockHeight()),
+		Members: types.BridgeValidators{
+			{Power: 3000, ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)},
+			{Power: 3000, ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[1].PublicKey)},
+			{Power: 4000, ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[2].PublicKey)},
+		},
+	})
+
+	// Relayer 3 is bonded locally, but the external bridge has not observed a
+	// relayer-set update that includes its external address.
+	bondRelayer(3)
+
+	tokenContract := helpers.GenExternalAddr(s.chainName)
+	receiver := s.relayerAddrs[4]
+	sender := helpers.GenExternalAddr(s.chainName)
+	amount := sdkmath.NewInt(12345)
+	k.SetBridgeToken(s.Ctx, &types.BridgeToken{
+		ContractAddress: tokenContract,
+		Denom:           "bug403",
+		Name:            "Bug 403",
+		Symbol:          "BUG403",
+		Decimal:         6,
+		Supply:          sdkmath.ZeroInt(),
+	})
+
+	newClaim := func(relayerIndex int) *types.MsgSendToMeClaim {
+		return &types.MsgSendToMeClaim{
+			EventNonce:     1,
+			BlockHeight:    1000,
+			TokenContract:  tokenContract,
+			Amount:         amount,
+			Sender:         sender,
+			Receiver:       receiver.String(),
+			RelayerAddress: s.relayerAddrs[relayerIndex].String(),
+			ChainName:      s.chainName,
+		}
+	}
+
+	for _, relayerIndex := range []int{0, 1, 3} {
+		_, err := s.MsgServer().SendToMeClaim(sdk.WrapSDKContext(s.Ctx), newClaim(relayerIndex))
+		s.Require().NoError(err)
+	}
+
+	probeClaim := newClaim(0)
+	att := k.GetAttestation(s.Ctx, probeClaim.EventNonce, probeClaim.ClaimHash())
+	s.Require().NotNil(att)
+	s.Require().False(att.Observed, "new local relayer must not help finalize before the external bridge observes it")
+	s.Require().Equal(sdkmath.ZeroInt(), s.App.BankKeeper.GetBalance(s.Ctx, receiver, "bug403").Amount)
+
+	_, err := s.MsgServer().SendToMeClaim(sdk.WrapSDKContext(s.Ctx), newClaim(2))
+	s.Require().NoError(err)
+	att = k.GetAttestation(s.Ctx, probeClaim.EventNonce, probeClaim.ClaimHash())
+	s.Require().NotNil(att)
+	s.Require().True(att.Observed, "old observed relayer quorum should still finalize the claim")
+	s.Require().Equal(amount, s.App.BankKeeper.GetBalance(s.Ctx, receiver, "bug403").Amount)
+
+	bridgeToken, err := k.GetBridgeTokenByContract(s.Ctx, tokenContract)
+	s.Require().NoError(err)
+	s.Require().Equal(amount, bridgeToken.Supply)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #403.

Gravity attestations previously counted votes using the current local relayer set and `LastTotalPower`. During a relayer-set transition, a newly bonded local relayer could therefore help finalize external bridge claims before the external bridge had observed a relayer-set update that trusted that relayer's external address.

This changes attestation quorum calculation to use `LastObservedRelayerSet` whenever it is available. Votes from relayers whose external address is not in that observed set are ignored, and the quorum denominator is the observed set's power. Empty or missing observed sets keep the previous local-power fallback for startup/genesis compatibility.

The regression covers `MsgSendToMeClaim`: A+B+D is enough under the old local-current-set calculation, but D is not in the last externally observed relayer set, so the claim must remain unobserved and no vouchers are minted until C, an observed relayer, votes.

## Tests

Passed:

```bash
git diff --check
```

Blocked by an unrelated upstream Ethermint compile error:

```bash
..\..\tools\go\bin\go.exe test .\x\gravity\keeper -run "TestGravityKeeperTestSuite/TestNewRelayerVotesDoNotCountBeforeExternalSetObservesIt$" -count=1 -v
```

Failure:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```
