### PR TITLE
fix(sequencer): return not found for missing handoff

### DIFF
--- a/x/sequencer/keeper/grpc_query_sequencers_by_rollapp.go
+++ b/x/sequencer/keeper/grpc_query_sequencers_by_rollapp.go
@@ -100,7 +100,7 @@ func (k Keeper) ReplaceProposerInfo(goCtx context.Context, req *types.QueryRepla
 			req.RollappId, err.Error())
 	}
 	if nil == replaceProposer {
-		return nil, nil
+		return nil, status.Error(codes.NotFound, "replace proposer not found")
 	}
 	return &types.QueryReplaceProposerInfoResponse{
 		ReplaceProposer: *replaceProposer,

--- a/x/sequencer/keeper/grpc_query_sequencers_by_rollapp_test.go
+++ b/x/sequencer/keeper/grpc_query_sequencers_by_rollapp_test.go
@@ -173,3 +173,16 @@ func (suite *SequencerTestSuite) TestSequencersByRollappByStatusQuery() {
 		})
 	}
 }
+
+func (suite *SequencerTestSuite) TestReplaceProposerInfoNoHandoffReturnsNotFound() {
+	suite.SetupTest()
+
+	rollappId := suite.CreateDefaultRollapp()
+	response, err := suite.App.SequencerKeeper.ReplaceProposerInfo(suite.Ctx, &types.QueryReplaceProposerInfoRequest{
+		RollappId: rollappId,
+	})
+
+	require.Nil(suite.T(), response)
+	require.Error(suite.T(), err)
+	require.Equal(suite.T(), codes.NotFound, status.Code(err))
+}


### PR DESCRIPTION
## Summary

Fixes #1017.

`ReplaceProposerInfo` returned `(nil, nil)` when the rollapp exists but there is no pending replace-proposer handoff. This changes the no-handoff branch to return `codes.NotFound` instead, so gRPC callers always get either a concrete response or an explicit error.

This is separate from #977, which handles nil request input for the same query. This PR only changes the no stored handoff path after the rollapp exists.

## Tests

Passed:

```bash
..\..\tools\go\bin\go.exe test .\x\sequencer\types -count=1
git diff --check
```

Blocked by an unrelated upstream Ethermint compile error before sequencer keeper tests can run:

```bash
..\..\tools\go\bin\go.exe test .\x\sequencer\keeper -run "TestSequencerKeeperTestSuite/TestReplaceProposerInfoNoHandoffReturnsNotFound$" -count=1 -v
..\..\tools\go\bin\go.exe test .\x\sequencer\keeper -count=1
```

Failure:

```text
github.com/openmetaearth/ethermint/app/ante/eip712.go:289:36: undefined: secp256k1.RecoverPubkey
github.com/openmetaearth/ethermint/app/ante/eip712.go:315:17: undefined: secp256k1.VerifySignature
```
