### PR TITLE
fix(gravity): reject zero-power attestation quorum

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -80,6 +80,11 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 	// This conditional stops the attestation from accidentally being applied twice.
 	// Sum the current powers of all validators who have voted and see if it passes the current threshold
 	totalPower := k.GetLastTotalPower(ctx)
+	if !totalPower.IsPositive() {
+		k.Logger(ctx).Error("TryAttestation", "non-positive total relayer power", totalPower.String(),
+			"claimEventNonce", claim.GetEventNonce(), "claimType", claim.GetType(), "claimHeight", claim.GetBlockHeight())
+		return
+	}
 	requiredPower := types.AttestationVotesPowerThreshold.Mul(totalPower).Quo(sdk.NewIntFromUint64(types.PowerBase))
 	attestationPower := sdkmath.NewInt(0)
 

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -10,6 +10,7 @@ package keeper_test
 // Coverage:
 //   GRAV-001  Attest must reject historical-nonce claims (no backward rewind)
 //   GRAV-004  Failed AttestationHandler must not advance lastObservedEventNonce
+//   GRAV-005  Zero-total-power attestations must not satisfy quorum
 
 import (
 	"encoding/hex"
@@ -193,6 +194,53 @@ func (s *KeeperTestSuite) TestGrav004_FailedAttestationMustNotLockNonce() {
 				"handler failed; retries are now impossible",
 			probeClaim.GetEventNonce())
 	}
+}
+
+// ---------------------------------------------------------------------------
+// GRAV-005: Zero-power relayers must not satisfy attestation quorum
+// ---------------------------------------------------------------------------
+//
+// TryAttestation derives requiredPower from LastTotalPower. When total power is
+// zero, requiredPower is also zero and the old comparison allowed a zero-power
+// vote to mark the attestation observed. Legacy imported state can still contain
+// a dust relayer, so attestation processing must reject zero total power even
+// after params validation prevents new zero-power bonding.
+
+func (s *KeeperTestSuite) TestGrav005_TryAttestationRejectsZeroTotalPower() {
+	k := s.Keeper()
+	relayer := s.relayerAddrs[0]
+
+	k.SetRelayer(s.Ctx, relayer, types.Relayer{
+		RelayerAddress:  relayer.String(),
+		ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[0].PublicKey),
+		DelegateAmount:  sdkmath.NewInt(1),
+		Online:          true,
+	})
+	k.SetLastTotalPower(s.Ctx)
+	s.Require().True(k.GetLastTotalPower(s.Ctx).IsZero(),
+		"test precondition: dust relayer should truncate to zero voting power")
+
+	claim := &types.MsgSendToMeClaim{
+		EventNonce:     1,
+		BlockHeight:    1,
+		TokenContract:  "0x0000000000000000000000000000000000000001",
+		Amount:         sdkmath.NewInt(12345),
+		Sender:         "0x0000000000000000000000000000000000000002",
+		Receiver:       s.relayerAddrs[1].String(),
+		RelayerAddress: relayer.String(),
+		ChainName:      s.chainName,
+	}
+	att := &types.Attestation{
+		Observed: false,
+		Votes:    []string{relayer.String()},
+	}
+
+	k.TryAttestation(s.Ctx, att, claim)
+
+	s.Require().False(att.Observed,
+		"GRAV-005: zero total relayer power must not observe an attestation")
+	s.Require().EqualValues(uint64(0), k.GetLastObservedEventNonce(s.Ctx),
+		"GRAV-005: zero-power attestation must not advance observed nonce")
 }
 
 // ---------------------------------------------------------------------------

--- a/x/gravity/types/params.go
+++ b/x/gravity/types/params.go
@@ -76,6 +76,9 @@ func (m *Params) ValidateBasic() error {
 	if !m.MinDelegate.IsPositive() {
 		return fmt.Errorf("invalid delegate threshold")
 	}
+	if m.MinDelegate.LT(sdk.DefaultPowerReduction) {
+		return fmt.Errorf("min delegate threshold must produce non-zero relayer power")
+	}
 	if !m.MaxDelegate.IsPositive() {
 		return fmt.Errorf("invalid delegate threshold")
 	}

--- a/x/gravity/types/params_test.go
+++ b/x/gravity/types/params_test.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParamsValidateBasicRejectsZeroPowerMinDelegate(t *testing.T) {
+	params := DefaultParams()
+	require.NoError(t, params.ValidateBasic())
+
+	params.MinDelegate = sdk.DefaultPowerReduction.Sub(sdkmath.NewInt(1))
+	params.MaxDelegate = sdk.DefaultPowerReduction
+	require.ErrorContains(t, params.ValidateBasic(), "min delegate threshold must produce non-zero relayer power")
+
+	params.MinDelegate = sdk.DefaultPowerReduction
+	params.MaxDelegate = sdk.DefaultPowerReduction
+	require.NoError(t, params.ValidateBasic())
+}


### PR DESCRIPTION
## Summary
- reject Gravity params where `MinDelegate` would truncate relayer voting power to zero
- prevent `TryAttestation` from observing claims when `LastTotalPower` is non-positive
- add regression coverage for params validation and legacy zero-power attestation state

Fixes #1071

## Tests
- Not run locally: Go/gofmt is not installed in this Windows environment.
- Ran `git diff --check`.