### PR TITLE
fix(types): prevent uint64 checkpoint signature truncation overflow

### DIFF
--- a/x/gravity/types/checkpoint_uint64_overflow_poc_test.go
+++ b/x/gravity/types/checkpoint_uint64_overflow_poc_test.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/openmetaearth/me-hub/utils"
+)
+
+func TestOutgoingBatchCheckpointMustEncodeUint64TimeoutWithoutInt64Truncation(t *testing.T) {
+	const gravityID = "me-gravity"
+	const firstUint64AboveInt64 = uint64(1) << 63
+
+	batch := &OutgoingTxBatch{
+		BatchNonce:    1,
+		BatchTimeout:  firstUint64AboveInt64,
+		TokenContract: "0x3fC91A3afd03b6dd40d11400240d25ffb4458d99",
+		FeeReceive:    "0x3fC91A3afd03b6dd40d11400240d25ffb4458d99",
+	}
+
+	actual, err := batch.GetCheckpoint(gravityID)
+	require.NoError(t, err)
+
+	// Calculate the correct expected solidity encoding using big.Int SetUint64
+	expected := correctOutgoingBatchCheckpointForUint64Timeout(t, batch, gravityID)
+
+	require.Equal(t, hex.EncodeToString(expected), hex.EncodeToString(actual),
+		"batch checkpoint must match the Solidity uint256 encoding of the stored uint64 timeout")
+}
+
+func correctOutgoingBatchCheckpointForUint64Timeout(t *testing.T, m *OutgoingTxBatch, gravityIDString string) []byte {
+	gravityID, err := utils.StrToByte32(gravityIDString)
+	require.NoError(t, err)
+
+	batchMethodName, err := utils.StrToByte32("transactionBatch")
+	require.NoError(t, err)
+
+	txAmounts := make([]*big.Int, len(m.Transactions))
+	txDestinations := make([]gethcommon.Address, len(m.Transactions))
+	txFees := make([]*big.Int, len(m.Transactions))
+	for i, tx := range m.Transactions {
+		txAmounts[i] = tx.Token.Amount.BigInt()
+		txDestinations[i] = toHexAddr(gravityIDString, tx.DestAddress)
+		txFees[i] = tx.Fee.Amount.BigInt()
+	}
+
+	abiEncodedBatch, err := outgoingBatchTxCheckpointABI.Pack("submitBatch",
+		gravityID,
+		batchMethodName,
+		txAmounts,
+		txDestinations,
+		txFees,
+		new(big.Int).SetUint64(m.BatchNonce),
+		toHexAddr(gravityIDString, m.TokenContract),
+		new(big.Int).SetUint64(m.BatchTimeout),
+		toHexAddr(gravityIDString, m.FeeReceive),
+	)
+	require.NoError(t, err)
+
+	return crypto.Keccak256Hash(abiEncodedBatch[4:]).Bytes()
+}

--- a/x/gravity/types/types.go
+++ b/x/gravity/types/types.go
@@ -193,12 +193,12 @@ func (r *RelayerSet) GetCheckpoint(gravityIDStr string) ([]byte, error) {
 	for i, m := range r.Members {
 		//memberAddresses[i] = gethcommon.HexToAddress(m.ExternalAddress)
 		memberAddresses[i] = toHexAddr(gravityIDStr, m.ExternalAddress)
-		convertedPowers[i] = big.NewInt(int64(m.Power))
+		convertedPowers[i] = new(big.Int).SetUint64(m.Power)
 	}
 	// the word 'checkpoint' needs to be the same as the 'name' above in the checkpointAbiJson
 	// but other than that it's a constant that has no impact on the output. This is because
 	// it gets encoded as a function name which we must then discard.
-	packBytes, packErr := relayerSetCheckpointABI.Pack("checkpoint", gravityID, checkpoint, big.NewInt(int64(r.Nonce)), memberAddresses, convertedPowers)
+	packBytes, packErr := relayerSetCheckpointABI.Pack("checkpoint", gravityID, checkpoint, new(big.Int).SetUint64(r.Nonce), memberAddresses, convertedPowers)
 
 	// this should never happen outside of test since any case that could crash on encoding
 	// should be filtered above.
@@ -305,9 +305,9 @@ func (m *OutgoingTxBatch) GetCheckpoint(gravityIDString string) ([]byte, error) 
 		txAmounts,
 		txDestinations,
 		txFees,
-		big.NewInt(int64(m.BatchNonce)),
+		new(big.Int).SetUint64(m.BatchNonce),
 		toHexAddr(gravityIDString, m.TokenContract),
-		big.NewInt(int64(m.BatchTimeout)),
+		new(big.Int).SetUint64(m.BatchTimeout),
 		toHexAddr(gravityIDString, m.FeeReceive),
 	)
 	// this should never happen outside of test since any case that could crash on encoding

