### PR TITLE
fix(gravity): validate genesis relayer power

### DIFF
--- a/x/gravity/keeper/relayer_set.go
+++ b/x/gravity/keeper/relayer_set.go
@@ -33,11 +33,21 @@ func (k Keeper) GetCurrentRelayerSet(ctx sdk.Context) *types.RelayerSet {
 		if power.LTE(sdkmath.ZeroInt()) {
 			continue
 		}
-		totalPower += power.Uint64()
+		if !power.IsUint64() {
+			continue
+		}
+		powerUint64 := power.Uint64()
+		if totalPower > math.MaxUint64-powerUint64 {
+			continue
+		}
+		totalPower += powerUint64
 		bridgeValidators = append(bridgeValidators, types.BridgeValidator{
-			Power:           power.Uint64(),
+			Power:           powerUint64,
 			ExternalAddress: relayer.ExternalAddress,
 		})
+	}
+	if totalPower == 0 {
+		return types.CurrentRelayerSet(k.GetLastRelayerSetNonce(ctx), uint64(ctx.BlockHeight()), bridgeValidators)
 	}
 	for i := range bridgeValidators {
 		// normalize power, use 10000 as the base, meaning 50.01% is 5001.

--- a/x/gravity/types/genesis.go
+++ b/x/gravity/types/genesis.go
@@ -1,10 +1,54 @@
 package types
 
+import (
+	"fmt"
+	"math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
 // ValidateBasic validates genesis state by looping through the params and
 // calling their validation functions
 func (m *GenesisState) ValidateBasic() error {
 	if err := m.Params.ValidateBasic(); err != nil {
 		return err
 	}
+	var totalPower uint64
+	for i := range m.Relayers {
+		power, err := validateGenesisRelayer(m.Params, m.Relayers[i])
+		if err != nil {
+			return fmt.Errorf("invalid relayer %d: %w", i, err)
+		}
+		if !m.Relayers[i].Online || power == 0 {
+			continue
+		}
+		if totalPower > math.MaxUint64-power {
+			return fmt.Errorf("total online relayer power exceeds uint64")
+		}
+		totalPower += power
+	}
 	return nil
+}
+
+func validateGenesisRelayer(params Params, relayer Relayer) (uint64, error) {
+	if _, err := sdk.AccAddressFromBech32(relayer.RelayerAddress); err != nil {
+		return 0, fmt.Errorf("invalid relayer address: %w", err)
+	}
+	if relayer.DelegateAmount.IsNil() || !relayer.DelegateAmount.IsPositive() {
+		return 0, fmt.Errorf("delegate amount must be positive")
+	}
+	if relayer.DelegateAmount.LT(params.MinDelegate) {
+		return 0, ErrDelegateAmountBelowMinimum
+	}
+	if relayer.DelegateAmount.GT(params.MaxDelegate) {
+		return 0, ErrDelegateAmountAboveMaximum
+	}
+	power := relayer.GetPower()
+	if power.IsPositive() && !power.IsUint64() {
+		return 0, fmt.Errorf("relayer power must fit uint64")
+	}
+	if !power.IsPositive() {
+		return 0, nil
+	}
+	return power.Uint64(), nil
 }

--- a/x/gravity/types/genesis_test.go
+++ b/x/gravity/types/genesis_test.go
@@ -1,0 +1,64 @@
+package types_test
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/openmetaearth/me-hub/app/params"
+	gravitytypes "github.com/openmetaearth/me-hub/x/gravity/types"
+)
+
+func TestGenesisStateValidateBasicAcceptsMaxUint64RelayerPower(t *testing.T) {
+	delegateAmount := sdkmath.NewIntFromUint64(math.MaxUint64).Mul(sdk.DefaultPowerReduction)
+	state := genesisWithRelayers(delegateAmount, []gravitytypes.Relayer{
+		genesisRelayer(1, delegateAmount, true),
+	})
+
+	require.NoError(t, state.ValidateBasic())
+}
+
+func TestGenesisStateValidateBasicRejectsRelayerPowerOverflow(t *testing.T) {
+	delegateAmount := sdkmath.NewIntFromUint64(math.MaxUint64).Add(sdkmath.OneInt()).Mul(sdk.DefaultPowerReduction)
+	state := genesisWithRelayers(delegateAmount, []gravitytypes.Relayer{
+		genesisRelayer(1, delegateAmount, true),
+	})
+
+	err := state.ValidateBasic()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "relayer power must fit uint64")
+}
+
+func TestGenesisStateValidateBasicRejectsTotalOnlineRelayerPowerOverflow(t *testing.T) {
+	delegateAmount := sdkmath.NewIntFromUint64(math.MaxUint64).Mul(sdk.DefaultPowerReduction)
+	state := genesisWithRelayers(delegateAmount, []gravitytypes.Relayer{
+		genesisRelayer(1, delegateAmount, true),
+		genesisRelayer(2, delegateAmount, true),
+	})
+
+	err := state.ValidateBasic()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "total online relayer power exceeds uint64")
+}
+
+func genesisWithRelayers(maxDelegate sdkmath.Int, relayers []gravitytypes.Relayer) *gravitytypes.GenesisState {
+	params := gravitytypes.DefaultParams()
+	params.MaxDelegate = maxDelegate
+	return &gravitytypes.GenesisState{
+		Params:   params,
+		Relayers: relayers,
+	}
+}
+
+func genesisRelayer(seed byte, delegateAmount sdkmath.Int, online bool) gravitytypes.Relayer {
+	return gravitytypes.Relayer{
+		RelayerAddress:  sdk.AccAddress(bytes.Repeat([]byte{seed}, 20)).String(),
+		ExternalAddress: "0x0000000000000000000000000000000000000001",
+		DelegateAmount:  delegateAmount,
+		Online:          online,
+	}
+}


### PR DESCRIPTION
Fixes #1075.

## What changed
- Validates imported Gravity relayers in `GenesisState.ValidateBasic`:
  - valid ME relayer address
  - positive delegate amount
  - delegate amount within `MinDelegate` / `MaxDelegate`
  - normalized relayer power must fit `uint64`
  - total online relayer power must not overflow `uint64`
- Hardens `GetCurrentRelayerSet` so existing bad state cannot panic on `power.Uint64()` or total power wraparound.
- Adds regression coverage for:
  - exact `math.MaxUint64` relayer power accepted
  - `math.MaxUint64 + 1` relayer power rejected at genesis validation
  - total online relayer power overflow rejected at genesis validation

## Notes
`Relayer` genesis state does not carry `chain_name`, so this PR does not guess an external-address router in types-level genesis validation. It focuses on the crash vector from delegate amount / power normalization and keeps external-address validation in the message paths that have chain context.

## Validation
- `go test ./x/gravity/types -run TestGenesisStateValidateBasic -count=1`
- `git diff --check`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC="zig cc -target x86_64-linux-gnu" go test -c ./x/gravity/keeper -o ../../artifacts/me-hub-gravity-genesis-relayer-power-linux.test`
