### PR TITLE
fix: preserve region withdraw grants in genesis

### DIFF
--- a/proto/metaearth/wstaking/genesis.proto
+++ b/proto/metaearth/wstaking/genesis.proto
@@ -70,6 +70,12 @@ message GenesisState {
   repeated FixedDeposit fixedDepositList = 11 [(gogoproto.nullable) = false];
   uint64 fixedDepositCount = 12;
   bool exported = 13;
+  repeated RegionWithdrawGrant regionWithdrawGrants = 14 [(gogoproto.nullable) = false];
+}
+
+message RegionWithdrawGrant {
+  string regionId = 1;
+  string address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
 // LastValidatorPower required for validator set update logic.

--- a/x/wstaking/keeper/genesis.go
+++ b/x/wstaking/keeper/genesis.go
@@ -65,6 +65,10 @@ func (k Keeper) InitGenesis(ctx sdk.Context, data *wstakingtypes.GenesisState) (
 		k.SetStake(ctx, stake)
 	}
 
+	for _, grant := range data.RegionWithdrawGrants {
+		k.SetRegionWithdraw(ctx, grant.RegionId, grant.Address)
+	}
+
 	for _, delegation := range data.Delegations {
 		k.SetDelegation(ctx, delegation)
 	}
@@ -196,5 +200,6 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *wstakingtypes.GenesisState {
 		FixedDepositList:     k.GetAllFixedDeposit(ctx),
 		FixedDepositCount:    k.GetFixedDepositCount(ctx),
 		Exported:             true,
+		RegionWithdrawGrants: k.GetAllRegionWithdrawGrants(ctx),
 	}
 }

--- a/x/wstaking/keeper/msg_server_region_test.go
+++ b/x/wstaking/keeper/msg_server_region_test.go
@@ -402,3 +402,35 @@ func (s *KeeperTestSuite) TestRevokeRegionWithdraw() {
 		})
 	}
 }
+
+func (s *KeeperTestSuite) TestExportGenesisPreservesRegionWithdrawGrant() {
+	s.SetupTest()
+
+	regionId := types.ExperienceRegionId
+	grantee := s.TestAccs[0].String()
+	_, err := s.msgServer.GrantRegionWithdraw(s.Ctx, &types.MsgGrantRegionWithdraw{
+		Creator:  s.Dao.GlobalDao,
+		RegionId: regionId,
+		Address:  grantee,
+	})
+	s.Require().NoError(err)
+	s.Require().True(s.Keeper().CanRegionWithdraw(s.Ctx, grantee, regionId))
+
+	exported := s.Keeper().ExportGenesis(s.Ctx)
+	s.Require().Contains(exported.RegionWithdrawGrants, types.RegionWithdrawGrant{
+		RegionId: regionId,
+		Address:  grantee,
+	})
+
+	freshApp := apptesting.Setup(s.T(), false)
+	freshCtx := freshApp.GetBaseApp().NewContext(false, tmproto.Header{})
+	imported := types.DefaultGenesisState()
+	imported.Exported = true
+	imported.Regions = exported.Regions
+	imported.RegionWithdrawGrants = exported.RegionWithdrawGrants
+	freshApp.StakingKeeper.InitGenesis(freshCtx, imported)
+
+	restored, found := freshApp.StakingKeeper.GetRegionWithdraw(freshCtx, regionId)
+	s.Require().True(found)
+	s.Require().Equal(grantee, restored)
+}

--- a/x/wstaking/keeper/region_withdraw.go
+++ b/x/wstaking/keeper/region_withdraw.go
@@ -29,6 +29,22 @@ func (k Keeper) DeleteRegionWithdraw(ctx sdk.Context, regionId string) {
 	store.Delete([]byte(regionId))
 }
 