--- a/x/tron/types/checkpoint.go
+++ b/x/tron/types/checkpoint.go
@@ -16,7 +16,7 @@ func GetCheckpointRelayerSet(relayerSet *types.RelayerSet, gravityIDStr string) 
 	powers := make([]*big.Int, len(relayerSet.Members))
 	for i, member := range relayerSet.Members {
 		addresses[i] = member.ExternalAddress
-		powers[i] = big.NewInt(int64(member.Power))
+		powers[i] = new(big.Int).SetUint64(member.Power)
 	}
 
 	gravityID, err := utils.StrToByte32(gravityIDStr)
@@ -31,7 +31,7 @@ func GetCheckpointRelayerSet(relayerSet *types.RelayerSet, gravityIDStr string) 
 	params := []abi.Param{
 		{"bytes32": gravityID},
 		{"bytes32": checkpoint},
-		{"uint256": big.NewInt(int64(relayerSet.Nonce))},
+		{"uint256": new(big.Int).SetUint64(relayerSet.Nonce)},
 		{"address[]": addresses},
 		{"uint256[]": powers},
 	}
@@ -68,9 +68,9 @@ func GetCheckpointConfirmBatch(txBatch *types.OutgoingTxBatch, gravityIDStr stri
 		{"uint256[]": amounts},
 		{"address[]": destinations},
 		{"uint256[]": fees},
-		{"uint256": big.NewInt(int64(txBatch.BatchNonce))},
+		{"uint256": new(big.Int).SetUint64(txBatch.BatchNonce)},
 		{"address": txBatch.TokenContract},
-		{"uint256": big.NewInt(int64(txBatch.BatchTimeout))},
+		{"uint256": new(big.Int).SetUint64(txBatch.BatchTimeout)},
 		{"address": txBatch.FeeReceive},
 	}
 


### PR DESCRIPTION
## Description

This PR fixes issue #1064 where , , and validator  (which are typed as  in proto models) are packed into Solidity  using .

### Root Cause
When any of these values are greater than or equal to  (the maximum value of a signed 64-bit integer), the conversion  overflows/truncates and turns into a negative number in Go. The go-ethereum ABI packer encodes this negative  value into a Solidity  value that is completely different from the representation of the original unsigned  value. This leads to signature mismatches on the external smart contracts (EVM/TRON), meaning that relays cannot successfully execute the batch, resulting in stuck bridge funds.

### Solution
Replace all  with  for all  fields, specifically:
- 
- 
- 
- 

This applies to both EVM () and TRON () checkpoint functions.

### Tests
Added a dedicated test file  verifying that  matches the correct Solidity  encoding for values above .

Closes #1064

---
**Bounty Submission Details**
- Solana Wallet: pJju8G3iRRiYSQyLMQShZFjtadJoeMiPrpJSC8rdwjb
- USDT (TRC-20) Wallet: TNemEuAqMEsfDaXnxsCj5HJR9A4b2hBdnm