### PR TITLE
fix: prevent chain halt from invalid treasury addresses in AllocateBlockReward (#1133)

### DIFF
--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -102,7 +102,11 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		amount := sdk.NewDecFromInt(region.GetRegionShare()).Mul(totalMintCoin.AmountOf(params.BaseDenom).ToLegacyDec()).Quo(totalRegionShareDec)
 		regionAmount := amount.TruncateInt()
 		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
-		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()), regionCoins)
+		treasuryAddr, addrErr := sdk.AccAddressFromBech32(region.GetRegionTreasureAddr())
+                if addrErr != nil {
+                    return addrErr
+                }
+                err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), treasuryAddr, regionCoins)
 		if err != nil {
 			return err
 		}

--- a/x/wdistri/keeper/keeper.go
+++ b/x/wdistri/keeper/keeper.go
@@ -103,10 +103,11 @@ func (k Keeper) AllocateBlockReward(ctx sdk.Context) error {
 		regionAmount := amount.TruncateInt()
 		regionCoins := sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(regionAmount.Int64())))
 		treasuryAddr, addrErr := sdk.AccAddressFromBech32(region.GetRegionTreasureAddr())
-                if addrErr != nil {
-                    return addrErr
-                }
-                err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), treasuryAddr, regionCoins)
+		if addrErr != nil {
+			ctx.Logger().Error("invalid region treasure address, skipping reward", "regionId", region.GetRegionId(), "addr", region.GetRegionTreasureAddr(), "err", addrErr)
+			continue
+		}
+		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, k.GetTreasuryModuleAccount(), treasuryAddr, regionCoins)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #1133

## Bug

`AllocateBlockReward()` uses `sdk.MustAccAddressFromBech32()` without
error handling. If any region has an invalid or empty treasury address,
the Must variant panics, halting the entire chain permanently.

## Fix

Replace `MustAccAddressFromBech32()` with `AccAddressFromBech32()` which
returns an error instead of panicking. The error is returned to the
caller, allowing the block to continue processing while skipping the
problematic region.

```go
// Before (panics on invalid address):
err := k.bankKeeper.SendCoinsFromModuleToAccount(
    ctx,
    k.GetTreasuryModuleAccount(),
    sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()), // PANIC
    regionCoins,
)

// After (returns error):
treasuryAddr, addrErr := sdk.AccAddressFromBech32(region.GetRegionTreasureAddr())
if addrErr != nil {
    return addrErr
}
err := k.bankKeeper.SendCoinsFromModuleToAccount(
    ctx,
    k.GetTreasuryModuleAccount(),
    treasuryAddr,
    regionCoins,
)
```