### PR TITLE
fix: KYC protocol region handling

### DIFF
--- a/x/kyc/keeper/grpc_query_test.go
+++ b/x/kyc/keeper/grpc_query_test.go
@@ -30,7 +30,37 @@ func (s *KeeperTestSuite) TestProtocol() {
 	s.Require().Equal(res.Protocol.Service.Description, "The KYC verifiable credential issuer based The DID(Decentralized Identity).")
 	s.Require().Equal(1, len(res.Protocol.Service.Issuers))
 	s.Require().Equal(res.Protocol.Service.Status, didtypes.SERVICE_STATUS_ACTIVE)
-	s.Require().Equal(6, len(res.Protocol.Regions))
+
+	expectedRegions := s.App.StakingKeeper.GetAllRegion(s.Ctx)
+	s.Require().Len(res.Protocol.Regions, len(expectedRegions))
+
+	regionsByID := make(map[string]string, len(res.Protocol.Regions))
+	for _, region := range res.Protocol.Regions {
+		s.Require().NotEmpty(region.Id)
+		s.Require().NotEmpty(region.Name)
+		regionsByID[region.Id] = region.Name
+	}
+
+	for _, region := range expectedRegions {
+		s.Require().Equal(region.Name, regionsByID[region.RegionId])
+	}
+}
+
+func (s *KeeperTestSuite) TestSetProtocolUpdatesService() {
+	s.SetupTest()
+
+	svc := didtypes.Service{
+		Sid:         types.ModuleName,
+		Name:        "updated-kyc",
+		Description: "updated service",
+		Status:      didtypes.SERVICE_STATUS_ACTIVE,
+	}
+	s.Keeper().SetProtocol(s.Ctx, svc)
+
+	proto, found := s.Keeper().GetProtocol(s.Ctx)
+	s.Require().True(found)
+	s.Require().Equal(svc, proto.Service)
+	s.Require().Len(proto.Regions, len(s.App.StakingKeeper.GetAllRegion(s.Ctx)))
 }
 
 func (s *KeeperTestSuite) TestDID() {

--- a/x/kyc/keeper/protocol.go
+++ b/x/kyc/keeper/protocol.go
@@ -25,7 +25,7 @@ func (k *Keeper) GetRegion(ctx sdk.Context, regionId string) (reg types.Region, 
 
 func (k *Keeper) GetAllRegions(ctx sdk.Context) (regs []types.Region) {
 	raws := k.stkKeeper.GetAllRegion(ctx)
-	regions := make([]types.Region, len(raws))
+	regions := make([]types.Region, 0, len(raws))
 	for _, rew := range raws {
 		regions = append(regions, types.Region{Id: rew.RegionId, Name: rew.Name})
 	}
@@ -43,6 +43,6 @@ func (k *Keeper) GetProtocol(ctx sdk.Context) (types.Protocol, bool) {
 	return types.Protocol{Service: svc, Regions: regions}, true
 }
 
-func (k *Keeper) SetProtocol(ctx sdk.Context, proto types.Protocol) {
-	k.SetService(ctx, proto.Service)
+func (k *Keeper) SetProtocol(ctx sdk.Context, svc didtypes.Service) {
+	k.SetService(ctx, svc)
 }


### PR DESCRIPTION
## Summary

- Change `SetProtocol` to accept only `didtypes.Service`, so callers can no longer pass `Protocol.Regions` through a setter that cannot persist them.
- Fix `GetAllRegions` to preallocate by capacity instead of length, avoiding leading zero-value regions in protocol responses.
- Update KYC protocol tests to assert the staking-backed regions are returned and add coverage for the service-only `SetProtocol` path.

Fixes #243.

## Validation

- `git diff --check` passed.
- `rg -n "SetProtocol\\(" x/kyc -g '*.go'` now shows only the new service-only setter and the new test call.
- Attempted targeted keeper tests locally with temporary Go caches:
  - `GOCACHE=/private/tmp/me-hub-gocache GOMODCACHE=/private/tmp/me-hub-gomodcache go test ./x/kyc/keeper -run TestKeeperTestSuite/TestProtocol -count=1`
  - `GOCACHE=/private/tmp/me-hub-gocache GOMODCACHE=/private/tmp/me-hub-gomodcache go test ./x/kyc/keeper -run 'TestKeeperTestSuite/Test(Protocol|SetProtocolUpdatesService)$' -count=1 -timeout=5m`
  - `GOCACHE=/private/tmp/me-hub-gocache GOMODCACHE=/private/tmp/me-hub-gomodcache go test ./x/kyc/keeper -run 'TestKeeperTestSuite/TestSetProtocolUpdatesService$' -count=1 -vet=off -timeout=2m`
- The keeper test commands did not complete in this local environment after repeated long dependency/build phases, so I stopped them to avoid leaving background processes.

No live chain, production service, account, or credential-based testing was performed.
