### PR TITLE
fix: restrict rollapp skip-delay to GlobalDao

### DIFF
--- a/x/rollapp/keeper/msg_server_skip_delay_rollapp.go
+++ b/x/rollapp/keeper/msg_server_skip_delay_rollapp.go
@@ -12,7 +12,7 @@ import (
 func (k msgServer) SkipDelayRollapp(goCtx context.Context, msg *types.MsgSkipDelayRollapp) (*types.MsgSkipDelayRollappResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if !k.daoKeeper.IsDao(ctx, msg.Creator) {
+	if !k.daoKeeper.IsGlobalDao(ctx, msg.Creator) {
 		return nil, types.ErrCheckGlobalDao
 	}
 

--- a/x/rollapp/keeper/msg_server_skip_delay_rollapp_test.go
+++ b/x/rollapp/keeper/msg_server_skip_delay_rollapp_test.go
@@ -1,0 +1,29 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+)
+
+func (suite *RollappTestSuite) TestSkipDelayRollappRequiresGlobalDao() {
+	suite.SetupTest()
+	suite.InitializeDao()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+	rollappID := suite.CreateDefaultRollapp()
+
+	_, err := suite.msgServer.SkipDelayRollapp(goCtx, &types.MsgSkipDelayRollapp{
+		Creator:   suite.Dao.MeidDao,
+		RollappId: rollappID,
+		Skip:      true,
+	})
+	suite.Require().ErrorIs(err, types.ErrCheckGlobalDao)
+	suite.Require().False(suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollappID))
+
+	_, err = suite.msgServer.SkipDelayRollapp(goCtx, &types.MsgSkipDelayRollapp{
+		Creator:   suite.Dao.GlobalDao,
+		RollappId: rollappID,
+		Skip:      true,
+	})
+	suite.Require().NoError(err)
+	suite.Require().True(suite.App.RollappKeeper.IsSkipDelayRollapp(suite.Ctx, rollappID))
+}

--- a/x/rollapp/types/expected_keepers.go
+++ b/x/rollapp/types/expected_keepers.go
@@ -15,5 +15,5 @@ type ChannelKeeper interface {
 }
 
 type DaoKeeper interface {
-	IsDao(ctx sdk.Context, address string) bool
+	IsGlobalDao(ctx sdk.Context, address string) bool
 }


### PR DESCRIPTION
## Summary
- require `IsGlobalDao` before `MsgSkipDelayRollapp` can toggle rollapp skip-delay state
- narrow the rollapp DAO keeper dependency to the global DAO authority check
- add regression coverage showing `MeidDao` is rejected while `GlobalDao` can update skip-delay

Fixes #84

## Validation
- `git diff --check`
- Not run: Go toolchain is not installed in this local Windows checkout