### PR TITLE
fix: reject validator updates to uncreated regions

### DIFF
--- a/x/wstaking/keeper/msg_server_validator_edit.go
+++ b/x/wstaking/keeper/msg_server_validator_edit.go
@@ -38,21 +38,32 @@ func (k MsgServer) UpdateValidator(goCtx context.Context, msg *types.MsgUpdateVa
 		description.RegionID = oldRegionId
 		validator.Description = description
 	} else {
-		if _, err := utils.CheckRegionName(strings.ToUpper(msg.Description.RegionID)); err != nil {
+		newRegionId := strings.ToLower(msg.Description.RegionID)
+		if _, err := utils.CheckRegionName(strings.ToUpper(newRegionId)); err != nil {
 			return nil, types.ErrRegionName
 		}
-		// remove duplication
-		validators := k.GetAllValidators(ctx)
-		for _, v := range validators {
-			if v.Description.RegionID == msg.Description.RegionID {
+		if strings.EqualFold(oldRegionId, newRegionId) {
+			description.RegionID = newRegionId
+			validator.Description = description
+		} else {
+			region, found := k.GetRegion(ctx, newRegionId)
+			if !found {
+				return nil, types.ErrRegionNotExist
+			}
+			if region.OperatorAddress != "" {
 				return nil, types.ErrValidatorRegionDuplication
 			}
-		}
-		k.UnBondRegion(ctx, oldRegionId)
-		description.RegionID = msg.Description.RegionID
-		validator.Description = description
-		region, f := k.GetRegion(ctx, msg.Description.RegionID)
-		if f && region.OperatorAddress == "" {
+
+			// remove duplication
+			validators := k.GetAllValidators(ctx)
+			for _, v := range validators {
+				if v.OperatorAddress != validator.OperatorAddress && strings.EqualFold(v.Description.RegionID, newRegionId) {
+					return nil, types.ErrValidatorRegionDuplication
+				}
+			}
+			k.UnBondRegion(ctx, oldRegionId)
+			description.RegionID = newRegionId
+			validator.Description = description
 			k.BondRegion(ctx, validator, validator.Tokens, true)
 		}
 	}

--- a/x/wstaking/keeper/msg_server_validator_edit_test.go
+++ b/x/wstaking/keeper/msg_server_validator_edit_test.go
@@ -1,0 +1,42 @@
+package keeper_test
+
+import (
+	"strings"
+
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestUpdateValidatorRejectsUncreatedRegionID() {
+	s.SetupTest()
+
+	_, err := s.msgServer.NewRegion(s.Ctx, &types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            "USA",
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	})
+	s.Require().NoError(err)
+
+	oldRegionID := strings.ToLower(s.usaValidator.Description.RegionID)
+	oldRegion, found := s.Keeper().GetRegion(s.Ctx, oldRegionID)
+	s.Require().True(found)
+	oldRegionOperator := oldRegion.OperatorAddress
+	oldRegionShare := oldRegion.RegionShare
+
+	description := s.usaValidator.Description
+	description.RegionID = "CAN"
+	_, err = s.msgServer.UpdateValidator(s.Ctx, &types.MsgUpdateValidator{
+		StakerAddress:   s.Dao.GlobalDao,
+		OperatorAddress: s.usaValidator.OperatorAddress,
+		Description:     description,
+	})
+	s.Require().ErrorIs(err, types.ErrRegionNotExist)
+
+	afterRegion, found := s.Keeper().GetRegion(s.Ctx, oldRegionID)
+	s.Require().True(found)
+	s.Require().Equal(oldRegionOperator, afterRegion.OperatorAddress)
+	s.Require().Equal(oldRegionShare.String(), afterRegion.RegionShare.String())
+
+	validator, found := s.Keeper().GetValidator(s.Ctx, s.usaValidator.GetOperator())
+	s.Require().True(found)
+	s.Require().Equal(oldRegionID, validator.Description.RegionID)
+}


### PR DESCRIPTION
## Summary
- normalize the requested validator region id before mutation
- reject syntactically valid but uncreated target regions before unbonding the old region
- reject already-bound target regions before any old-region state changes
- add a regression proving an attempted update to uncreated `CAN` returns `ErrRegionNotExist` and leaves the old `usa` region plus validator binding unchanged

Fixes #1078.

## Validation
- `CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="zig cc -target x86_64-linux-gnu" go test -c ./x/wstaking/keeper -o ../../artifacts/me-hub-wstaking-update-validator-region-linux.test`
- `git diff --check`

Note: direct Windows execution of `go test ./x/wstaking/keeper -run TestKeeperTestSuite/TestUpdateValidatorRejectsUncreatedRegionID -count=1` is blocked by the repository's native secp256k1/cgo build path on Windows (`undefined: secp256k1.RecoverPubkey`, `undefined: secp256k1.VerifySignature`). The Linux target keeper test binary compiles successfully.
