### PR TITLE
fix: reject join when group admin is invalid

### DIFF
--- a/x/megroup/keeper/keeper_test.go
+++ b/x/megroup/keeper/keeper_test.go
@@ -1,0 +1,90 @@
+package keeper_test
+
+import (
+	"testing"
+
+	cometbftproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
+	"github.com/openmetaearth/me-hub/x/megroup/keeper"
+	"github.com/openmetaearth/me-hub/x/megroup/types"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type KeeperTestSuite struct {
+	apptesting.KeeperTestHelper
+
+	msgServer types.MsgServer
+	testAccs  []sdk.AccAddress
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (s *KeeperTestSuite) SetupTest() {
+	app := apptesting.Setup(s.T(), false)
+	ctx := app.GetBaseApp().NewContext(false, cometbftproto.Header{})
+
+	s.App = app
+	s.Ctx = ctx
+	s.msgServer = keeper.NewMsgServerImpl(*app.GroupKeeper)
+	s.testAccs = s.NewAccounts(2)
+}
+
+func (s *KeeperTestSuite) setActiveKyc(address sdk.AccAddress, did, regionID string) {
+	s.App.KycKeeper.SetDID(s.Ctx, address, did)
+	s.App.KycKeeper.SetDidInfo(s.Ctx, did, didtypes.DidInfo{
+		Did:      did,
+		Address:  address.String(),
+		RegionId: regionID,
+		KycLevel: didtypes.KYC_LEVEL_TWO,
+		Status:   didtypes.DID_STATUS_ACTIVE,
+	})
+}
+
+func (s *KeeperTestSuite) TestJoinGroupRejectsEmptyAdminBeforeMutatingState() {
+	s.SetupTest()
+
+	const (
+		groupID  uint64 = 1
+		regionID        = "test-region"
+	)
+	applicant := s.testAccs[0]
+	treasure := s.testAccs[1]
+	s.setActiveKyc(applicant, "did-join-001", regionID)
+
+	s.App.StakingKeeper.SetRegion(s.Ctx, wstakingtypes.Region{
+		RegionId:           regionID,
+		RegionTreasureAddr: treasure.String(),
+		RegionShare:        sdk.ZeroInt(),
+		DelegateInterest:   sdk.ZeroDec(),
+		DelegateAmount:     sdk.ZeroInt(),
+		FixedDepositAmount: sdk.ZeroInt(),
+	})
+	s.App.GroupKeeper.SetGroupInfo(s.Ctx, types.GroupInfo{
+		Id:          groupID,
+		Admin:       "",
+		TotalWeight: sdk.ZeroInt().String(),
+		RegionID:    regionID,
+	})
+	s.App.GroupKeeper.SetGroupToRegion(s.Ctx, regionID, groupID)
+	s.App.GroupKeeper.SetGroupMemberCount(s.Ctx, groupID, 0)
+
+	_, err := s.msgServer.JoinGroup(s.Ctx, &types.MsgJoinGroup{
+		Creator:          applicant.String(),
+		GroupId:          groupID,
+		ApplicantAddress: applicant.String(),
+	})
+	s.Require().ErrorIs(err, types.ErrProcData)
+	s.Require().ErrorContains(err, "group admin address is invalid")
+
+	_, joined := s.App.GroupKeeper.GetMemberJoined(s.Ctx, applicant.String())
+	s.Require().False(joined)
+
+	groupMemberCount, found := s.App.GroupKeeper.GetGroupMemberCount(s.Ctx, groupID)
+	s.Require().True(found)
+	s.Require().Equal(uint64(0), groupMemberCount)
+}

--- a/x/megroup/keeper/msg_server_join_group.go
+++ b/x/megroup/keeper/msg_server_join_group.go
@@ -54,6 +54,30 @@ func (k msgServer) JoinGroup(goCtx context.Context, msg *types.MsgJoinGroup) (*t
 		return nil, errors.Wrap(types.ErrPermissionDenied, errLogBytes)
 	}
 
+	var (
+		adminAccAddr          sdk.AccAddress
+		regionTreasureAccAddr sdk.AccAddress
+		rewardRegionID        string
+	)
+	if !JoinGroupFound { //send rewards if user has not joined group
+		region, found := k.stakingKeeper.GetRegion(ctx, groupInfo.RegionID)
+		if !found {
+			return nil, errors.Wrapf(types.ErrRegionNotExist, "group's region: %s", groupInfo.RegionID)
+		}
+		rewardRegionID = region.RegionId
+
+		regionTreasureAccAddr, err = sdk.AccAddressFromBech32(region.GetRegionTreasureAddr())
+		if err != nil {
+			return nil, errors.Wrapf(types.ErrProcData, "region treasure address is invalid. err = %s, addr = %s",
+				err.Error(), region.GetRegionTreasureAddr())
+		}
+		adminAccAddr, err = sdk.AccAddressFromBech32(groupInfo.Admin)
+		if err != nil {
+			return nil, errors.Wrapf(types.ErrProcData, "group admin address is invalid. err = %s, addr = %s",
+				err.Error(), groupInfo.Admin)
+		}
+	}
+
 	//set member's join group info
 	k.SetMemberJoined(ctx, types.MemberJoined{
 		Address: msg.ApplicantAddress,
@@ -72,28 +96,23 @@ func (k msgServer) JoinGroup(goCtx context.Context, msg *types.MsgJoinGroup) (*t
 	k.SetGroupMemberCount(ctx, msg.GroupId, grpNumber+1)
 
 	if !JoinGroupFound { //send rewards if user has not joined group
-		//get RegionTreasureAddr
-		region, found := k.stakingKeeper.GetRegion(ctx, groupInfo.RegionID)
-		if !found {
-			return nil, errors.Wrap(types.ErrRegionNotExist, fmt.Sprintf("group's region: %s", groupInfo.RegionID))
-		}
 		rewardsCoin := sdk.NewCoin(params.BaseDenom, math.NewInt(1000000))
-		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()),
-			sdk.MustAccAddressFromBech32(msg.ApplicantAddress), sdk.NewCoins(rewardsCoin), fmt.Sprintf("JoinGroup_SendApplicantRewards_%s", region.RegionId))
+		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, regionTreasureAccAddr,
+			userAccAddr, sdk.NewCoins(rewardsCoin), fmt.Sprintf("JoinGroup_SendApplicantRewards_%s", rewardRegionID))
 		if err != nil {
 			return nil, errors.Wrap(types.ErrProcData, fmt.Sprintf("transfer rewards coins error. err = %s,fromAddr = %s,toAddr = %s",
-				err.Error(), region.GetRegionTreasureAddr(), msg.ApplicantAddress))
+				err.Error(), regionTreasureAccAddr.String(), msg.ApplicantAddress))
 		}
-		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()),
-			sdk.MustAccAddressFromBech32(groupInfo.Admin), sdk.NewCoins(rewardsCoin), fmt.Sprintf("JoinGroup_SendAdminRewards_%s", region.RegionId))
+		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, regionTreasureAccAddr,
+			adminAccAddr, sdk.NewCoins(rewardsCoin), fmt.Sprintf("JoinGroup_SendAdminRewards_%s", rewardRegionID))
 		if err != nil {
 			return nil, errors.Wrap(types.ErrProcData, fmt.Sprintf("transfer rewards coins error. err = %s,fromAddr = %s,toAddr = %s",
-				err.Error(), region.GetRegionTreasureAddr(), groupInfo.Admin))
+				err.Error(), regionTreasureAccAddr.String(), groupInfo.Admin))
 		}
 		ctx.EventManager().EmitEvent(sdk.NewEvent(types.EvtJoinGroupReward,
 			sdk.NewAttribute("applicant", msg.ApplicantAddress),
 			sdk.NewAttribute("admin", groupInfo.Admin),
-			sdk.NewAttribute("regionTreasureAddress", region.GetRegionTreasureAddr()),
+			sdk.NewAttribute("regionTreasureAddress", regionTreasureAccAddr.String()),
 			sdk.NewAttribute("rewards", rewardsCoin.String()),
 		))
 	}


### PR DESCRIPTION
## Summary
- validate the reward region treasury and group admin addresses before JoinGroup mutates membership state
- replace state-derived MustAccAddressFromBech32 calls in the reward path with checked address parsing
- add a keeper regression test for an empty group admin, asserting the join fails without creating MemberJoined state or incrementing the member count

Fixes #1084.

## Validation
- `go test ./x/megroup/types -run TestMsgJoinGroup_ValidateBasic -count=1`
- `CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="zig cc -target x86_64-linux-gnu" go test -c ./x/megroup/keeper -o ../../artifacts/me-hub-megroup-keeper-linux.test`

Note: direct Windows execution of the keeper test is blocked by the repository's native secp256k1/cgo build path on Windows (`undefined: secp256k1.RecoverPubkey`, `undefined: secp256k1.VerifySignature`). The Linux target keeper test binary compiles successfully.
