### PR TITLE
fix(wstaking): allow historical fixed deposit migration rates

### DIFF
--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -294,22 +294,19 @@ func (k Keeper) transferDeposit(ctx sdk.Context, fromRegion, toRegion *types.Reg
 	}
 	//It is a regional rule used to define parameters such as fixed deposit term and interest rate for a certain region.
 	depositConfig := k.GetAllFixedDepositCfg(ctx, toRegion.RegionId)
-	depositConfigMap := make(map[int64]sdk.Dec)
+	depositConfigMap := make(map[int64]types.FixedDepositCfg)
 	for _, cfg := range depositConfig {
-		if cfg.Status == types.RegionFixedDepositCfgStatusInactive {
-			return errors.New("fixed deposit cfg status is inactive")
-		}
-		depositConfigMap[cfg.Term] = cfg.Rate
+		depositConfigMap[cfg.Term] = cfg
 	}
 	totalFixedDepositByAcc := sdk.ZeroInt()
 	totalFixedInterestCoin := sdk.ZeroInt()
 	for _, fixed := range fixedDeposits {
 		totalFixedDepositByAcc = totalFixedDepositByAcc.Add(fixed.Principal.Amount)
 		totalFixedInterestCoin = totalFixedInterestCoin.Add(fixed.Interest.Amount)
-		//check toRegion deposit config is exist and deposit rate is equal
-		rate, exists := depositConfigMap[fixed.Term]
-		if !exists || !rate.Equal(fixed.Rate) {
-			return errors.New(fmt.Sprintf("deposit cfg not same.rate=%s,fixed.Rate=%s,exists=%v,fixed.Term=%v", rate.String(), fixed.Rate.String(), exists, fixed.Term))
+		// Historical deposits keep their stored rate and interest. Migration only
+		// needs the destination term to still exist and accept deposits.
+		if err := validateTransferFixedDepositCfg(fixed, depositConfigMap); err != nil {
+			return err
 		}
 
 		err := k.IncreaseFixedDepositCountOfCfg(ctx, toRegion.RegionId, fixed.Term)
@@ -360,6 +357,17 @@ func (k Keeper) transferDeposit(ctx sdk.Context, fromRegion, toRegion *types.Reg
 			sdk.NewAttribute(types.AttributeKeyFixedDeposit, totalFixedInterestCoin.String()+params.BaseDenom),
 		),
 	})
+	return nil
+}
+
+func validateTransferFixedDepositCfg(fixed types.FixedDeposit, depositConfigMap map[int64]types.FixedDepositCfg) error {
+	cfg, exists := depositConfigMap[fixed.Term]
+	if !exists {
+		return errors.New(fmt.Sprintf("deposit cfg not found.exists=%v,fixed.Term=%v", exists, fixed.Term))
+	}
+	if cfg.Status != types.RegionFixedDepositCfgStatusActive {
+		return errors.New(fmt.Sprintf("fixed deposit cfg status is not active.term=%v,status=%v", fixed.Term, cfg.Status))
+	}
 	return nil
 }
 

--- a/x/wstaking/keeper/kyc_reward_transfer_deposit_test.go
+++ b/x/wstaking/keeper/kyc_reward_transfer_deposit_test.go
@@ -1,0 +1,38 @@
+package keeper
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTransferFixedDepositCfgAllowsHistoricalRateMismatch(t *testing.T) {
+	fixed := types.FixedDeposit{
+		Term: 30,
+		Rate: sdk.NewDecWithPrec(1, 1),
+	}
+
+	cfgs := map[int64]types.FixedDepositCfg{
+		30: {
+			Term:   30,
+			Rate:   sdk.NewDecWithPrec(2, 1),
+			Status: types.RegionFixedDepositCfgStatusActive,
+		},
+	}
+
+	require.NoError(t, validateTransferFixedDepositCfg(fixed, cfgs))
+}
+
+func TestValidateTransferFixedDepositCfgRejectsMissingOrInactiveTerm(t *testing.T) {
+	fixed := types.FixedDeposit{Term: 30}
+
+	require.Error(t, validateTransferFixedDepositCfg(fixed, map[int64]types.FixedDepositCfg{}))
+	require.Error(t, validateTransferFixedDepositCfg(fixed, map[int64]types.FixedDepositCfg{
+		30: {
+			Term:   30,
+			Status: types.RegionFixedDepositCfgStatusInactive,
+		},
+	}))
+}


### PR DESCRIPTION
Fixes #933.

## Summary
- keeps migrated fixed deposits on their stored historical rate and interest instead of requiring the destination region's current config rate to match
- requires only that the destination region still has an active config for each migrated fixed-deposit term
- adds a focused regression test for historical-rate mismatch plus missing/inactive term rejection

## Tests
- Passed: `git diff --check`
- Attempted: `..\..\tools\go\bin\go.exe test .\x\wstaking\keeper -run TestValidateTransferFixedDepositCfg -count=1 -v`
  - Blocked by existing upstream dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.
- Attempted: `..\..\tools\go\bin\go.exe test .\x\wstaking\types -count=1`
  - Blocked by existing `MsgIbcTransferFromRegionTreasure` fixture failures with blank IBC port/channel identifiers.