### PR TITLE
fix(eibc): block malformed demand order recipients

### DIFF
--- a/x/eibc/keeper/handler.go
+++ b/x/eibc/keeper/handler.go
@@ -147,7 +147,7 @@ func (k *Keeper) getEIBCTransferDenom(packet channeltypes.Packet, fungibleTokenP
 func (k Keeper) BlockedAddr(addr string) bool {
 	account, err := sdk.AccAddressFromBech32(addr)
 	if err != nil {
-		return false
+		return true
 	}
 	return k.bk.BlockedAddr(account)
 }

--- a/x/eibc/keeper/handler_test.go
+++ b/x/eibc/keeper/handler_test.go
@@ -2,8 +2,11 @@ package keeper_test
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	commontypes "github.com/openmetaearth/me-hub/x/common/types"
 	dacktypes "github.com/openmetaearth/me-hub/x/delayedack/types"
+	eibctypes "github.com/openmetaearth/me-hub/x/eibc/types"
 )
 
 func (suite *KeeperTestSuite) TestCreateDemandOrderOnRecv() {
@@ -79,4 +82,26 @@ func (suite *KeeperTestSuite) TestCreateDemandOrderOnRecv() {
 			}
 		})
 	}
+}
+
+func (suite *KeeperTestSuite) TestBlockedAddr() {
+	suite.Require().True(suite.App.EIBCKeeper.BlockedAddr("not-a-bech32-address"))
+	suite.Require().True(suite.App.EIBCKeeper.BlockedAddr(authtypes.NewModuleAddress(authtypes.FeeCollectorName).String()))
+	suite.Require().False(suite.App.EIBCKeeper.BlockedAddr(eibcReceiverAddr.String()))
+}
+
+func (suite *KeeperTestSuite) TestDemandOrderHandlerBlocksMalformedOriginalReceiver() {
+	data := transferPacketData
+	data.Receiver = "not-a-bech32-address"
+	packet := channeltypes.NewPacket(data.GetBytes(), 2, portid, chanid, cpportid, cpchanid, timeoutHeight, timeoutTimestamp)
+	localRollappPacket := *rollappPacket
+	localRollappPacket.Type = commontypes.RollappPacket_ON_TIMEOUT
+	localRollappPacket.Packet = &packet
+
+	err := suite.App.EIBCKeeper.EIBCDemandOrderHandler(suite.Ctx, localRollappPacket, data)
+	suite.Require().ErrorIs(err, eibctypes.ErrBlockedAddress)
+
+	orders, err := suite.App.EIBCKeeper.ListAllDemandOrders(suite.Ctx)
+	suite.Require().NoError(err)
+	suite.Require().Empty(orders)
 }


### PR DESCRIPTION
## Summary
- Treat malformed or non-hub Bech32 recipient strings as blocked in the eIBC demand-order recipient guard.
- Add regression coverage for malformed recipient strings, blocked module accounts, normal non-blocked account addresses, and the timeout/error-ack demand-order handler path.

## Why
`BlockedAddr` is used as the fail-safe gate before creating eIBC demand orders. Returning `false` when an address cannot be parsed allows malformed or wrong-prefix recipient strings to bypass the blocked-address check. Failing closed keeps demand order creation limited to recipients the hub can parse and verify.

Fixes #1148

## Validation
- `go test ./x/eibc/keeper -run 'TestKeeperTestSuite/Test(DemandOrderHandlerBlocksMalformedOriginalReceiver|BlockedAddr)' -count=1 -v`
- `go test ./x/eibc/keeper -count=1`
- `go test ./x/eibc/... -count=1`
- `git diff --check`

## Bounty payout
Meta Earth / ME Pass wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`