### PR TITLE
fix(wbank): validate fee receiver metadata before transfer

### DIFF
--- a/x/wbank/keeper/keeper.go
+++ b/x/wbank/keeper/keeper.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"errors"
 	"fmt"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -92,27 +91,32 @@ func (k BaseKeeperWrapper) UnstakeCoinsFromModuleToModule(
 }
 
 func (k BaseKeeperWrapper) FeeToReceivers(ctx sdk.Context, inputs []banktypes.Input, outputs []banktypes.Output, receiverTypes []types.FeeReceiverType) error {
+	if len(inputs) == 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "inputs error")
+	}
+	if len(receiverTypes) != len(outputs) {
+		return sdkerrors.Wrapf(
+			sdkerrors.ErrInvalidRequest,
+			"fee receiver types and outputs are not equal: got %d receiver types for %d outputs",
+			len(receiverTypes),
+			len(outputs),
+		)
+	}
+
 	err := k.InputOutputCoins(ctx, inputs, outputs)
 	if err != nil {
 		return sdkerrors.Wrap(err, "failed to process input-output coins")
 	}
 
-	if len(receiverTypes) != len(outputs) {
-		return sdkerrors.Wrap(err, "fee receiver types and outputs are not equal")
-	}
-
 	attributes := []sdk.Attribute{}
-	if len(inputs) > 0 {
-		attributes = append(attributes, sdk.NewAttribute(sdk.AttributeKeySender, inputs[0].Address))
-		for index, output := range outputs {
-			attributes = append(attributes, sdk.NewAttribute(fmt.Sprintf("%s", receiverTypes[index]), output.Address))
-			attributes = append(attributes, sdk.NewAttribute(fmt.Sprintf("%s_amount", receiverTypes[index]), output.Coins.String()))
-		}
-		event := sdk.NewEvent(types.EventTypeFeeToReceivers, attributes...)
-		ctx.EventManager().EmitEvent(event)
-	} else {
-		return errors.New("inputs error")
+	attributes = append(attributes, sdk.NewAttribute(sdk.AttributeKeySender, inputs[0].Address))
+	for index, output := range outputs {
+		attributes = append(attributes, sdk.NewAttribute(fmt.Sprintf("%s", receiverTypes[index]), output.Address))
+		attributes = append(attributes, sdk.NewAttribute(fmt.Sprintf("%s_amount", receiverTypes[index]), output.Coins.String()))
 	}
+	event := sdk.NewEvent(types.EventTypeFeeToReceivers, attributes...)
+	ctx.EventManager().EmitEvent(event)
+
 	return nil
 }
 

--- a/x/wbank/keeper/keeper_test.go
+++ b/x/wbank/keeper/keeper_test.go
@@ -1,0 +1,54 @@
+package keeper_test
+
+import (
+	"testing"
+
+	cometbftproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	bankutil "github.com/cosmos/cosmos-sdk/x/bank/testutil"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	"github.com/openmetaearth/me-hub/app/params"
+	wbanktypes "github.com/openmetaearth/me-hub/x/wbank/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeeToReceiversRejectsReceiverTypeMismatchBeforeTransfer(t *testing.T) {
+	meApp := apptesting.Setup(t, false)
+	ctx := meApp.BaseApp.NewContext(false, cometbftproto.Header{}).WithBlockHeight(1)
+
+	sender := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	receiverA := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	receiverB := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+
+	inputCoins := sdk.NewCoins(sdk.NewInt64Coin(params.BaseDenom, 100))
+	outputCoinsA := sdk.NewCoins(sdk.NewInt64Coin(params.BaseDenom, 40))
+	outputCoinsB := sdk.NewCoins(sdk.NewInt64Coin(params.BaseDenom, 60))
+
+	err := bankutil.FundAccount(meApp.BankKeeper, ctx, sender, inputCoins)
+	require.NoError(t, err)
+
+	inputs := []banktypes.Input{{
+		Address: sender.String(),
+		Coins:   inputCoins,
+	}}
+	outputs := []banktypes.Output{
+		{Address: receiverA.String(), Coins: outputCoinsA},
+		{Address: receiverB.String(), Coins: outputCoinsB},
+	}
+	receiverTypes := []wbanktypes.FeeReceiverType{wbanktypes.FeeReceiverDevOperator}
+
+	senderBefore := meApp.BankKeeper.GetAllBalances(ctx, sender)
+	receiverABefore := meApp.BankKeeper.GetAllBalances(ctx, receiverA)
+	receiverBBefore := meApp.BankKeeper.GetAllBalances(ctx, receiverB)
+
+	err = meApp.BankKeeper.FeeToReceivers(ctx, inputs, outputs, receiverTypes)
+	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
+	require.ErrorContains(t, err, "fee receiver types and outputs are not equal")
+
+	require.True(t, senderBefore.IsEqual(meApp.BankKeeper.GetAllBalances(ctx, sender)))
+	require.True(t, receiverABefore.IsEqual(meApp.BankKeeper.GetAllBalances(ctx, receiverA)))
+	require.True(t, receiverBBefore.IsEqual(meApp.BankKeeper.GetAllBalances(ctx, receiverB)))
+}


### PR DESCRIPTION
## Summary

- Validate `FeeToReceivers` inputs before calling `InputOutputCoins`.
- Return a concrete `ErrInvalidRequest` when receiver metadata does not match the outputs instead of wrapping a nil error.
- Add a regression test that confirms mismatched receiver metadata returns an error and leaves balances unchanged.

Fixes   #251  #260  #298  #382  #1110 

## Validation

- `go test ./x/wbank/... -count=1`
- `git diff --check origin/main...HEAD`

I also tried `go test ./app/ante -count=1`; it currently fails to build because the generated `MockDaoKeeper` in `app/ante/mock` is missing `IsDao`, which is unrelated to this change.

## Bounty payout

Meta Earth bug bounty payout: $MEC via ME Pass
MEC wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`
