### PR TITLE
fix(eibc): register update demand order message

### DIFF
--- a/x/eibc/types/codec.go
+++ b/x/eibc/types/codec.go
@@ -11,6 +11,7 @@ import (
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgFulfillOrder{}, "eibc/MsgFulfillOrder", nil)
+	cdc.RegisterConcrete(&MsgUpdateDemandOrder{}, "eibc/MsgUpdateDemandOrder", nil)
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
@@ -18,6 +19,7 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		&MsgFulfillOrder{},
+		&MsgUpdateDemandOrder{},
 	)
 }
 

--- a/x/eibc/types/codec_test.go
+++ b/x/eibc/types/codec_test.go
@@ -1,0 +1,45 @@
+package types_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmetaearth/me-hub/x/eibc/types"
+)
+
+func TestRegisterCodecIncludesMsgUpdateDemandOrder(t *testing.T) {
+	cdc := codec.NewLegacyAmino()
+	sdk.RegisterLegacyAminoCodec(cdc)
+	types.RegisterCodec(cdc)
+
+	msg := sdk.Msg(types.NewMsgUpdateDemandOrder(
+		"cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88yqg82a",
+		strings.Repeat("a", 64),
+		"1",
+	))
+
+	bz, err := cdc.MarshalJSON(msg)
+	require.NoError(t, err)
+	require.Contains(t, string(bz), "eibc/MsgUpdateDemandOrder")
+
+	var decoded sdk.Msg
+	require.NoError(t, cdc.UnmarshalJSON(bz, &decoded))
+	require.IsType(t, &types.MsgUpdateDemandOrder{}, decoded)
+}
+
+func TestRegisterInterfacesIncludesMsgUpdateDemandOrder(t *testing.T) {
+	registry := cdctypes.NewInterfaceRegistry()
+	sdk.RegisterInterfaces(registry)
+	types.RegisterInterfaces(registry)
+
+	require.Contains(
+		t,
+		registry.ListImplementations(sdk.MsgInterfaceProtoName),
+		sdk.MsgTypeURL(&types.MsgUpdateDemandOrder{}),
+	)
+}


### PR DESCRIPTION
Fixes #1164

## Summary
- register `MsgUpdateDemandOrder` with the eIBC legacy Amino codec
- include `MsgUpdateDemandOrder` in the module `sdk.Msg` interface registrations
- add codec coverage for Amino JSON round-tripping and interface registration

## Validation
- `go test ./x/eibc/types -count=1`
- `go test ./x/eibc/... -count=1`
- `go test ./... -count=1`
- `git diff --check`

## Payout
Meta Earth bug bounty payout in `$MEC` via ME Pass:

`me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`