### PR TITLE
fix: correct FrozenHeight revision number/height argument order in fraud_handler.go

### DIFF
--- a/x/rollapp/keeper/fraud_handler.go
+++ b/x/rollapp/keeper/fraud_handler.go
@@ -97,7 +97,7 @@ func (k Keeper) freezeClientState(ctx sdk.Context, clientId string) error {
 		return errorsmod.Wrapf(types.ErrInvalidClientState, "client state with ID %s is not a tendermint client state", clientId)
 	}
 
-	tmClientState.FrozenHeight = clienttypes.NewHeight(tmClientState.GetLatestHeight().GetRevisionHeight(), tmClientState.GetLatestHeight().GetRevisionNumber())
+	tmClientState.FrozenHeight = clienttypes.NewHeight(tmClientState.GetLatestHeight().GetRevisionNumber(), tmClientState.GetLatestHeight().GetRevisionHeight())
 	k.ibcClientKeeper.SetClientState(ctx, clientId, tmClientState)
 
 	return nil


### PR DESCRIPTION
Closes #1109

## Bug

`freezeClientState` in `x/rollapp/keeper/fraud_handler.go` passes
`GetRevisionHeight()` as the first argument to `clienttypes.NewHeight()`
and `GetRevisionNumber()` as the second, but `NewHeight` expects
`(revisionNumber, revisionHeight)`.

```go
// Before (buggy):
tmClientState.FrozenHeight = clienttypes.NewHeight(
    tmClientState.GetLatestHeight().GetRevisionHeight(),  // should be Number
    tmClientState.GetLatestHeight().GetRevisionNumber(),  // should be Height
)

// After (fixed):
tmClientState.FrozenHeight = clienttypes.NewHeight(
    tmClientState.GetLatestHeight().GetRevisionNumber(),
    tmClientState.GetLatestHeight().GetRevisionHeight(),
)
```

## Impact

Incorrect `FrozenHeight` causes the IBC client to freeze at the wrong
height, breaking fraud handling for rollapps. When fraud is detected,
the client state FrozenHeight is stored with swapped revision number
and height, potentially allowing the fraudulent state to remain
unfrozen.

## Fix

Swap the two arguments to match `NewHeight(revisionNumber, revisionHeight)`.