### PR TITLE
fix(sequencer): preserve replacement unbonding period

### DIFF
--- a/x/sequencer/keeper/hook_listener.go
+++ b/x/sequencer/keeper/hook_listener.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
@@ -51,13 +52,17 @@ func (hook rollappHook) AfterStateFinalized(ctx sdk.Context, rollappID string, s
 	}
 	if val != nil {
 		if (stateInfo.StartHeight + stateInfo.NumBlocks - 1) >= uint64(val.ReplaceProposer.BlockHeight) {
-			err = hook.k.forceRemoveUnbondingSequencer(ctx, val.ReplaceProposer.OldProposer, stateInfo.StartHeight, stateInfo.NumBlocks)
-			if err != nil {
-				hook.k.Logger(ctx).Error("forceRemoveUnbondingSequencer error.", "sequencer", val.ReplaceProposer.OldProposer,
-					"rollapp", rollappID, "state_block_info", fmt.Sprintf("%d-%d", stateInfo.StartHeight,
-						stateInfo.StartHeight+stateInfo.NumBlocks-1), "error", err.Error())
-				return fmt.Errorf("forceRemoveUnbondingSequencer error in AfterStateFinalized.sequencer=%s,"+
-					" rollapp = %s, err = %s", val.ReplaceProposer.OldProposer, rollappID, err.Error())
+			oldSequencer, found := hook.k.GetSequencer(ctx, val.ReplaceProposer.OldProposer)
+			if !found {
+				return types.ErrUnknownSequencer
+			}
+			if oldSequencer.Status != types.Unbonding {
+				return errorsmod.Wrapf(
+					types.ErrInvalidSequencerStatus,
+					"replace proposer old sequencer %s is not unbonding: got %s",
+					val.ReplaceProposer.OldProposer,
+					oldSequencer.Status.String(),
+				)
 			}
 			hook.k.DeleteReplaceProposer(ctx, rollappID)
 			hook.k.Logger(ctx).Info("AfterStateFinalized processed ReplaceProposer.", "rollapp", rollappID,

--- a/x/sequencer/keeper/replace_proposer.go
+++ b/x/sequencer/keeper/replace_proposer.go
@@ -120,7 +120,9 @@ func (k Keeper) ProcSequencerByPendingStates(ctx sdk.Context, rollappId, creator
 			oldSequencer.Proposer = false
 			oldSequencer.Status = types.Unbonding
 			oldSequencer.UnbondingHeight = ctx.BlockHeight()
+			oldSequencer.UnbondTime = ctx.BlockHeader().Time.Add(k.UnbondingTime(ctx))
 			k.UpdateSequencer(ctx, oldSequencer, types.Bonded)
+			k.setUnbondingSequencerQueue(ctx, oldSequencer)
 			newSequencer, found := k.GetSequencer(ctx, val.ReplaceProposer.NewProposer)
 			if !found {
 				return fmt.Errorf("can not found new sequencer: %s", val.ReplaceProposer.NewProposer)

--- a/x/sequencer/keeper/replace_proposer_test.go
+++ b/x/sequencer/keeper/replace_proposer_test.go
@@ -1,0 +1,78 @@
+package keeper_test
+
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
+	"github.com/openmetaearth/me-hub/x/sequencer/types"
+)
+
+func (suite *SequencerTestSuite) TestReplaceProposerKeepsOldProposerBondUntilUnbondingTime() {
+	suite.SetupTest()
+
+	startTime := time.Unix(1_700_000_000, 0).UTC()
+	suite.Ctx = suite.Ctx.WithBlockHeight(10).WithBlockTime(startTime)
+
+	keeper := suite.App.SequencerKeeper
+	rollappId := suite.CreateDefaultRollapp()
+	oldProposer := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	newProposer := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	oldAddr := sdk.MustAccAddressFromBech32(oldProposer)
+	balanceBeforeFinalize := suite.App.BankKeeper.GetBalance(suite.Ctx, oldAddr, bond.Denom)
+
+	err := keeper.SetReplaceProposer(suite.Ctx, &types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: oldProposer,
+		NewProposer: newProposer,
+		BlockHeight: 12,
+	})
+	suite.Require().NoError(err)
+
+	stateInfo := &rollapptypes.StateInfo{
+		StartHeight: 11,
+		NumBlocks:   2,
+	}
+
+	err = keeper.ProcSequencerByPendingStates(suite.Ctx, rollappId, oldProposer, stateInfo)
+	suite.Require().NoError(err)
+
+	oldSeq, found := keeper.GetSequencer(suite.Ctx, oldProposer)
+	suite.Require().True(found)
+	suite.Equal(types.Unbonding, oldSeq.Status)
+	suite.False(oldSeq.Proposer)
+	suite.Equal(startTime.Add(keeper.UnbondingTime(suite.Ctx)), oldSeq.UnbondTime)
+
+	newSeq, found := keeper.GetSequencer(suite.Ctx, newProposer)
+	suite.Require().True(found)
+	suite.Equal(types.Bonded, newSeq.Status)
+	suite.True(newSeq.Proposer)
+
+	err = keeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, stateInfo)
+	suite.Require().NoError(err)
+
+	balanceAfterFinalize := suite.App.BankKeeper.GetBalance(suite.Ctx, oldAddr, bond.Denom)
+	suite.True(balanceBeforeFinalize.IsEqual(balanceAfterFinalize), "old proposer bond was refunded before unbonding time")
+
+	oldSeq, found = keeper.GetSequencer(suite.Ctx, oldProposer)
+	suite.Require().True(found)
+	suite.Equal(types.Unbonding, oldSeq.Status)
+	suite.False(oldSeq.Tokens.IsZero())
+
+	replaceProposer, err := keeper.GetReplaceProposer(suite.Ctx, rollappId)
+	suite.Require().NoError(err)
+	suite.Nil(replaceProposer)
+
+	matureBeforeUnbondTime := keeper.GetMatureUnbondingSequencers(suite.Ctx, oldSeq.UnbondTime.Add(-time.Second))
+	suite.Len(matureBeforeUnbondTime, 0)
+
+	keeper.UnbondAllMatureSequencers(suite.Ctx, oldSeq.UnbondTime.Add(time.Second))
+
+	oldSeq, found = keeper.GetSequencer(suite.Ctx, oldProposer)
+	suite.Require().True(found)
+	suite.Equal(types.Unbonded, oldSeq.Status)
+	suite.True(oldSeq.Tokens.IsZero())
+
+	balanceAfterUnbondTime := suite.App.BankKeeper.GetBalance(suite.Ctx, oldAddr, bond.Denom)
+	suite.True(balanceAfterFinalize.Add(bond).IsEqual(balanceAfterUnbondTime), "old proposer bond should refund after unbonding time")
+}


### PR DESCRIPTION
## Summary
- set `UnbondTime` and enqueue the old proposer when `ReplaceProposer` processing moves it to `Unbonding`
- stop `AfterStateFinalized` from force-refunding/removing the old proposer before the normal unbonding period matures
- add regression coverage that the old proposer bond is not refunded at replacement finalization, and is refunded only after `UnbondTime`

## Bounty
Addresses #1070.

Bounty attribution/payment details can be provided privately after maintainer acceptance.

## Validation
- `go test -c ./x/sequencer/keeper -o ..\..\artifacts\me-hub-sequencer-keeper-linux.test` with `GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC="zig cc -target x86_64-linux-gnu"` -> passed
- `go test ./x/sequencer/types -run Test -count=1` -> passed
- `git diff --check` -> passed

Note: direct Windows execution of `go test ./x/sequencer/keeper` is blocked by upstream `wasmvm v1.4.1` not shipping a Windows `wasmvm.dll/libwasmvm.a`; the package compiles successfully for the Linux/CGO target used by this chain.
