### PR TITLE
fix(gravity): harden outgoing batch timeout projection

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"math/bits"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
@@ -23,8 +24,8 @@ func (k Keeper) BuildOutgoingTxBatch(ctx sdk.Context, contractAddress, feeReceiv
 		return nil, errorsmod.Wrap(types.ErrInvalid, "max elements value")
 	}
 	projectedCurrentExternalHeight, batchTimeout := k.GetBatchTimeoutHeight(ctx)
-	if batchTimeout <= 0 {
-		return nil, errorsmod.Wrapf(types.ErrInvalid, "batch timeout height %d less than 0", batchTimeout)
+	if batchTimeout == 0 || batchTimeout <= projectedCurrentExternalHeight {
+		return nil, errorsmod.Wrapf(types.ErrInvalid, "batch timeout height %d not above projected current external height %d", batchTimeout, projectedCurrentExternalHeight)
 	}
 
 	// if there is a more profitable batch for this token type do not create a new batch
@@ -82,25 +83,49 @@ func (k Keeper) BuildOutgoingTxBatch(ctx sdk.Context, contractAddress, feeReceiv
 
 // GetBatchTimeoutHeight This gets the batch timeout height in External blocks.
 func (k Keeper) GetBatchTimeoutHeight(ctx sdk.Context) (uint64, uint64) {
-	currentMeHeight := ctx.BlockHeight()
-	params := k.GetParams(ctx)
+	return projectBatchTimeoutHeight(ctx.BlockHeight(), k.GetLastObservedBlockHeight(ctx), k.GetParams(ctx))
+}
+
+func projectBatchTimeoutHeight(currentMeHeight int64, heights types.LastObservedBlockHeight, params types.Params) (uint64, uint64) {
 	if params.AverageExternalBlockTime == 0 {
 		return 0, 0
 	}
-	// we store the last observed Cosmos and Ethereum heights, we do not concern ourselves if these values
-	// are zero because no batch can be produced if the last Ethereum block height is not first populated by a deposit event.
-	heights := k.GetLastObservedBlockHeight(ctx)
+	if params.ExternalBatchTimeout < params.AverageExternalBlockTime {
+		return 0, 0
+	}
+	if currentMeHeight < 0 {
+		return 0, 0
+	}
 	if heights.ExternalBlockHeight == 0 {
 		return 0, 0
 	}
+	currentBlockHeight := uint64(currentMeHeight)
+	elapsedMeBlocks := uint64(0)
+	if currentBlockHeight > heights.BlockHeight {
+		elapsedMeBlocks = currentBlockHeight - heights.BlockHeight
+	}
 	// we project how long it has been in milliseconds since the last Ethereum block height was observed
-	projectedMillis := (uint64(currentMeHeight) - heights.BlockHeight) * params.AverageBlockTime
+	overflow, projectedMillis := bits.Mul64(elapsedMeBlocks, params.AverageBlockTime)
+	if overflow != 0 {
+		return 0, 0
+	}
 	// we convert that projection into the current Ethereum height using the average Ethereum block time in millis
-	projectedCurrentEthereumHeight := (projectedMillis / params.AverageExternalBlockTime) + heights.ExternalBlockHeight
+	projectedExternalBlocks := projectedMillis / params.AverageExternalBlockTime
+	projectedCurrentEthereumHeight, carry := bits.Add64(projectedExternalBlocks, heights.ExternalBlockHeight, 0)
+	if carry != 0 {
+		return 0, 0
+	}
 	// we convert our target time for block timeouts (lets say 12 hours) into a number of blocks to
 	// place on top of our projection of the current Ethereum block height.
 	blocksToAdd := params.ExternalBatchTimeout / params.AverageExternalBlockTime
-	return projectedCurrentEthereumHeight, projectedCurrentEthereumHeight + blocksToAdd
+	if blocksToAdd == 0 {
+		return 0, 0
+	}
+	batchTimeout, carry := bits.Add64(projectedCurrentEthereumHeight, blocksToAdd, 0)
+	if carry != 0 {
+		return 0, 0
+	}
+	return projectedCurrentEthereumHeight, batchTimeout
 }
 
 // OutgoingTxBatchExecuted is run when the Cosmos chain detects that a batch has been executed on Ethereum

--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -155,3 +155,22 @@ func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {
 	)
 	suite.Equal(len(batchs), index)
 }
+
+func (suite *KeeperTestSuite) TestGravityTimingParamsRejectUnsafeBatchTimeouts() {
+	params := suite.Keeper().GetParams(suite.Ctx)
+	params.ExternalBatchTimeout = 60_000
+	params.AverageExternalBlockTime = 120_000
+	suite.Require().ErrorContains(
+		suite.Keeper().SetParams(suite.Ctx, &params),
+		"at least one average external block",
+	)
+
+	params = suite.Keeper().GetParams(suite.Ctx)
+	params.AverageBlockTime = uint64(1) << 63
+	params.AverageExternalBlockTime = 100
+	params.ExternalBatchTimeout = 60_000
+	suite.Require().ErrorContains(
+		suite.Keeper().SetParams(suite.Ctx, &params),
+		"at least one average ME block",
+	)
+}

--- a/x/gravity/keeper/batch_timeout_test.go
+++ b/x/gravity/keeper/batch_timeout_test.go
@@ -1,0 +1,46 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectBatchTimeoutHeightRejectsUnsafeProjection(t *testing.T) {
+	params := types.DefaultParams()
+	params.AverageBlockTime = uint64(1) << 63
+	params.AverageExternalBlockTime = 100
+	params.ExternalBatchTimeout = 60_000
+
+	projected, timeout := projectBatchTimeoutHeight(12, types.LastObservedBlockHeight{
+		BlockHeight:         10,
+		ExternalBlockHeight: 1_000,
+	}, params)
+	require.Zero(t, projected)
+	require.Zero(t, timeout)
+}
+
+func TestProjectBatchTimeoutHeightRejectsZeroExternalBlockWindow(t *testing.T) {
+	params := types.DefaultParams()
+	params.ExternalBatchTimeout = 60_000
+	params.AverageExternalBlockTime = 120_000
+
+	projected, timeout := projectBatchTimeoutHeight(20, types.LastObservedBlockHeight{
+		BlockHeight:         10,
+		ExternalBlockHeight: 1_000,
+	}, params)
+	require.Zero(t, projected)
+	require.Zero(t, timeout)
+}
+
+func TestProjectBatchTimeoutHeightHandlesImportedLocalHeight(t *testing.T) {
+	params := types.DefaultParams()
+
+	projected, timeout := projectBatchTimeoutHeight(1, types.LastObservedBlockHeight{
+		BlockHeight:         10,
+		ExternalBlockHeight: 1_000,
+	}, params)
+	require.Equal(t, uint64(1_000), projected)
+	require.Greater(t, timeout, projected)
+}

--- a/x/gravity/types/params.go
+++ b/x/gravity/types/params.go
@@ -55,6 +55,12 @@ func (m *Params) ValidateBasic() error {
 	if m.AverageExternalBlockTime < 100 {
 		return fmt.Errorf("invalid average external block time, too short for latency limitations")
 	}
+	if m.ExternalBatchTimeout < m.AverageExternalBlockTime {
+		return fmt.Errorf("invalid target batch timeout, must cover at least one average external block")
+	}
+	if m.ExternalBatchTimeout < m.AverageBlockTime {
+		return fmt.Errorf("invalid target batch timeout, must cover at least one average ME block")
+	}
 	if m.SignedWindow <= 1 {
 		return fmt.Errorf("invalid signed window, too short")
 	}

--- a/x/gravity/types/params_test.go
+++ b/x/gravity/types/params_test.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParamsValidateBasicRejectsUnsafeBatchTiming(t *testing.T) {
+	params := DefaultParams()
+	params.ExternalBatchTimeout = 60_000
+	params.AverageExternalBlockTime = 120_000
+	require.ErrorContains(t, params.ValidateBasic(), "at least one average external block")
+
+	params = DefaultParams()
+	params.AverageBlockTime = uint64(1) << 63
+	params.AverageExternalBlockTime = 100
+	params.ExternalBatchTimeout = 60_000
+	require.ErrorContains(t, params.ValidateBasic(), "at least one average ME block")
+}


### PR DESCRIPTION
## Summary

- reject Gravity timing params that would create a zero external-block batch timeout window
- reject batch timing params where one average ME block is larger than the target batch timeout window
- make outgoing batch timeout projection use checked uint64 arithmetic and fail closed on overflow or invalid timeout windows
- add focused regressions for unsafe params, projection overflow, zero-window timeouts, and imported local-height state

Fixes #1062
Fixes #1073

## Validation

```bash
go test ./x/gravity/types -count=1
go test ./x/gravity/keeper -run 'TestProjectBatchTimeoutHeight|TestGravityKeeperTestSuite/(TestGravityTimingParamsRejectUnsafeBatchTimeouts|TestRequestBatchBaseFee|TestClaimMsgGasConsumed)$' -count=1 -v
git diff --check
```

I also ran:

```bash
go test ./x/gravity/keeper -count=1
```

That broader package run still fails on existing unrelated baseline failures:

- `TestGrav004_FailedAttestationMustNotLockNonce`
- `TestMsgBondedRelayer/error_-_relayer_existed`
- `TestMsgBondedRelayer/error_-_external_address_is_bound`
- `TestRelayerSetSlash`

## Payout

Meta Earth bug-bounty payout in `$MEC` via ME Pass wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`