### PR TITLE
fix(gravity): keep GravityId immutable

### DIFF
--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -380,6 +380,10 @@ func (s MsgServer) UpdateParams(c context.Context, req *types.MsgUpdateParams) (
 		return nil, errorsmod.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", s.authority, req.Authority)
 	}
 	ctx := sdk.UnwrapSDKContext(c)
+	currentParams := s.GetParams(ctx)
+	if currentParams.GravityId != "" && currentParams.GravityId != req.Params.GravityId {
+		return nil, errorsmod.Wrap(types.ErrInvalid, "GravityId cannot be changed after initialization")
+	}
 	if err := s.SetParams(ctx, &req.Params); err != nil {
 		return nil, err
 	}

--- a/x/gravity/keeper/msg_server_test.go
+++ b/x/gravity/keeper/msg_server_test.go
@@ -277,6 +277,49 @@ func (s *KeeperTestSuite) TestMsgAddDelegate() {
 	}
 }
 
+func (s *KeeperTestSuite) TestMsgUpdateParamsKeepsGravityIDImmutable() {
+	originalParams := s.Keeper().GetParams(s.Ctx)
+	originalGravityID := originalParams.GravityId
+	relayerSet := types.RelayerSet{
+		Nonce:  1,
+		Height: 1,
+		Members: []types.BridgeValidator{
+			{
+				Power:           types.PowerBase,
+				ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[0].PublicKey),
+			},
+		},
+	}
+	originalCheckpoint, err := relayerSet.GetCheckpoint(originalGravityID)
+	s.Require().NoError(err)
+
+	updatedParams := originalParams
+	updatedParams.SignedWindow++
+	_, err = s.MsgServer().UpdateParams(sdk.WrapSDKContext(s.Ctx), &types.MsgUpdateParams{
+		Authority: s.Keeper().GetAuthority(),
+		ChainName: s.chainName,
+		Params:    updatedParams,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(originalGravityID, s.Keeper().GetGravityID(s.Ctx))
+	s.Require().Equal(updatedParams.SignedWindow, s.Keeper().GetParams(s.Ctx).SignedWindow)
+
+	mutatedParams := s.Keeper().GetParams(s.Ctx)
+	mutatedParams.GravityId = "changed-gravity-id"
+	_, err = s.MsgServer().UpdateParams(sdk.WrapSDKContext(s.Ctx), &types.MsgUpdateParams{
+		Authority: s.Keeper().GetAuthority(),
+		ChainName: s.chainName,
+		Params:    mutatedParams,
+	})
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "GravityId cannot be changed after initialization")
+	s.Require().Equal(originalGravityID, s.Keeper().GetGravityID(s.Ctx))
+
+	currentCheckpoint, err := relayerSet.GetCheckpoint(s.Keeper().GetGravityID(s.Ctx))
+	s.Require().NoError(err)
+	s.Require().Equal(originalCheckpoint, currentCheckpoint)
+}
+
 func (s *KeeperTestSuite) TestMsgSetRelayerSetConfirm() {
 	normalMsg := &types.MsgBondedRelayer{
 		RelayerAddress:  s.relayerAddrs[0].String(),


### PR DESCRIPTION
## Summary

- reject `MsgUpdateParams` attempts that change the stored GravityId after initialization
- keep ordinary parameter updates working when they preserve the current GravityId
- add regression coverage that verifies the bridge checkpoint salt stays unchanged after a rejected GravityId update

Fixes #1060

## Validation

```bash
go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestMsgUpdateParamsKeepsGravityIDImmutable' -count=1 -v
git diff --check
```

I also ran:

```bash
go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestMsg(UpdateParamsKeepsGravityIDImmutable|SetRelayerSetConfirm|AddDelegate|BondedRelayer)$' -count=1 -v
go test ./x/gravity/keeper -count=1
```

Those broader keeper runs still hit existing unrelated baseline failures:

- `TestGrav004_FailedAttestationMustNotLockNonce`
- `TestMsgBondedRelayer/error_-_relayer_existed` expected-string mismatch
- `TestMsgBondedRelayer/error_-_external_address_is_bound` expected-string mismatch
- `TestRelayerSetSlash`

## Payout

Meta Earth bug-bounty payout in `$MEC` via ME Pass wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`