+// GetAllRegionWithdrawGrants returns every region withdraw grant in store.
+func (k Keeper) GetAllRegionWithdrawGrants(ctx sdk.Context) (grants []types.RegionWithdrawGrant) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.RegionWithdrawKeyPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		grants = append(grants, types.RegionWithdrawGrant{
+			RegionId: string(iterator.Key()),
+			Address:  string(iterator.Value()),
+		})
+	}
+
+	return grants
+}
+
 // CanRegionWithdraw returns true if address is the authorized
 // withdrawer for regionId.
 func (k Keeper) CanRegionWithdraw(ctx sdk.Context, address, regionId string) bool {

--- a/x/wstaking/types/genesis.go
+++ b/x/wstaking/types/genesis.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"time"
 )
@@ -45,6 +46,9 @@ func ValidateGenesis(data *GenesisState) error {
 	if err := validateGenesisStateValidators(data.Validators); err != nil {
 		return err
 	}
+	if err := validateGenesisStateRegionWithdrawGrants(data.RegionWithdrawGrants, data.Regions); err != nil {
+		return err
+	}
 
 	return data.Params.Validate()
 }
@@ -82,6 +86,34 @@ func validateGenesisStateValidators(validators []stakingtypes.Validator) error {
 		}
 
 		addrMap[strKey] = true
