### PR TITLE
fix(wstaking): reject replace pubkey delay overflow

### DIFF
--- a/x/wstaking/keeper/msg_server_replace_consensus_pubkey_test.go
+++ b/x/wstaking/keeper/msg_server_replace_consensus_pubkey_test.go
@@ -1,0 +1,54 @@
+package keeper_test
+
+import (
+	"math"
+
+	ed25519 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+
+	"github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestReplaceConsensusPubKeySchedulesFutureHeight() {
+	s.SetupTest()
+	s.Ctx = s.Ctx.WithBlockHeight(10)
+
+	msg, err := types.NewMsgReplaceConsensusPubKeyRequest(
+		s.Dao.GlobalDao,
+		s.meEarthValidator.OperatorAddress,
+		ed25519.GenPrivKey().PubKey(),
+		10,
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(msg.ValidateBasic())
+
+	_, err = s.msgServer.ReplaceConsensusPubKey(s.Ctx, msg)
+	s.Require().NoError(err)
+
+	pending, err := s.Keeper().GetReplaceConsensusPubKeyInfo(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().NotNil(pending)
+	s.Require().Equal(int64(20), pending.UpdateAtHeight)
+}
+
+func (s *KeeperTestSuite) TestReplaceConsensusPubKeyRejectsOverflowingDelay() {
+	s.SetupTest()
+	s.Ctx = s.Ctx.WithBlockHeight(10)
+	overflowingDelay := int64(math.MaxInt64) - s.Ctx.BlockHeight() + 1
+
+	msg, err := types.NewMsgReplaceConsensusPubKeyRequest(
+		s.Dao.GlobalDao,
+		s.meEarthValidator.OperatorAddress,
+		ed25519.GenPrivKey().PubKey(),
+		overflowingDelay,
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(msg.ValidateBasic())
+
+	_, err = s.msgServer.ReplaceConsensusPubKey(s.Ctx, msg)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "update height overflows")
+
+	pending, err := s.Keeper().GetReplaceConsensusPubKeyInfo(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Nil(pending)
+}

--- a/x/wstaking/keeper/msg_server_validator.go
+++ b/x/wstaking/keeper/msg_server_validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"strings"
 
 	ed25519 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
@@ -184,12 +185,16 @@ func (k MsgServer) ReplaceConsensusPubKey(goCtx context.Context, req *types.MsgR
 	if err != nil {
 		return nil, sdkerrors.Wrapf(types.ErrInterProc, "GetConsAddr from validator error: %v", err)
 	}
+	updateAtHeight, err := safeReplaceConsensusPubKeyUpdateHeight(ctx.BlockHeight(), req.ReplacePubKey.BlockNumber)
+	if err != nil {
+		return nil, err
+	}
 
 	update := &types.UpdatePubKeyInfo{
 		OperatorAddress: req.ReplacePubKey.OperatorAddress,
 		OldConsAddress:  needReplaceConsAddr.Bytes(),
 		PubKey:          pubKeyData,
-		UpdateAtHeight:  ctx.BlockHeight() + req.ReplacePubKey.BlockNumber,
+		UpdateAtHeight:  updateAtHeight,
 	}
 
 	if err = k.SetReplacePubKeyInfo(ctx, update); err != nil {
@@ -206,4 +211,24 @@ func (k MsgServer) ReplaceConsensusPubKey(goCtx context.Context, req *types.MsgR
 	})
 
 	return &types.MsgReplaceConsensusPubKeyResponse{}, nil
+}
+
+func safeReplaceConsensusPubKeyUpdateHeight(currentHeight, blockNumber int64) (int64, error) {
+	const cleanupDelayBlocks int64 = 2
+	if blockNumber < 1 {
+		return 0, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid block number (%d)", blockNumber)
+	}
+	if currentHeight < 0 {
+		return 0, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid current block height (%d)", currentHeight)
+	}
+	maxDelay := int64(math.MaxInt64) - currentHeight - cleanupDelayBlocks
+	if maxDelay < 1 || blockNumber > maxDelay {
+		return 0, sdkerrors.Wrapf(
+			sdkerrors.ErrInvalidRequest,
+			"replace consensus pubkey update height overflows: current height %d, block number %d",
+			currentHeight,
+			blockNumber,
+		)
+	}
+	return currentHeight + blockNumber, nil
 }


### PR DESCRIPTION
Fixes #1066.

## What changed
- Replaces the unchecked `ctx.BlockHeight() + req.ReplacePubKey.BlockNumber` with checked scheduling logic.
- Rejects replacement delays that would overflow the target update height.
- Reserves the existing two-block cleanup window used by `UpdateValidatorPubKey()` (`UpdateAtHeight + 1/+2`) so accepted schedules remain safe for the full replacement lifecycle.
- Adds regression coverage for:
  - normal delay scheduling to a future height
  - overflowing delay rejection without writing pending replacement state

## Validation
- `git diff --check`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=1 CC="zig cc -target x86_64-linux-gnu" go test -c ./x/wstaking/keeper -o ../../artifacts/me-hub-wstaking-replace-pubkey-overflow-linux.test`
