### PR TITLE
fix(gravity): prevent mutation of immutable GravityId in UpdateParams

### DIFF
--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -380,6 +380,12 @@ func (s MsgServer) UpdateParams(c context.Context, req *types.MsgUpdateParams) (
 		return nil, errorsmod.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", s.authority, req.Authority)
 	}
 	ctx := sdk.UnwrapSDKContext(c)
+
+	currentParams := s.GetParams(ctx)
+	if req.Params.GravityId != currentParams.GravityId {
+		return nil, errorsmod.Wrapf(types.ErrInvalid, "GravityId is immutable and cannot be changed (current: %s, proposed: %s)", currentParams.GravityId, req.Params.GravityId)
+	}
+
 	if err := s.SetParams(ctx, &req.Params); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #1060

## Description
This PR fixes a critical vulnerability where `UpdateParams` allowed the mutation of the `GravityId`. The `GravityId` serves as the signing-domain salt for relayers and must remain immutable once the contract is deployed. Modifying it invalidates all checkpoint signatures, potentially freezing the bridge.

### Fix
Added a check in `x/gravity/keeper/msg_server.go` -> `UpdateParams` that compares the proposed `GravityId` against the current state `GravityId`. If they do not match, it returns an explicit `ErrInvalid` preventing the state update.

---
**Bounty Submission Details**
- USDT (TRC-20) Wallet: TNemEuAqMEsfDaXnxsCj5HJR9A4b2hBdnm
- Solana (USDC) Wallet: pJju8G3iRRiYSQyLMQShZFjtadJoeMiPrpJSC8rdwjb
