### PR TITLE
fix(eibc): return query input errors accurately

### DIFF
--- a/x/eibc/keeper/grpc_query.go
+++ b/x/eibc/keeper/grpc_query.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -42,19 +43,28 @@ func (q Querier) DemandOrderById(goCtx context.Context, req *types.QueryGetDeman
 	var demandOrder *types.DemandOrder
 	var err error
 	statuses := []commontypes.Status{commontypes.Status_PENDING, commontypes.Status_FINALIZED, commontypes.Status_REVERTED}
-	for _, status := range statuses {
-		demandOrder, err = q.GetDemandOrder(ctx, status, req.Id)
+	for _, orderStatus := range statuses {
+		demandOrder, err = q.GetDemandOrder(ctx, orderStatus, req.Id)
 		if err == nil && demandOrder != nil {
 			return &types.QueryGetDemandOrderResponse{DemandOrder: demandOrder}, nil
 		}
+		if err != nil && !errors.Is(err, types.ErrDemandOrderDoesNotExist) {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
-	return nil, status.Error(codes.Internal, err.Error())
+	return nil, status.Error(codes.NotFound, types.ErrDemandOrderDoesNotExist.Error())
 }
 
 func (q Querier) DemandOrdersByStatus(goCtx context.Context, req *types.QueryDemandOrdersByStatusRequest) (*types.QueryDemandOrdersByStatusResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
+	if req.FulfillmentState != types.FulfillmentState_UNDEFINED {
+		if _, ok := types.FulfillmentState_name[int32(req.FulfillmentState)]; !ok {
+			return nil, status.Error(codes.InvalidArgument, "invalid fulfillment state")
+		}
+	}
+
 	// Get the demand orders by status, with optional filters
 	demandOrders, err := q.ListDemandOrdersByStatus(sdk.UnwrapSDKContext(goCtx), req.Status, int(req.Limit), filterOpts(req)...)
 	if err != nil {

--- a/x/eibc/keeper/grpc_query_test.go
+++ b/x/eibc/keeper/grpc_query_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	commontypes "github.com/openmetaearth/me-hub/x/common/types"
 	"github.com/openmetaearth/me-hub/x/eibc/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (suite *KeeperTestSuite) TestParamsQuery() {
@@ -31,6 +33,12 @@ func (suite *KeeperTestSuite) TestQueryDemandOrderById() {
 	res, err := suite.queryClient.DemandOrderById(sdk.WrapSDKContext(suite.Ctx), &types.QueryGetDemandOrderRequest{})
 	suite.Require().Error(err)
 	suite.Require().Nil(res)
+	suite.Require().Equal(codes.NotFound, status.Code(err))
+
+	res, err = suite.queryClient.DemandOrderById(sdk.WrapSDKContext(suite.Ctx), &types.QueryGetDemandOrderRequest{Id: "does-not-exist"})
+	suite.Require().Error(err)
+	suite.Require().Nil(res)
+	suite.Require().Equal(codes.NotFound, status.Code(err))
 
 	// Create a demand order with status pending
 	recipientAddress := apptesting.AddTestAddrs(suite.App, suite.Ctx, 1, math.NewInt(1000))[0]
@@ -102,4 +110,12 @@ func (suite *KeeperTestSuite) TestQueryDemandOrdersByStatus() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(res.DemandOrders)
 	suite.Require().Equal(false, res.DemandOrders[0].IsFulfilled(), "Expected 0 demand orders with fulfillment state unfulfilled")
+
+	res, err = suite.queryClient.DemandOrdersByStatus(sdk.WrapSDKContext(suite.Ctx), &types.QueryDemandOrdersByStatusRequest{
+		Status:           commontypes.Status_PENDING,
+		FulfillmentState: types.FulfillmentState(99),
+	})
+	suite.Require().Error(err)
+	suite.Require().Nil(res)
+	suite.Require().Equal(codes.InvalidArgument, status.Code(err))
 }


### PR DESCRIPTION
## Summary

Fixes #1015.
Fixes #1016.

This tightens eIBC query error handling:

- `DemandOrderById` now returns `codes.NotFound` when the order id is absent from all demand-order status stores, instead of surfacing that normal user miss as `codes.Internal`.
- `DemandOrdersByStatus` now rejects unknown `FulfillmentState` enum values with `codes.InvalidArgument` instead of treating them as `UNFULFILLED`.

Regression coverage checks the gRPC status codes for both paths.

## Tests

Passed:

```bash
..\..\tools\go\bin\go.exe test .\x\eibc\types -count=1
git diff --check
```

Blocked by an unrelated upstream Ethermint compile error before eIBC keeper tests can run:

```bash
..\..\tools\go\bin\go.exe test .\x\eibc\keeper -run "TestKeeperTestSuite/TestQueryDemandOrderById$" -count=1 -v
..\..\tools\go\bin\go.exe test .\x\eibc\keeper -run "TestKeeperTestSuite/TestQueryDemandOrdersByStatus$" -count=1 -v
```

Failure:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```
