### PR TITLE
fix(gravity): conditional SlashTimes reset in AddDelegate

### DIFF
--- a/x/gravity/keeper/gravity_new001_test.go
+++ b/x/gravity/keeper/gravity_new001_test.go
@@ -1,0 +1,72 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+)
+
+// TestGravityNew001_FixSlashTimesReset verifies the fix for:
+// AddDelegate unconditionally resetting SlashTimes to 0.
+//
+// Before fix: AddDelegate always reset SlashTimes=0, allowing infinite bypass.
+// After fix:  SlashTimes only resets when relayer was fully offline (>= MaxSlashTimes).
+func (s *KeeperTestSuite) TestGravityNew001_FixSlashTimesResetViaAddDelegate() {
+	k := s.Keeper()
+	relayer := s.relayerAddrs[0]
+
+	// Set MaxSlashTimes to 3
+	params2 := k.GetParams(s.Ctx)
+	params2.MaxSlashTimes = 3
+	k.SetParams(s.Ctx, &params2)
+
+	// Bond relayer
+	minDelegate := k.GetGravityMinDelegate(s.Ctx)
+	bondMsg := &types.MsgBondedRelayer{
+		RelayerAddress:  relayer.String(),
+		ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[0].PublicKey),
+		DelegateAmount:  sdk.NewCoin(params.BaseDenom, minDelegate),
+		ChainName:       s.chainName,
+	}
+	_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), bondMsg)
+	s.Require().NoError(err)
+
+	// === CYCLE 1: Slash 2 times (below MaxSlashTimes), AddDelegate should NOT reset ===
+	for i := uint64(0); i < 2; i++ {
+		s.Require().NoError(k.SlashRelayer(s.Ctx, relayer.String()))
+	}
+	relayerData, _ := k.GetRelayer(s.Ctx, relayer)
+	s.Require().True(relayerData.Online, "cycle 1: still online after 2 slashes")
+	s.Require().Equal(int64(2), relayerData.SlashTimes, "cycle 1: SlashTimes=2")
+
+	// AddDelegate — fix should NOT reset SlashTimes (2 < MaxSlashTimes=3)
+	addMsg := &types.MsgAddDelegate{
+		RelayerAddress: relayer.String(),
+		Amount:         sdk.NewCoin(params.BaseDenom, minDelegate),
+		ChainName:      s.chainName,
+	}
+	_, err = s.MsgServer().AddDelegate(sdk.WrapSDKContext(s.Ctx), addMsg)
+	s.Require().NoError(err)
+
+	relayerData, _ = k.GetRelayer(s.Ctx, relayer)
+	s.Require().Equal(int64(2), relayerData.SlashTimes,
+		"FIXED: AddDelegate did NOT reset SlashTimes when < MaxSlashTimes")
+	s.Require().True(relayerData.Online)
+
+	// === CYCLE 2: 1 more slash → hits MaxSlashTimes → goes offline ===
+	s.Require().NoError(k.SlashRelayer(s.Ctx, relayer.String()))
+
+	relayerData, _ = k.GetRelayer(s.Ctx, relayer)
+	s.Require().False(relayerData.Online, "cycle 2: offline after MaxSlashTimes (3)")
+	s.Require().Equal(int64(3), relayerData.SlashTimes, "cycle 2: SlashTimes=3")
+
+	// === RECOVERY: AddDelegate when fully offline → SHOULD reset SlashTimes ===
+	_, err = s.MsgServer().AddDelegate(sdk.WrapSDKContext(s.Ctx), addMsg)
+	s.Require().NoError(err)
+
+	relayerData, _ = k.GetRelayer(s.Ctx, relayer)
+	s.Require().Equal(int64(0), relayerData.SlashTimes,
+		"FIXED: AddDelegate DID reset SlashTimes when >= MaxSlashTimes (recovery)")
+	s.Require().True(relayerData.Online, "FIXED: relayer back online after recovery")
+}

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -131,7 +131,9 @@ func (s MsgServer) AddDelegate(c context.Context, msg *types.MsgAddDelegate) (*t
 		relayer.StartHeight = ctx.BlockHeight()
 	}
 
-	relayer.SlashTimes = 0
+	if uint64(relayer.SlashTimes) >= s.Keeper.GetParams(ctx).MaxSlashTimes {
+		relayer.SlashTimes = 0
+	}
 	s.SetRelayer(ctx, relayerAddress, relayer)
 	s.SetLastTotalPower(ctx)
 


### PR DESCRIPTION
## Summary

- `AddDelegate` unconditionally reset `relayer.SlashTimes = 0` at `msg_server.go:134`
- This allowed slashed relayers to bypass the `MaxSlashTimes` offline mechanism indefinitely
- Fix: only reset `SlashTimes` when relayer was fully offline (`SlashTimes >= MaxSlashTimes`)
- Recovery path preserved: offline relayers can rejoin by calling `AddDelegate`
- Bypass path blocked: mid-cycle relayers cannot reset their slash history

## Severity: Medium-High

The `MaxSlashTimes` parameter existed to permanently offline bad relayers after repeated slashes. With the unconditional reset, a malicious relayer could call `AddDelegate` after `MaxSlashTimes - 1` slashes to reset the counter, then repeat indefinitely. The slashing mechanism was effectively disabled.

## Root Cause

`x/gravity/keeper/msg_server.go:134`:

```go
// BEFORE (vulnerable):
relayer.SlashTimes = 0
```

This line executed regardless of the relayer's current slash state. A relayer with `SlashTimes = N-1` (one away from offline) could call `AddDelegate` with minimum delegation to reset to `SlashTimes = 0`.

## Fix

```go
// AFTER (fixed):
if uint64(relayer.SlashTimes) >= s.Keeper.GetParams(ctx).MaxSlashTimes {
    relayer.SlashTimes = 0
}
```

Only reset when relayer was fully offline (`SlashTimes >= MaxSlashTimes`). This preserves the recovery path while blocking the infinite bypass.

## Validation

```
go test -v -run "TestGravityKeeperTestSuite/TestGravityNew001_Fix" -count=1 ./x/gravity/keeper/
```

Result: **PASS** — test verifies:
1. AddDelegate does NOT reset SlashTimes when below MaxSlashTimes
2. Relayer goes offline after reaching MaxSlashTimes
3. AddDelegate DOES reset SlashTimes when fully offline (recovery path)

Pre-existing test failures (`TestRelayerSetSlash`, `TestMsgBondedRelayer/*`) confirmed NOT caused by this fix.

## Bounty payout

Meta Earth bug bounty payout: $MEC via ME Pass. MEC address: `0x80431E5A0983c0A0303Be0c647F27f1C54D4e41e`