+	}
+
+	return nil
+}
+
+func validateGenesisStateRegionWithdrawGrants(grants []RegionWithdrawGrant, regions []Region) error {
+	regionIDs := make(map[string]struct{}, len(regions))
+	for _, region := range regions {
+		if region.RegionId != "" {
+			regionIDs[region.RegionId] = struct{}{}
+		}
+	}
+
+	seen := make(map[string]struct{}, len(grants))
+	for _, grant := range grants {
+		if grant.RegionId == "" {
+			return fmt.Errorf("region withdraw grant has empty region id")
+		}
+		if _, ok := regionIDs[grant.RegionId]; !ok {
+			return fmt.Errorf("region withdraw grant references unknown region: %s", grant.RegionId)
+		}
+		if _, ok := seen[grant.RegionId]; ok {
+			return fmt.Errorf("duplicate region withdraw grant in genesis state: region %s", grant.RegionId)
+		}
+		if _, err := sdk.AccAddressFromBech32(grant.Address); err != nil {
+			return fmt.Errorf("invalid region withdraw grant address for region %s: %w", grant.RegionId, err)
+		}
+		seen[grant.RegionId] = struct{}{}
 	}
 
 	return nil

--- a/x/wstaking/types/genesis.pb.go
+++ b/x/wstaking/types/genesis.pb.go
@@ -48,11 +48,12 @@ type GenesisState struct {
 	// stakes defines the stakes active at genesis.
 	Stakes []Stake `protobuf:"bytes,8,rep,name=stakes,proto3" json:"stakes"`
 	// unbonding_stakes defines the unbonding stakes active at genesis.
-	UnbondingStakes   []UnbondingStake `protobuf:"bytes,9,rep,name=unbonding_stakes,json=unbondingStakes,proto3" json:"unbonding_stakes"`
-	Regions           []Region         `protobuf:"bytes,10,rep,name=regions,proto3" json:"regions"`
-	FixedDepositList  []FixedDeposit   `protobuf:"bytes,11,rep,name=fixedDepositList,proto3" json:"fixedDepositList"`
-	FixedDepositCount uint64           `protobuf:"varint,12,opt,name=fixedDepositCount,proto3" json:"fixedDepositCount,omitempty"`
-	Exported          bool             `protobuf:"varint,13,opt,name=exported,proto3" json:"exported,omitempty"`
+	UnbondingStakes      []UnbondingStake      `protobuf:"bytes,9,rep,name=unbonding_stakes,json=unbondingStakes,proto3" json:"unbonding_stakes"`
+	Regions              []Region              `protobuf:"bytes,10,rep,name=regions,proto3" json:"regions"`
+	FixedDepositList     []FixedDeposit        `protobuf:"bytes,11,rep,name=fixedDepositList,proto3" json:"fixedDepositList"`
+	FixedDepositCount    uint64                `protobuf:"varint,12,opt,name=fixedDepositCount,proto3" json:"fixedDepositCount,omitempty"`
+	Exported             bool                  `protobuf:"varint,13,opt,name=exported,proto3" json:"exported,omitempty"`
+	RegionWithdrawGrants []RegionWithdrawGrant `protobuf:"bytes,14,rep,name=regionWithdrawGrants,proto3" json:"regionWithdrawGrants"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -172,6 +173,65 @@ func (m *GenesisState) GetExported() bool {
 	return false
 }
 
+func (m *GenesisState) GetRegionWithdrawGrants() []RegionWithdrawGrant {
+	if m != nil {
+		return m.RegionWithdrawGrants
+	}
+	return nil
+}
+
+type RegionWithdrawGrant struct {
+	RegionId string `protobuf:"bytes,1,opt,name=regionId,proto3" json:"regionId,omitempty"`
+	Address  string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+}
+
+func (m *RegionWithdrawGrant) Reset()         { *m = RegionWithdrawGrant{} }
+func (m *RegionWithdrawGrant) String() string { return proto.CompactTextString(m) }
+func (*RegionWithdrawGrant) ProtoMessage()    {}
+func (*RegionWithdrawGrant) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4c2ce6d8a4a0b180, []int{1}
+}
+func (m *RegionWithdrawGrant) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RegionWithdrawGrant) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RegionWithdrawGrant.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RegionWithdrawGrant) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RegionWithdrawGrant.Merge(m, src)
+}
+func (m *RegionWithdrawGrant) XXX_Size() int {
+	return m.Size()
+}
+func (m *RegionWithdrawGrant) XXX_DiscardUnknown() {
+	xxx_messageInfo_RegionWithdrawGrant.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RegionWithdrawGrant proto.InternalMessageInfo
+
+func (m *RegionWithdrawGrant) GetRegionId() string {
+	if m != nil {
+		return m.RegionId
+	}
+	return ""
+}
+
+func (m *RegionWithdrawGrant) GetAddress() string {
+	if m != nil {
+		return m.Address
+	}
+	return ""
+}
+
 // LastValidatorPower required for validator set update logic.
 type LastValidatorPower struct {
 	// address is the address of the validator.
@@ -215,6 +275,7 @@ var xxx_messageInfo_LastValidatorPower proto.InternalMessageInfo
 
 func init() {
 	proto.RegisterType((*GenesisState)(nil), "metaearth.wstaking.GenesisState")
+	proto.RegisterType((*RegionWithdrawGrant)(nil), "metaearth.wstaking.RegionWithdrawGrant")
 	proto.RegisterType((*LastValidatorPower)(nil), "metaearth.wstaking.LastValidatorPower")
 }
 
@@ -286,6 +347,20 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.RegionWithdrawGrants) > 0 {
+		for iNdEx := len(m.RegionWithdrawGrants) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.RegionWithdrawGrants[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenesis(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x72
+		}
+	}
 	if m.Exported {
 		i--
 		if m.Exported {
@@ -450,6 +525,43 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *RegionWithdrawGrant) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RegionWithdrawGrant) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RegionWithdrawGrant) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Address) > 0 {
+		i -= len(m.Address)
+		copy(dAtA[i:], m.Address)
+		i = encodeVarintGenesis(dAtA, i, uint64(len(m.Address)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.RegionId) > 0 {
+		i -= len(m.RegionId)
+		copy(dAtA[i:], m.RegionId)
+		i = encodeVarintGenesis(dAtA, i, uint64(len(m.RegionId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *LastValidatorPower) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -565,6 +677,29 @@ func (m *GenesisState) Size() (n int) {
 	}
 	if m.Exported {
 		n += 2
+	}
+	if len(m.RegionWithdrawGrants) > 0 {
+		for _, e := range m.RegionWithdrawGrants {
+			l = e.Size()
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *RegionWithdrawGrant) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.RegionId)
+	if l > 0 {
+		n += 1 + l + sovGenesis(uint64(l))
+	}
+	l = len(m.Address)
+	if l > 0 {
+		n += 1 + l + sovGenesis(uint64(l))
 	}
 	return n
 }
@@ -1031,6 +1166,154 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Exported = bool(v != 0)
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RegionWithdrawGrants", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RegionWithdrawGrants = append(m.RegionWithdrawGrants, RegionWithdrawGrant{})
+			if err := m.RegionWithdrawGrants[len(m.RegionWithdrawGrants)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenesis(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RegionWithdrawGrant) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenesis
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RegionWithdrawGrant: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RegionWithdrawGrant: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RegionId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RegionId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Address", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Address = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenesis(dAtA[iNdEx:])

--- a/x/wstaking/types/types_test.go
+++ b/x/wstaking/types/types_test.go
@@ -1,11 +1,60 @@
 package types
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"strings"
 	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPowerReduction(t *testing.T) {
 	t.Log(sdk.DefaultPowerReduction.String())
 
+}
+
+func TestValidateGenesisRegionWithdrawGrants(t *testing.T) {
+	validAddr := sdk.AccAddress([]byte("region_withdrawer_01")).String()
+
+	validGenesis := func() *GenesisState {
+		genesis := DefaultGenesisState()
+		genesis.Regions = []Region{{RegionId: ExperienceRegionId}}
+		genesis.RegionWithdrawGrants = []RegionWithdrawGrant{{
+			RegionId: ExperienceRegionId,
+			Address:  validAddr,
+		}}
+		return genesis
+	}
+
+	require.NoError(t, ValidateGenesis(validGenesis()))
+	encoded, err := validGenesis().Marshal()
+	require.NoError(t, err)
+	var decoded GenesisState
+	require.NoError(t, decoded.Unmarshal(encoded))
+	require.Equal(t, validGenesis().RegionWithdrawGrants, decoded.RegionWithdrawGrants)
+
+	registry := codectypes.NewInterfaceRegistry()
+	RegisterInterfaces(registry)
+	stakingtypes.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+	jsonGenesis := cdc.MustMarshalJSON(validGenesis())
+	require.True(t, strings.Contains(string(jsonGenesis), "regionWithdrawGrants"))
+	var decodedJSON GenesisState
+	cdc.MustUnmarshalJSON(jsonGenesis, &decodedJSON)
+	require.Equal(t, validGenesis().RegionWithdrawGrants, decodedJSON.RegionWithdrawGrants)
+
+	duplicate := validGenesis()
+	duplicate.RegionWithdrawGrants = append(duplicate.RegionWithdrawGrants, duplicate.RegionWithdrawGrants[0])
+	require.ErrorContains(t, ValidateGenesis(duplicate), "duplicate region withdraw grant")
+
+	unknownRegion := validGenesis()
+	unknownRegion.RegionWithdrawGrants[0].RegionId = "unknown"
+	require.ErrorContains(t, ValidateGenesis(unknownRegion), "unknown region")
+
+	invalidAddress := validGenesis()
+	invalidAddress.RegionWithdrawGrants[0].Address = "not-a-valid-address"
+	require.ErrorContains(t, ValidateGenesis(invalidAddress), "invalid region withdraw grant address")
 }


### PR DESCRIPTION
## Summary
- add `regionWithdrawGrants` to wstaking genesis state and protobuf definitions
- export all `RegionWithdrawKeyPrefix` grants and restore them during `InitGenesis`
- validate genesis grants for duplicate regions, unknown regions, empty region IDs, and invalid Bech32 addresses
- add regressions for export/import restoration plus binary and Proto JSON genesis round-trips

Fixes #1083.

## Validation
- `go test ./x/wstaking/types -run TestValidateGenesisRegionWithdrawGrants -count=1`
- `CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="zig cc -target x86_64-linux-gnu" go test -c ./x/wstaking/keeper -o ../../artifacts/me-hub-wstaking-keeper-region-withdraw-grants-linux.test`
- `git diff --check`

Note: direct Windows execution of `go test ./x/wstaking/keeper -run TestKeeperTestSuite/TestExportGenesisPreservesRegionWithdrawGrant -count=1` is blocked by the repository's native secp256k1/cgo build path on Windows (`undefined: secp256k1.RecoverPubkey`, `undefined: secp256k1.VerifySignature`). The Linux target keeper test binary compiles successfully.
