### PR TITLE
fix(gravity): bind chain name in claim attestations

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -13,6 +13,10 @@ import (
 )
 
 func (k Keeper) Attest(ctx sdk.Context, relayerAddr sdk.AccAddress, claim types.ExternalClaim) (*types.Attestation, error) {
+	if err := k.validateClaimRoute(claim); err != nil {
+		return nil, err
+	}
+
 	anyClaim, err := codectypes.NewAnyWithValue(claim)
 	if err != nil {
 		return nil, errorsmod.Wrap(types.ErrUnknown, "msg to any")

--- a/x/gravity/keeper/bridge_token_collision_test.go
+++ b/x/gravity/keeper/bridge_token_collision_test.go
@@ -73,6 +73,7 @@ func (suite *KeeperTestSuite) TestBridgeTokenSymbolNonNativeAllowed() {
 	for _, relayer := range relayers {
 		claim := &types.MsgBridgeTokenClaim{
 			EventNonce:     1,
+			BlockHeight:    1,
 			TokenContract:  tokenContract,
 			Symbol:         "USDT",
 			Name:           "Tether USD",

--- a/x/gravity/keeper/chain_name_claim_hash_test.go
+++ b/x/gravity/keeper/chain_name_claim_hash_test.go
@@ -1,0 +1,64 @@
+package keeper_test
+
+import (
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+)
+
+func (s *KeeperTestSuite) TestSendToMeClaimRejectsMixedChainNameVotes() {
+	s.setupBondedRelayerSetForAuditTest()
+
+	tokenContract := s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)
+	receiver := s.relayerAddrs[0]
+	s.Keeper().SetBridgeToken(s.Ctx, &types.BridgeToken{
+		ContractAddress: tokenContract,
+		Denom:           "uusdt",
+		Name:            "Tether USD",
+		Symbol:          "USDT",
+		Decimal:         18,
+		Supply:          sdkmath.ZeroInt(),
+	})
+
+	eventNonce := s.Keeper().GetLastObservedEventNonce(s.Ctx) + 1
+	blockHeight := uint64(100)
+	amount := sdkmath.NewIntWithDecimal(1, 18)
+	sender := s.PubKeyToExternalAddr(s.externalPris[1].PublicKey)
+
+	var honestClaim *types.MsgSendToMeClaim
+	for i := 0; i < 6; i++ {
+		honestClaim = &types.MsgSendToMeClaim{
+			EventNonce:     eventNonce,
+			BlockHeight:    blockHeight,
+			TokenContract:  tokenContract,
+			Amount:         amount,
+			Sender:         sender,
+			Receiver:       receiver.String(),
+			RelayerAddress: s.relayerAddrs[i].String(),
+			ChainName:      s.chainName,
+		}
+		_, err := s.MsgServer().SendToMeClaim(sdk.WrapSDKContext(s.Ctx), honestClaim)
+		s.Require().NoError(err)
+	}
+
+	att := s.Keeper().GetAttestation(s.Ctx, eventNonce, honestClaim.ClaimHash())
+	s.Require().NotNil(att)
+	s.Require().Len(att.Votes, 6)
+	s.Require().False(att.Observed)
+
+	wrongChainClaim := *honestClaim
+	wrongChainClaim.RelayerAddress = s.relayerAddrs[6].String()
+	wrongChainClaim.ChainName = types.ModuleName
+
+	_, err := s.MsgServer().SendToMeClaim(sdk.WrapSDKContext(s.Ctx), &wrongChainClaim)
+	s.Require().Error(err)
+
+	balance := s.App.BankKeeper.GetBalance(s.Ctx, receiver, "uusdt")
+	s.Require().True(balance.Amount.IsZero())
+	s.Require().EqualValues(eventNonce-1, s.Keeper().GetLastObservedEventNonce(s.Ctx))
+
+	att = s.Keeper().GetAttestation(s.Ctx, eventNonce, honestClaim.ClaimHash())
+	s.Require().NotNil(att)
+	s.Require().Len(att.Votes, 6)
+	s.Require().False(att.Observed)
+}

--- a/x/gravity/keeper/claim.go
+++ b/x/gravity/keeper/claim.go
@@ -12,6 +12,10 @@ import (
 // claimHandlerCommon is an internal function that provides common code for processing claims once they are
 // translated from the message to the Ethereum claim interface
 func (s MsgServer) claimHandlerCommon(ctx sdk.Context, msg types.ExternalClaim) (err error) {
+	if err := s.validateClaimRoute(msg); err != nil {
+		return err
+	}
+
 	bridgerAddr := msg.GetClaimer()
 	if err := s.checkIsRelayer(ctx, bridgerAddr); err != nil {
 		return err
@@ -20,6 +24,16 @@ func (s MsgServer) claimHandlerCommon(ctx sdk.Context, msg types.ExternalClaim) 
 	// Add the claim to the store
 	if _, err := s.Attest(ctx, bridgerAddr, msg); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (k Keeper) validateClaimRoute(msg types.ExternalClaim) error {
+	if err := msg.ValidateBasic(); err != nil {
+		return err
+	}
+	if msg.GetChainName() != k.moduleName {
+		return errorsmod.Wrapf(types.ErrInvalid, "claim chain name %s does not match module %s", msg.GetChainName(), k.moduleName)
 	}
 	return nil
 }

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -231,7 +231,11 @@ func (s MsgServer) RelayerSetConfirm(c context.Context, msg *types.MsgRelayerSet
 // RelayerSetUpdateClaim handles claims for executing a relayer set update on Ethereum
 func (s MsgServer) RelayerSetUpdateClaim(c context.Context, msg *types.MsgRelayerSetUpdateClaim) (*types.MsgRelayerSetUpdateClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
-	relayerAddress := sdk.MustAccAddressFromBech32(msg.RelayerAddress)
+	if err := s.validateClaimRoute(msg); err != nil {
+		return nil, err
+	}
+
+	relayerAddress := msg.GetClaimer()
 	err := s.checkIsRelayer(ctx, relayerAddress)
 	if err != nil {
 		return nil, err

--- a/x/gravity/types/msg_claim.go
+++ b/x/gravity/types/msg_claim.go
@@ -35,6 +35,7 @@ type ExternalClaim interface {
 	GetClaimer() sdk.AccAddress
 	// GetType Which type of claim this is
 	GetType() ClaimType
+	GetChainName() string
 	ValidateBasic() error
 	ClaimHash() []byte
 }
@@ -109,7 +110,7 @@ func (m *MsgSendToMeClaim) Route() string { return RouterKey }
 
 // ClaimHash Hash implements BridgeSendToExternal.Hash
 func (m *MsgSendToMeClaim) ClaimHash() []byte {
-	path := fmt.Sprintf("%d/%d/%s/%s/%s/%s", m.BlockHeight, m.EventNonce, m.TokenContract, m.Sender, m.Amount.String(), m.Receiver)
+	path := fmt.Sprintf("%s/%d/%d/%s/%s/%s/%s", m.ChainName, m.BlockHeight, m.EventNonce, m.TokenContract, m.Sender, m.Amount.String(), m.Receiver)
 	return tmhash.Sum([]byte(path))
 }
 
@@ -145,7 +146,7 @@ func (m *MsgSendToExternalClaim) ValidateBasic() (err error) {
 
 // ClaimHash Hash implements SendToFxBatch.Hash
 func (m *MsgSendToExternalClaim) ClaimHash() []byte {
-	path := fmt.Sprintf("%d/%d/%s/%d", m.BlockHeight, m.EventNonce, m.TokenContract, m.BatchNonce)
+	path := fmt.Sprintf("%s/%d/%d/%s/%d", m.ChainName, m.BlockHeight, m.EventNonce, m.TokenContract, m.BatchNonce)
 	return tmhash.Sum([]byte(path))
 }
 
@@ -217,7 +218,7 @@ func (m *MsgBridgeTokenClaim) GetType() ClaimType {
 }
 
 func (m *MsgBridgeTokenClaim) ClaimHash() []byte {
-	path := fmt.Sprintf("%d/%d/%s/%s/%s/%d", m.BlockHeight, m.EventNonce, m.TokenContract, m.Name, m.Symbol, m.Decimals)
+	path := fmt.Sprintf("%s/%d/%d/%s/%s/%s/%d", m.ChainName, m.BlockHeight, m.EventNonce, m.TokenContract, m.Name, m.Symbol, m.Decimals)
 	return tmhash.Sum([]byte(path))
 }
 
@@ -282,6 +283,6 @@ func (m *MsgRelayerSetUpdateClaim) ClaimHash() []byte {
 	for _, member := range m.Members {
 		membersStr += member.String()
 	}
-	path := fmt.Sprintf("%d/%d/%d/%s", m.BlockHeight, m.RelayerSetNonce, m.EventNonce, membersStr)
+	path := fmt.Sprintf("%s/%d/%d/%d/%s", m.ChainName, m.BlockHeight, m.RelayerSetNonce, m.EventNonce, membersStr)
 	return tmhash.Sum([]byte(path))
 }

--- a/x/gravity/types/msg_claim_hash_test.go
+++ b/x/gravity/types/msg_claim_hash_test.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"encoding/hex"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimHashBindsChainName(t *testing.T) {
+	t.Run("send to me", func(t *testing.T) {
+		claim := &MsgSendToMeClaim{
+			EventNonce:    2,
+			BlockHeight:   100,
+			TokenContract: "0x0000000000000000000000000000000000000001",
+			Sender:        "0x0000000000000000000000000000000000000002",
+			Amount:        sdkmath.NewInt(100),
+			Receiver:      "me1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a",
+			ChainName:     "bsc",
+		}
+		other := *claim
+		other.ChainName = "gravity"
+
+		require.NotEqual(t, hex.EncodeToString(claim.ClaimHash()), hex.EncodeToString(other.ClaimHash()))
+	})
+
+	t.Run("send to external", func(t *testing.T) {
+		claim := &MsgSendToExternalClaim{
+			EventNonce:    3,
+			BlockHeight:   101,
+			BatchNonce:    5,
+			TokenContract: "0x0000000000000000000000000000000000000001",
+			ChainName:     "bsc",
+		}
+		other := *claim
+		other.ChainName = "gravity"
+
+		require.NotEqual(t, hex.EncodeToString(claim.ClaimHash()), hex.EncodeToString(other.ClaimHash()))
+	})
+
+	t.Run("bridge token", func(t *testing.T) {
+		claim := &MsgBridgeTokenClaim{
+			EventNonce:    4,
+			BlockHeight:   102,
+			TokenContract: "0x0000000000000000000000000000000000000001",
+			Name:          "Tether USD",
+			Symbol:        "USDT",
+			Decimals:      18,
+			ChainName:     "bsc",
+		}
+		other := *claim
+		other.ChainName = "gravity"
+
+		require.NotEqual(t, hex.EncodeToString(claim.ClaimHash()), hex.EncodeToString(other.ClaimHash()))
+	})
+
+	t.Run("relayer set update", func(t *testing.T) {
+		claim := &MsgRelayerSetUpdateClaim{
+			EventNonce:      5,
+			BlockHeight:     103,
+			RelayerSetNonce: 7,
+			Members: []BridgeValidator{
+				{Power: 100, ExternalAddress: "0x0000000000000000000000000000000000000001"},
+			},
+			ChainName: "bsc",
+		}
+		other := *claim
+		other.ChainName = "gravity"
+
+		require.NotEqual(t, hex.EncodeToString(claim.ClaimHash()), hex.EncodeToString(other.ClaimHash()))
+	})
+}


### PR DESCRIPTION
Fixes #865

## Summary

- include `ChainName` in the claim hash for all Gravity attestation claim types
- validate claim messages and reject claims whose `ChainName` does not match the keeper module before votes are stored
- add regression coverage proving mixed-chain `MsgSendToMeClaim` votes cannot combine into one observed attestation
- add hash coverage for send-to-me, send-to-external, bridge-token, and relayer-set update claims

## Why

Gravity attestations are keyed by event nonce plus claim hash. If a field that affects execution is omitted from the hash, relayers can end up voting on different execution payloads under the same attestation key. For BSC USDT/USDC, `ChainName` controls the decimal conversion path, so it must be part of the attested identity.

The handler now also validates claims at the keeper boundary and rejects claims routed to the wrong module before they can append votes or create attestation state.

## Validation

- `go test ./x/gravity/types -run TestClaimHashBindsChainName -count=1 -v`
- `go test ./x/gravity/keeper -run TestGravityKeeperTestSuite/TestSendToMeClaimRejectsMixedChainNameVotes -count=1 -v`
- `go test ./x/gravity/keeper -run "TestGravityKeeperTestSuite/(TestSendToMeClaimRejectsMixedChainNameVotes|TestClaimMsgGasConsumed|TestMsgBridgeTokenClaim|TestRequestBatchBaseFee)$" -count=1 -v`
- `go test ./x/gravity/keeper -count=1`
- `go test ./x/gravity/... -count=1`
- `git diff --check`

## Bounty payout

Meta Earth / OpenMetaEarth bug bounty payout: `$MEC` via ME Pass.

Wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`
