### PR TITLE
fix(rollapp): authenticate transfers from packet endpoints

### DIFF
--- a/testutil/keeper/delayedack.go
+++ b/testutil/keeper/delayedack.go
@@ -101,7 +101,11 @@ func (RollappKeeperStub) GetAllRollapps(ctx sdk.Context) (list []rollapptypes.Ro
 	return []rollapptypes.Rollapp{}
 }
 
-func (r RollappKeeperStub) GetValidTransfer(ctx sdk.Context, packetData []byte, raPortOnHub, raChanOnHub string) (data rollapptypes.TransferData, err error) {
+func (r RollappKeeperStub) GetValidTransferFromReceivedPacket(ctx sdk.Context, packet channeltypes.Packet) (data rollapptypes.TransferData, err error) {
+	return rollapptypes.TransferData{}, nil
+}
+
+func (r RollappKeeperStub) GetValidTransferFromSentPacket(ctx sdk.Context, packet channeltypes.Packet) (data rollapptypes.TransferData, err error) {
 	return rollapptypes.TransferData{}, nil
 }
 

--- a/x/bridgingfee/ibc_module.go
+++ b/x/bridgingfee/ibc_module.go
@@ -67,7 +67,7 @@ func (w *IBCModule) OnRecvPacket(ctx sdk.Context, packet channeltypes.Packet, re
 		return w.IBCModule.OnRecvPacket(ctx, packet, relayer)
 	}
 
-	transfer, err := w.rollappKeeper.GetValidTransfer(ctx, packet.GetData(), packet.GetDestPort(), packet.GetDestChannel())
+	transfer, err := w.rollappKeeper.GetValidTransferFromReceivedPacket(ctx, packet)
 	if err != nil {
 		l.Error("Get valid transfer.", "err", err)
 		err = errorsmod.Wrapf(err, "%s: get valid transfer", ModuleName)

--- a/x/delayedack/keeper/transfer.go
+++ b/x/delayedack/keeper/transfer.go
@@ -23,11 +23,15 @@ func (k Keeper) GetValidTransferWithFinalizationInfo(
 	switch packetType {
 	case commontypes.RollappPacket_ON_RECV:
 		port, channel = packet.GetDestPort(), packet.GetDestChannel()
+		data.TransferData, err = k.rollappKeeper.GetValidTransferFromReceivedPacket(ctx, packet)
 	case commontypes.RollappPacket_ON_TIMEOUT, commontypes.RollappPacket_ON_ACK:
 		port, channel = packet.GetSourcePort(), packet.GetSourceChannel()
+		data.TransferData, err = k.rollappKeeper.GetValidTransferFromSentPacket(ctx, packet)
+	default:
+		err = errors.Wrapf(gerrc.ErrInvalidArgument, "unsupported rollapp packet type: %s", packetType)
+		return
 	}
 
-	data.TransferData, err = k.rollappKeeper.GetValidTransfer(ctx, packet.GetData(), port, channel)
 	if err != nil {
 		err = errors.Wrap(err, "get valid transfer data")
 		return

--- a/x/delayedack/types/expected_keepers.go
+++ b/x/delayedack/types/expected_keepers.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 
 	commontypes "github.com/openmetaearth/me-hub/x/common/types"
 	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
@@ -20,10 +21,13 @@ type RollappKeeper interface {
 	MustGetStateInfo(ctx sdk.Context, rollappId string, index uint64) rollapptypes.StateInfo
 	GetLatestFinalizedStateIndex(ctx sdk.Context, rollappId string) (val rollapptypes.StateInfoIndex, found bool)
 	GetAllRollapps(ctx sdk.Context) (list []rollapptypes.Rollapp)
-	GetValidTransfer(
+	GetValidTransferFromReceivedPacket(
 		ctx sdk.Context,
-		packetData []byte,
-		raPortOnHub, raChanOnHub string,
+		packet channeltypes.Packet,
+	) (data rollapptypes.TransferData, err error)
+	GetValidTransferFromSentPacket(
+		ctx sdk.Context,
+		packet channeltypes.Packet,
 	) (data rollapptypes.TransferData, err error)
 	IsSkipDelayRollapp(ctx sdk.Context, rollappId string) bool
 }

--- a/x/denommetadata/ibc_middleware.go
+++ b/x/denommetadata/ibc_middleware.go
@@ -55,7 +55,7 @@ func (im IBCModule) OnRecvPacket(
 		return im.IBCModule.OnRecvPacket(ctx, packet, relayer)
 	}
 
-	transferData, err := im.rollappKeeper.GetValidTransfer(ctx, packet.Data, packet.DestinationPort, packet.DestinationChannel)
+	transferData, err := im.rollappKeeper.GetValidTransferFromReceivedPacket(ctx, packet)
 	if err != nil {
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
@@ -117,7 +117,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 		return im.IBCModule.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 	}
 
-	transferData, err := im.rollappKeeper.GetValidTransfer(ctx, packet.Data, packet.GetSourcePort(), packet.GetSourceChannel())
+	transferData, err := im.rollappKeeper.GetValidTransferFromSentPacket(ctx, packet)
 	if err != nil {
 		return errorsmod.Wrapf(errortypes.ErrInvalidRequest, "get valid transfer data: %s", err.Error())
 	}
@@ -195,7 +195,7 @@ func (m *ICS4Wrapper) SendPacket(
 		return 0, types.ErrMemoDenomMetadataAlreadyExists
 	}
 
-	transferData, err := m.rollappKeeper.GetValidTransfer(ctx, data, sourcePort, sourceChannel)
+	transferData, err := m.rollappKeeper.GetValidTransferFromSendPacket(ctx, data, sourcePort, sourceChannel)
 	if err != nil {
 		return 0, errorsmod.Wrapf(errortypes.ErrInvalidRequest, "get valid transfer data: %s", err.Error())
 	}

--- a/x/denommetadata/ibc_middleware_test.go
+++ b/x/denommetadata/ibc_middleware_test.go
@@ -636,7 +636,19 @@ func (m *mockRollappKeeper) SetRollapp(_ sdk.Context, rollapp rollapptypes.Rolla
 	m.returnRollapp = &rollapp
 }
 
-func (m *mockRollappKeeper) GetValidTransfer(sdk.Context, []byte, string, string) (data rollapptypes.TransferData, err error) {
+func (m *mockRollappKeeper) GetValidTransferFromReceivedPacket(sdk.Context, channeltypes.Packet) (data rollapptypes.TransferData, err error) {
+	return m.transferData()
+}
+
+func (m *mockRollappKeeper) GetValidTransferFromSentPacket(sdk.Context, channeltypes.Packet) (data rollapptypes.TransferData, err error) {
+	return m.transferData()
+}
+
+func (m *mockRollappKeeper) GetValidTransferFromSendPacket(sdk.Context, []byte, string, string) (data rollapptypes.TransferData, err error) {
+	return m.transferData()
+}
+
+func (m *mockRollappKeeper) transferData() (data rollapptypes.TransferData, err error) {
 	return rollapptypes.TransferData{
 		Rollapp:                 m.returnRollapp,
 		FungibleTokenPacketData: m.packetData,

--- a/x/denommetadata/types/expected_keepers.go
+++ b/x/denommetadata/types/expected_keepers.go
@@ -3,6 +3,7 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
 )
 
@@ -18,9 +19,17 @@ type DenomMetadataKeeper interface {
 
 type RollappKeeper interface {
 	SetRollapp(ctx sdk.Context, rollapp rollapptypes.Rollapp)
-	GetValidTransfer(
+	GetValidTransferFromReceivedPacket(
+		ctx sdk.Context,
+		packet channeltypes.Packet,
+	) (data rollapptypes.TransferData, err error)
+	GetValidTransferFromSentPacket(
+		ctx sdk.Context,
+		packet channeltypes.Packet,
+	) (data rollapptypes.TransferData, err error)
+	GetValidTransferFromSendPacket(
 		ctx sdk.Context,
 		packetData []byte,
-		raPortOnHub, raChanOnHub string,
+		sourcePort, sourceChannel string,
 	) (data rollapptypes.TransferData, err error)
 }

--- a/x/rollapp/keeper/authenticate_packet.go
+++ b/x/rollapp/keeper/authenticate_packet.go
@@ -4,16 +4,45 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	"github.com/openmetaearth/me-hub/utils/gerrc"
 	uibc "github.com/openmetaearth/me-hub/utils/uibc"
 	"github.com/openmetaearth/me-hub/x/rollapp/types"
 )
 
-// GetValidTransfer takes a packet, ensures it is a (basic) validated fungible token packet, and gets the chain id.
+// GetValidTransferFromReceivedPacket authenticates a received IBC transfer against
+// the packet destination endpoint on the hub.
+func (k Keeper) GetValidTransferFromReceivedPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+) (types.TransferData, error) {
+	return k.getValidTransfer(ctx, packet.GetData(), packet.GetDestPort(), packet.GetDestChannel())
+}
+
+// GetValidTransferFromSentPacket authenticates an acknowledgement or timeout
+// against the packet source endpoint on the hub.
+func (k Keeper) GetValidTransferFromSentPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+) (types.TransferData, error) {
+	return k.getValidTransfer(ctx, packet.GetData(), packet.GetSourcePort(), packet.GetSourceChannel())
+}
+
+// GetValidTransferFromSendPacket authenticates an outgoing SendPacket transfer
+// against the source endpoint supplied by the ICS4 wrapper.
+func (k Keeper) GetValidTransferFromSendPacket(
+	ctx sdk.Context,
+	packetData []byte,
+	sourcePort, sourceChannel string,
+) (types.TransferData, error) {
+	return k.getValidTransfer(ctx, packetData, sourcePort, sourceChannel)
+}
+
+// getValidTransfer takes a packet, ensures it is a (basic) validated fungible token packet, and gets the chain id.
 // If the channel chain id is also a rollapp id, we check that the canonical channel id we have saved for that rollapp
 // agrees is indeed the channel we are receiving from. In this way, we stop anyone from pretending to be the RA. (Assuming
 // that the mechanism for setting the canonical channel in the first place is correct).
-func (k Keeper) GetValidTransfer(
+func (k Keeper) getValidTransfer(
 	ctx sdk.Context,
 	packetData []byte,
 	raPortOnHub, raChanOnHub string,

--- a/x/rollapp/keeper/authenticate_packet_test.go
+++ b/x/rollapp/keeper/authenticate_packet_test.go
@@ -1,0 +1,130 @@
+package keeper
+
+import (
+	"fmt"
+	"testing"
+
+	cometbftdb "github.com/cometbft/cometbft-db"
+	"github.com/cometbft/cometbft/libs/log"
+	cometbftproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
+	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+)
+
+type authenticatePacketChannelKeeper struct {
+	chainIDsByEndpoint map[string]string
+}
+
+func (k authenticatePacketChannelKeeper) GetChannelClientState(
+	_ sdk.Context,
+	portID string,
+	channelID string,
+) (string, exported.ClientState, error) {
+	chainID, ok := k.chainIDsByEndpoint[fmt.Sprintf("%s/%s", portID, channelID)]
+	if !ok {
+		return "", nil, fmt.Errorf("missing endpoint mapping for %s/%s", portID, channelID)
+	}
+
+	return "client-0", &ibctmtypes.ClientState{ChainId: chainID}, nil
+}
+
+func setupAuthenticatePacketKeeper(t *testing.T) (Keeper, sdk.Context) {
+	t.Helper()
+
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	db := cometbftdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	ctx := sdk.NewContext(stateStore, cometbftproto.Header{}, false, log.NewNopLogger())
+	k := Keeper{
+		cdc:      types.ModuleCdc,
+		storeKey: storeKey,
+		channelKeeper: authenticatePacketChannelKeeper{
+			chainIDsByEndpoint: map[string]string{
+				"transfer/channel-victim":   "victim_100-1",
+				"transfer/channel-attacker": "attacker_100-1",
+			},
+		},
+	}
+
+	return k, ctx
+}
+
+func validAuthenticatePacketData() []byte {
+	packetData := transfertypes.FungibleTokenPacketData{
+		Denom:    "uatom",
+		Amount:   "1",
+		Sender:   "sender",
+		Receiver: "receiver",
+	}
+	return transfertypes.ModuleCdc.MustMarshalJSON(&packetData)
+}
+
+func TestGetValidTransferFromReceivedPacketUsesDestinationEndpoint(t *testing.T) {
+	k, ctx := setupAuthenticatePacketKeeper(t)
+	k.SetRollapp(ctx, types.Rollapp{
+		RollappId: "victim_100-1",
+		ChannelId: "channel-victim",
+	})
+
+	transfer, err := k.GetValidTransferFromReceivedPacket(ctx, channeltypes.Packet{
+		Data:               validAuthenticatePacketData(),
+		SourcePort:         "transfer",
+		SourceChannel:      "channel-attacker",
+		DestinationPort:    "transfer",
+		DestinationChannel: "channel-victim",
+	})
+
+	require.NoError(t, err)
+	require.True(t, transfer.IsRollapp())
+	require.Equal(t, "victim_100-1", transfer.RollappId())
+}
+
+func TestGetValidTransferFromReceivedPacketIgnoresSpoofedSourceEndpoint(t *testing.T) {
+	k, ctx := setupAuthenticatePacketKeeper(t)
+	k.SetRollapp(ctx, types.Rollapp{
+		RollappId: "victim_100-1",
+		ChannelId: "channel-victim",
+	})
+
+	transfer, err := k.GetValidTransferFromReceivedPacket(ctx, channeltypes.Packet{
+		Data:               validAuthenticatePacketData(),
+		SourcePort:         "transfer",
+		SourceChannel:      "channel-victim",
+		DestinationPort:    "transfer",
+		DestinationChannel: "channel-attacker",
+	})
+
+	require.NoError(t, err)
+	require.False(t, transfer.IsRollapp())
+}
+
+func TestGetValidTransferFromSentPacketUsesSourceEndpoint(t *testing.T) {
+	k, ctx := setupAuthenticatePacketKeeper(t)
+	k.SetRollapp(ctx, types.Rollapp{
+		RollappId: "victim_100-1",
+		ChannelId: "channel-victim",
+	})
+
+	transfer, err := k.GetValidTransferFromSentPacket(ctx, channeltypes.Packet{
+		Data:               validAuthenticatePacketData(),
+		SourcePort:         "transfer",
+		SourceChannel:      "channel-victim",
+		DestinationPort:    "transfer",
+		DestinationChannel: "channel-attacker",
+	})
+
+	require.NoError(t, err)
+	require.True(t, transfer.IsRollapp())
+	require.Equal(t, "victim_100-1", transfer.RollappId())
+}

--- a/x/rollapp/transfergenesis/ibc_module.go
+++ b/x/rollapp/transfergenesis/ibc_module.go
@@ -101,7 +101,7 @@ func (w IBCModule) OnRecvPacket(
 		return w.IBCModule.OnRecvPacket(ctx, packet, relayer)
 	}
 
-	transfer, err := w.rollappKeeper.GetValidTransfer(ctx, packet.GetData(), packet.GetDestPort(), packet.GetDestChannel())
+	transfer, err := w.rollappKeeper.GetValidTransferFromReceivedPacket(ctx, packet)
 	if err != nil {
 		l.Error("Get valid transfer from received packet", "err", err)
 		return channeltypes.NewErrorAcknowledgement(errorsmod.Wrap(err, "transfer genesis: get valid transfer"))


### PR DESCRIPTION
## Summary
- replace the generic rollapp transfer authentication API with direction-specific packet helpers for received packets and sent packet acknowledgements/timeouts
- update bridging fee, transfer genesis, delayed ack, and denom metadata middleware to derive the hub endpoint from the verified packet direction
- add keeper regressions covering received-packet destination authentication, spoofed-source rejection, and sent-packet source authentication

Fixes #1161

## Testing
- `go test ./x/rollapp/keeper -run 'TestGetValidTransferFrom' -count=1`
- `go test ./x/rollapp/... ./x/delayedack/... ./x/denommetadata/... -count=1`
- `go test ./... -count=1`
- `git diff --check`

Meta Earth bug bounty payout: `$MEC` via ME Pass address `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.
