### PR TITLE
fix(gravity): guard batch timeout overflow

### DIFF
--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	errorsmod "cosmossdk.io/errors"
@@ -83,6 +84,9 @@ func (k Keeper) BuildOutgoingTxBatch(ctx sdk.Context, contractAddress, feeReceiv
 // GetBatchTimeoutHeight This gets the batch timeout height in External blocks.
 func (k Keeper) GetBatchTimeoutHeight(ctx sdk.Context) (uint64, uint64) {
 	currentMeHeight := ctx.BlockHeight()
+	if currentMeHeight < 0 {
+		return 0, 0
+	}
 	params := k.GetParams(ctx)
 	if params.AverageExternalBlockTime == 0 {
 		return 0, 0
@@ -94,12 +98,27 @@ func (k Keeper) GetBatchTimeoutHeight(ctx sdk.Context) (uint64, uint64) {
 		return 0, 0
 	}
 	// we project how long it has been in milliseconds since the last Ethereum block height was observed
-	projectedMillis := (uint64(currentMeHeight) - heights.BlockHeight) * params.AverageBlockTime
+	currentMeHeightUint := uint64(currentMeHeight)
+	if currentMeHeightUint < heights.BlockHeight {
+		return 0, 0
+	}
+	heightDelta := currentMeHeightUint - heights.BlockHeight
+	if params.AverageBlockTime > 0 && heightDelta > math.MaxUint64/params.AverageBlockTime {
+		return 0, 0
+	}
+	projectedMillis := heightDelta * params.AverageBlockTime
 	// we convert that projection into the current Ethereum height using the average Ethereum block time in millis
-	projectedCurrentEthereumHeight := (projectedMillis / params.AverageExternalBlockTime) + heights.ExternalBlockHeight
+	projectedExternalBlocks := projectedMillis / params.AverageExternalBlockTime
+	if projectedExternalBlocks > math.MaxUint64-heights.ExternalBlockHeight {
+		return 0, 0
+	}
+	projectedCurrentEthereumHeight := projectedExternalBlocks + heights.ExternalBlockHeight
 	// we convert our target time for block timeouts (lets say 12 hours) into a number of blocks to
 	// place on top of our projection of the current Ethereum block height.
 	blocksToAdd := params.ExternalBatchTimeout / params.AverageExternalBlockTime
+	if blocksToAdd == 0 || projectedCurrentEthereumHeight > math.MaxUint64-blocksToAdd {
+		return 0, 0
+	}
 	return projectedCurrentEthereumHeight, projectedCurrentEthereumHeight + blocksToAdd
 }
 

--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"math"
+
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -154,4 +156,32 @@ func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {
 		},
 	)
 	suite.Equal(len(batchs), index)
+}
+
+func (suite *KeeperTestSuite) TestBatchTimeoutHeightProjection() {
+	params := suite.Keeper().GetParams(suite.Ctx)
+	params.AverageBlockTime = 100
+	params.AverageExternalBlockTime = 100
+	params.ExternalBatchTimeout = 60_000
+	suite.Require().NoError(suite.Keeper().SetParams(suite.Ctx, &params))
+
+	suite.Keeper().SetLastObservedBlockHeight(suite.Ctx, 1_000, uint64(suite.Ctx.BlockHeight()))
+
+	projectedCurrentExternalHeight, batchTimeout := suite.Keeper().GetBatchTimeoutHeight(suite.Ctx)
+	suite.Require().Equal(uint64(1_000), projectedCurrentExternalHeight)
+	suite.Require().Equal(uint64(1_600), batchTimeout)
+}
+
+func (suite *KeeperTestSuite) TestBatchTimeoutAdditionMustNotWrapBelowProjection() {
+	params := suite.Keeper().GetParams(suite.Ctx)
+	params.AverageBlockTime = 100
+	params.AverageExternalBlockTime = 100
+	params.ExternalBatchTimeout = 60_000
+	suite.Require().NoError(suite.Keeper().SetParams(suite.Ctx, &params))
+
+	suite.Keeper().SetLastObservedBlockHeight(suite.Ctx, math.MaxUint64-100, uint64(suite.Ctx.BlockHeight()))
+
+	projectedCurrentExternalHeight, batchTimeout := suite.Keeper().GetBatchTimeoutHeight(suite.Ctx)
+	suite.Require().Zero(projectedCurrentExternalHeight)
+	suite.Require().Zero(batchTimeout)
 }


### PR DESCRIPTION
Fixes #1074.

## What changed
- Guard `GetBatchTimeoutHeight` against unsafe `uint64` arithmetic:
  - negative / regressed ME height projection input
  - elapsed block-time multiplication overflow
  - projected external-height addition overflow
  - final `projectedCurrentExternalHeight + blocksToAdd` overflow
- Fail closed by returning `0, 0`, so batch creation rejects the invalid timeout instead of creating an already-expired batch.
- Added regression coverage for both the normal projection path and the near-`math.MaxUint64` overflow path.

## Validation
- `git diff --check`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC="zig cc -target x86_64-linux-gnu" go test -c ./x/gravity/keeper -o ../../artifacts/me-hub-gravity-batch-timeout-overflow-linux.test`

Windows-native `go test ./x/gravity/keeper -run TestGravityKeeperTestSuite/TestBatchTimeout -count=1` is still blocked by the repo's existing `secp256k1` native dependency path in `github.com/openmetaearth/ethermint/app/ante`, with unresolved `RecoverPubkey` / `VerifySignature` symbols. The Linux/CGO keeper package test binary compiles successfully.
