### PR TITLE
fix(kyc): preserve non-dao issuers on dao update

### DIFF
--- a/x/kyc/keeper/did.go
+++ b/x/kyc/keeper/did.go
@@ -45,7 +45,7 @@ func (k Keeper) SetKycIssers(ctx sdk.Context, oldDaoAddress, newDaoAddress []str
 		return fmt.Errorf("kyc service not found")
 	}
 
-	dids := []string{}
+	daoDIDs := []string{}
 	for i, dao := range oldDaoAddress {
 		did, found := k.GetDID(ctx, sdk.MustAccAddressFromBech32(dao))
 		if !found {
@@ -62,10 +62,32 @@ func (k Keeper) SetKycIssers(ctx sdk.Context, oldDaoAddress, newDaoAddress []str
 
 		didInfo.Address = newDaoAddress[i]
 		k.SetDidInfo(ctx, did, didInfo)
-		dids = append(dids, did)
+		daoDIDs = append(daoDIDs, did)
 	}
 
-	service.Issuers = dids
+	service.Issuers = mergeKycIssuerDIDs(service.Issuers, daoDIDs)
 	k.didKeeper.SetService(ctx, types.ModuleName, service)
 	return nil
+}
+
+func mergeKycIssuerDIDs(existingIssuers, daoDIDs []string) []string {
+	seen := make(map[string]struct{}, len(existingIssuers)+len(daoDIDs))
+	merged := make([]string, 0, len(existingIssuers)+len(daoDIDs))
+
+	for _, issuer := range existingIssuers {
+		if _, ok := seen[issuer]; ok {
+			continue
+		}
+		merged = append(merged, issuer)
+		seen[issuer] = struct{}{}
+	}
+	for _, did := range daoDIDs {
+		if _, ok := seen[did]; ok {
+			continue
+		}
+		merged = append(merged, did)
+		seen[did] = struct{}{}
+	}
+
+	return merged
 }

--- a/x/kyc/keeper/kyc_issuers_test.go
+++ b/x/kyc/keeper/kyc_issuers_test.go
@@ -1,0 +1,20 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeKycIssuerDIDsPreservesExistingNonDaoIssuers(t *testing.T) {
+	merged := mergeKycIssuerDIDs(
+		[]string{"did:dao:global", "did:third-party", "did:dao:global"},
+		[]string{"did:dao:global", "did:dao:meid"},
+	)
+
+	require.Equal(t, []string{
+		"did:dao:global",
+		"did:third-party",
+		"did:dao:meid",
+	}, merged)
+}


### PR DESCRIPTION
Fixes #668.

## Summary
- keeps existing KYC service issuers when DAO addresses are updated
- updates DAO DID address ownership as before, then merges the DAO issuer DIDs back into the existing issuer list instead of replacing it
- adds focused coverage to preserve third-party issuers and avoid duplicate DAO issuer entries

## Tests
- Passed: `git diff --check`
- Passed: `git diff --cached --check`
- Attempted: `..\..\tools\go\bin\go.exe test .\x\kyc\keeper -run TestMergeKycIssuerDIDsPreservesExistingNonDaoIssuers -count=1 -v`
  - Blocked by existing upstream dependency compile error in `github.com/openmetaearth/ethermint/app/ante/eip712.go`: missing `secp256k1.RecoverPubkey` and `secp256k1.VerifySignature`.
- Attempted: `..\..\tools\go\bin\go.exe test .\x\kyc\types -count=1`
  - Blocked by existing genesis fixture failures in `x/kyc/types` (`default_is_invalid` and `valid_genesis_state`).