### PR TITLE
fix(did): bound credential data size

### DIFF
--- a/x/did/types/credential.go
+++ b/x/did/types/credential.go
@@ -1,5 +1,7 @@
 package types
 
+const maxCredentialDataLength = 64 * 1024
+
 func NewCredential(did, sid, hash, uri string, data []byte) Credential {
 
 	return Credential{Did: did, Sid: sid, Hash: hash, Uri: uri, Data: data}

--- a/x/did/types/message_create_vc.go
+++ b/x/did/types/message_create_vc.go
@@ -68,6 +68,9 @@ func (m *MsgCreateVC) ValidateBasic() error {
 	if len(m.Uri) > 1024 {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "uri length exceeds 1024")
 	}
+	if len(m.Data) > maxCredentialDataLength {
+		return errors.Wrapf(sdkerrors.ErrInvalidType, "data length exceeds %d", maxCredentialDataLength)
+	}
 
 	for _, filter := range m.Filters {
 		if len(filter) > 1024 {

--- a/x/did/types/message_update_vc.go
+++ b/x/did/types/message_update_vc.go
@@ -65,6 +65,9 @@ func (m *MsgUpdateVC) ValidateBasic() error {
 	if len(m.Uri) > 1024 {
 		return errors.Wrap(sdkerrors.ErrInvalidType, "uri length exceeds 1024")
 	}
+	if len(m.Data) > maxCredentialDataLength {
+		return errors.Wrapf(sdkerrors.ErrInvalidType, "data length exceeds %d", maxCredentialDataLength)
+	}
 
 	for _, filter := range m.Filters {
 		if len(filter) > 1024 {

--- a/x/did/types/message_vc_test.go
+++ b/x/did/types/message_vc_test.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"os"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testIssuer = "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4"
+	testDid    = "did:me:holder"
+	testSid    = "kyc"
+)
+
+func TestMain(m *testing.M) {
+	sdk.GetConfig().SetBech32PrefixForAccount("me", "mepub")
+	os.Exit(m.Run())
+}
+
+func TestMsgCreateVCValidateBasicDataSize(t *testing.T) {
+	require.NoError(t, newValidCreateVC(make([]byte, maxCredentialDataLength)).ValidateBasic())
+
+	err := newValidCreateVC(make([]byte, maxCredentialDataLength+1)).ValidateBasic()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "data length exceeds")
+}
+
+func TestMsgUpdateVCValidateBasicDataSize(t *testing.T) {
+	require.NoError(t, newValidUpdateVC(make([]byte, maxCredentialDataLength)).ValidateBasic())
+
+	err := newValidUpdateVC(make([]byte, maxCredentialDataLength+1)).ValidateBasic()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "data length exceeds")
+}
+
+func newValidCreateVC(data []byte) *MsgCreateVC {
+	return NewMsgCreateVC(testIssuer, testDid, testSid, "hash", "https://example.com/vc", data, nil)
+}
+
+func newValidUpdateVC(data []byte) *MsgUpdateVC {
+	return NewMsgUpdateVC(testIssuer, testDid, testSid, "hash", "https://example.com/vc", data, nil)
+}


### PR DESCRIPTION
## Summary
- Add a 64 KiB maximum for DID credential data payloads.
- Apply the bound to both `MsgCreateVC` and `MsgUpdateVC` validation.
- Add boundary tests for accepted max-size payloads and rejected oversized payloads.

Fixes #1103

## Testing
- `go test ./x/did/types -run "TestMsg(Create|Update)VCValidateBasicDataSize" -count=1 -v`
- `go test ./x/did/... -count=1`
- `go test ./... -count=1`
- `git diff --check`

Meta Earth bug bounty payout: `$MEC` via ME Pass address `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.