### PR TITLE
fix: validate DID genesis state

### DIFF
--- a/x/did/types/genesis.go
+++ b/x/did/types/genesis.go
@@ -1,5 +1,13 @@
 package types
 
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const MaxCredentialDataSize = 64 * 1024
+
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
@@ -12,5 +20,120 @@ func DefaultGenesis() *GenesisState {
 
 // Validate performs basic genesis state validation returning an error upon any failure.
 func (gs *GenesisState) Validate() error {
+	dids := make(map[string]struct{}, len(gs.Infos))
+	addresses := make(map[string]struct{}, len(gs.Infos))
+	for i, info := range gs.Infos {
+		if len(info.Did) != DidLength {
+			return fmt.Errorf("infos[%d]: DID length must be equal to %d", i, DidLength)
+		}
+		if _, ok := dids[info.Did]; ok {
+			return fmt.Errorf("infos[%d]: duplicated DID %q", i, info.Did)
+		}
+		dids[info.Did] = struct{}{}
+
+		if _, err := sdk.AccAddressFromBech32(info.Address); err != nil {
+			return fmt.Errorf("infos[%d]: invalid address %q: %w", i, info.Address, err)
+		}
+		if _, ok := addresses[info.Address]; ok {
+			return fmt.Errorf("infos[%d]: duplicated address %q", i, info.Address)
+		}
+		addresses[info.Address] = struct{}{}
+
+		if info.Pubkey == "" {
+			return fmt.Errorf("infos[%d]: pubkey must not be empty", i)
+		}
+		if _, ok := DidStatus_name[int32(info.Status)]; !ok {
+			return fmt.Errorf("infos[%d]: DID status must be ACTIVE or INACTIVE", i)
+		}
+	}
+
+	services := make(map[string]struct{}, len(gs.Svcs))
+	for i, svc := range gs.Svcs {
+		if len(svc.Sid) < 2 || len(svc.Sid) > 8 {
+			return fmt.Errorf("svcs[%d]: sid length must be between 2 and 8", i)
+		}
+		if _, ok := services[svc.Sid]; ok {
+			return fmt.Errorf("svcs[%d]: duplicated service id %q", i, svc.Sid)
+		}
+		services[svc.Sid] = struct{}{}
+
+		if len(svc.Name) == 0 || len(svc.Name) > 20 {
+			return fmt.Errorf("svcs[%d]: name length must be between 1 and 20", i)
+		}
+		if len(svc.Description) > 1024 {
+			return fmt.Errorf("svcs[%d]: description length exceeds 1024", i)
+		}
+		if _, ok := ServiceStatus_name[int32(svc.Status)]; !ok {
+			return fmt.Errorf("svcs[%d]: service status must be ACTIVE or INACTIVE", i)
+		}
+		for issuerIndex, issuer := range svc.Issuers {
+			if len(issuer) != DidLength {
+				return fmt.Errorf("svcs[%d].issuers[%d]: issuer DID length must be equal to %d", i, issuerIndex, DidLength)
+			}
+			if _, ok := dids[issuer]; !ok {
+				return fmt.Errorf("svcs[%d].issuers[%d]: issuer DID %q not found", i, issuerIndex, issuer)
+			}
+		}
+	}
+
+	credentials := make(map[string]struct{}, len(gs.Vcs))
+	for i, vc := range gs.Vcs {
+		key, err := validateGenesisCredential(i, vc, dids, services)
+		if err != nil {
+			return err
+		}
+		if _, ok := credentials[key]; ok {
+			return fmt.Errorf("vcs[%d]: duplicated credential %q", i, key)
+		}
+		credentials[key] = struct{}{}
+	}
+
+	filterLogs := make(map[string]struct{}, len(gs.Flogs))
+	for i, flog := range gs.Flogs {
+		key := credentialKey(flog.Did, flog.Sid)
+		if _, ok := credentials[key]; !ok {
+			return fmt.Errorf("flogs[%d]: credential %q not found", i, key)
+		}
+		if _, ok := filterLogs[key]; ok {
+			return fmt.Errorf("flogs[%d]: duplicated filter logger %q", i, key)
+		}
+		filterLogs[key] = struct{}{}
+		for filterIndex, filter := range flog.Filters {
+			if len(filter) > 1024 {
+				return fmt.Errorf("flogs[%d].filters[%d]: filter length exceeds 1024", i, filterIndex)
+			}
+		}
+	}
+
 	return nil
+}
+
+func validateGenesisCredential(index int, vc Credential, dids, services map[string]struct{}) (string, error) {
+	if len(vc.Did) != DidLength {
+		return "", fmt.Errorf("vcs[%d]: DID length must be equal to %d", index, DidLength)
+	}
+	if _, ok := dids[vc.Did]; !ok {
+		return "", fmt.Errorf("vcs[%d]: DID %q not found", index, vc.Did)
+	}
+	if len(vc.Sid) < 2 || len(vc.Sid) > 8 {
+		return "", fmt.Errorf("vcs[%d]: sid length must be between 2 and 8", index)
+	}
+	if _, ok := services[vc.Sid]; !ok {
+		return "", fmt.Errorf("vcs[%d]: service %q not found", index, vc.Sid)
+	}
+	if len(vc.Hash) == 0 || len(vc.Hash) > 128 {
+		return "", fmt.Errorf("vcs[%d]: hash length must be between 1 and 128", index)
+	}
+	if len(vc.Uri) > 1024 {
+		return "", fmt.Errorf("vcs[%d]: uri length exceeds 1024", index)
+	}
+	if len(vc.Data) > MaxCredentialDataSize {
+		return "", fmt.Errorf("vcs[%d]: data length exceeds %d", index, MaxCredentialDataSize)
+	}
+
+	return credentialKey(vc.Did, vc.Sid), nil
+}
+
+func credentialKey(did, sid string) string {
+	return did + "/" + sid
 }

--- a/x/did/types/genesis_test.go
+++ b/x/did/types/genesis_test.go
@@ -1,24 +1,131 @@
 package types_test
 
 import (
+	"bytes"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/evmos/ethermint/crypto/ethsecp256k1"
+	_ "github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGenesisState_Validate(t *testing.T) {
-	test := types.GenesisState{
+	test := validGenesis()
+
+	err := test.Validate()
+	require.NoError(t, err)
+}
+
+func TestGenesisState_ValidateRejectsCorruptState(t *testing.T) {
+	tooLargeCredentialData := bytes.Repeat([]byte("x"), types.MaxCredentialDataSize+1)
+
+	testCases := []struct {
+		name   string
+		mutate func(*types.GenesisState)
+	}{
+		{
+			name: "duplicate DID",
+			mutate: func(genesis *types.GenesisState) {
+				duplicate := genesis.Infos[0]
+				duplicate.Address = testAddress(2)
+				genesis.Infos = append(genesis.Infos, duplicate)
+			},
+		},
+		{
+			name: "duplicate address",
+			mutate: func(genesis *types.GenesisState) {
+				duplicate := genesis.Infos[0]
+				duplicate.Did = "1000000000002"
+				genesis.Infos = append(genesis.Infos, duplicate)
+			},
+		},
+		{
+			name: "invalid DID status",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Infos[0].Status = types.DidStatus(99)
+			},
+		},
+		{
+			name: "service references unknown issuer DID",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Svcs[0].Issuers = []string{"9999999999999"}
+			},
+		},
+		{
+			name: "duplicate service",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Svcs = append(genesis.Svcs, genesis.Svcs[0])
+			},
+		},
+		{
+			name: "credential references unknown DID",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Vcs[0].Did = "9999999999999"
+			},
+		},
+		{
+			name: "credential references unknown service",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Vcs[0].Sid = "other"
+			},
+		},
+		{
+			name: "duplicate credential",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Vcs = append(genesis.Vcs, genesis.Vcs[0])
+			},
+		},
+		{
+			name: "oversized credential data",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Vcs[0].Data = tooLargeCredentialData
+			},
+		},
+		{
+			name: "filter logger references missing credential",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Flogs[0].Sid = "other"
+			},
+		},
+		{
+			name: "duplicate filter logger",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Flogs = append(genesis.Flogs, genesis.Flogs[0])
+			},
+		},
+		{
+			name: "oversized filter",
+			mutate: func(genesis *types.GenesisState) {
+				genesis.Flogs[0].Filters[0] = bytes.Repeat([]byte("x"), 1025)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			genesis := validGenesis()
+			tc.mutate(&genesis)
+
+			err := genesis.Validate()
+			require.Error(t, err)
+		})
+	}
+}
+
+func validGenesis() types.GenesisState {
+	return types.GenesisState{
 		Infos: []types.DidInfo{
-			types.DidInfo{
-				Did:    "1000000000001",
-				Pubkey: "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}",
-				Status: types.DID_STATUS_ACTIVE,
+			{
+				Did:     "1000000000001",
+				Address: testAddress(1),
+				Pubkey:  "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}",
+				Status:  types.DID_STATUS_ACTIVE,
 			},
 		},
 		Svcs: []types.Service{
-			types.Service{
+			{
 				Sid:         "kyc",
 				Name:        "kyc",
 				Description: "this is kyc test service.",
@@ -27,7 +134,7 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 		},
 		Vcs: []types.Credential{
-			types.Credential{
+			{
 				Did:  "1000000000001",
 				Sid:  "kyc",
 				Hash: "0000000000000000001",
@@ -36,8 +143,8 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 		},
 		Flogs: []types.FilterLogger{
-			types.FilterLogger{
-				Did: "000000000001",
+			{
+				Did: "1000000000001",
 				Sid: "kyc",
 				Filters: [][]byte{
 					[]byte("A0"),
@@ -45,7 +152,8 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 		},
 	}
+}
 
-	err := test.Validate()
-	require.NoError(t, err)
+func testAddress(seed byte) string {
+	return sdk.AccAddress(bytes.Repeat([]byte{seed}, 20)).String()
 }


### PR DESCRIPTION
Fixes #1095

## Summary
- add DID genesis validation for duplicate DID and address mappings, invalid addresses, missing pubkeys, and invalid DID status values
- validate services, issuer references, credentials, and filter-log references before InitGenesis can write conflicting state or panic on missing credentials
- add regression coverage for duplicate keys, missing references, oversized credential data, and oversized filters

## Validation
- go test ./x/did/types -run TestGenesisState_Validate -count=1 -v
- go test ./x/did/... -count=1
- go test ./... -count=1
- git diff --check

## Payout
Meta Earth bug-bounty payout in $MEC via ME Pass address: me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j
