### PR TITLE
fix(sequencer): allow permissioned sequencers past public cap

### DIFF
--- a/x/sequencer/keeper/invariants.go
+++ b/x/sequencer/keeper/invariants.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"slices"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
 )
@@ -75,7 +77,13 @@ func SequencersPerRollappInvariant(k Keeper) sdk.Invariant {
 			bonded := k.GetSequencersByRollappByStatus(ctx, rollapp.RollappId, types.Bonded)
 			unbonding := k.GetSequencersByRollappByStatus(ctx, rollapp.RollappId, types.Unbonding)
 
-			if rollapp.MaxSequencers > 0 && len(bonded)+len(unbonding) > int(rollapp.MaxSequencers) {
+			limitedSequencers := len(bonded) + len(unbonding)
+			if len(rollapp.PermissionedAddresses) > 0 {
+				limitedSequencers = countNonPermissionedSequencers(bonded, rollapp.PermissionedAddresses) +
+					countNonPermissionedSequencers(unbonding, rollapp.PermissionedAddresses)
+			}
+
+			if rollapp.MaxSequencers > 0 && limitedSequencers > int(rollapp.MaxSequencers) {
 				broken = true
 				msg += "too many sequencers for rollapp " + rollapp.RollappId + "\n"
 			}
@@ -106,4 +114,14 @@ func SequencersPerRollappInvariant(k Keeper) sdk.Invariant {
 			msg,
 		), broken
 	}
+}
+
+func countNonPermissionedSequencers(sequencers []types.Sequencer, permissionedAddresses []string) int {
+	count := 0
+	for _, sequencer := range sequencers {
+		if !slices.Contains(permissionedAddresses, sequencer.SequencerAddress) {
+			count++
+		}
+	}
+	return count
 }

--- a/x/sequencer/keeper/msg_server_create_sequencer.go
+++ b/x/sequencer/keeper/msg_server_create_sequencer.go
@@ -36,7 +36,8 @@ func (k msgServer) CreateSequencer(goCtx context.Context, msg *types.MsgCreateSe
 	// check if there are permissionedAddresses.
 	// if the list is not empty, it means that only permissioned sequencers can be added
 	permissionedAddresses := rollapp.PermissionedAddresses
-	if 0 < len(permissionedAddresses) && !slices.Contains(permissionedAddresses, msg.Creator) {
+	isPermissioned := slices.Contains(permissionedAddresses, msg.Creator)
+	if 0 < len(permissionedAddresses) && !isPermissioned {
 		return nil, types.ErrSequencerNotPermissioned
 	}
 
@@ -87,7 +88,7 @@ func (k msgServer) CreateSequencer(goCtx context.Context, msg *types.MsgCreateSe
 	unbondingSequencers := k.GetSequencersByRollappByStatus(ctx, msg.RollappId, types.Unbonding)
 	// check to see if we reached the maximum number of sequencers for this rollapp
 	currentNumOfSequencers := len(bondedSequencers) + len(unbondingSequencers)
-	if rollapp.MaxSequencers > 0 && uint64(currentNumOfSequencers) >= rollapp.MaxSequencers {
+	if !isPermissioned && rollapp.MaxSequencers > 0 && uint64(currentNumOfSequencers) >= rollapp.MaxSequencers {
 		return nil, types.ErrMaxSequencersLimit
 	}
 	// this is the first sequencer, make it a PROPOSER

--- a/x/sequencer/keeper/msg_server_create_sequencer_test.go
+++ b/x/sequencer/keeper/msg_server_create_sequencer_test.go
@@ -7,6 +7,7 @@ import (
 	bankutil "github.com/cosmos/cosmos-sdk/x/bank/testutil"
 
 	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/openmetaearth/me-hub/x/sequencer/keeper"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
 
 	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
@@ -501,6 +502,67 @@ func (suite *SequencerTestSuite) TestMaxSequencersLimit() {
 		_, err = suite.msgServer.CreateSequencer(goCtx, &sequencerMsg)
 		suite.EqualError(err, types.ErrMaxSequencersLimit.Error())
 	}
+}
+
+func (suite *SequencerTestSuite) TestPermissionedSequencerCanJoinWhenPublicSlotsAreFull() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	rollapp := rollapptypes.Rollapp{
+		RollappId:             "rollapp1",
+		Creator:               alice,
+		Version:               0,
+		MaxSequencers:         1,
+		PermissionedAddresses: []string{},
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+	rollappId := rollapp.GetRollappId()
+
+	publicSequencer := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	suite.Require().NotEmpty(publicSequencer)
+
+	permissionedPubkey := secp256k1.GenPrivKey().PubKey()
+	permissionedAddr := sdk.AccAddress(permissionedPubkey.Address())
+	permissionedAddress := permissionedAddr.String()
+	err := bankutil.FundAccount(suite.App.BankKeeper, suite.Ctx, permissionedAddr, sdk.NewCoins(bond))
+	suite.Require().NoError(err)
+
+	rollapp.PermissionedAddresses = []string{permissionedAddress}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, rollapp)
+
+	pkAny, err := codectypes.NewAnyWithValue(permissionedPubkey)
+	suite.Require().NoError(err)
+	sequencerMsg := types.MsgCreateSequencer{
+		Creator:      permissionedAddress,
+		DymintPubKey: pkAny,
+		Bond:         bond,
+		RollappId:    rollappId,
+		Description:  types.Description{},
+	}
+
+	_, err = suite.msgServer.CreateSequencer(goCtx, &sequencerMsg)
+	suite.Require().NoError(err)
+
+	sequencers := suite.App.SequencerKeeper.GetSequencersByRollapp(suite.Ctx, rollappId)
+	suite.Require().Len(sequencers, 2)
+
+	unpermissionedPubkey := secp256k1.GenPrivKey().PubKey()
+	unpermissionedAddr := sdk.AccAddress(unpermissionedPubkey.Address())
+	unpermissionedPkAny, err := codectypes.NewAnyWithValue(unpermissionedPubkey)
+	suite.Require().NoError(err)
+	unpermissionedMsg := types.MsgCreateSequencer{
+		Creator:      unpermissionedAddr.String(),
+		DymintPubKey: unpermissionedPkAny,
+		Bond:         bond,
+		RollappId:    rollappId,
+		Description:  types.Description{},
+	}
+
+	_, err = suite.msgServer.CreateSequencer(goCtx, &unpermissionedMsg)
+	suite.Require().ErrorIs(err, types.ErrSequencerNotPermissioned)
+
+	msg, broken := keeper.AllInvariants(suite.App.SequencerKeeper)(suite.Ctx)
+	suite.Require().False(broken, msg)
 }
 
 func (suite *SequencerTestSuite) TestMaxSequencersNotSet() {


### PR DESCRIPTION
## Summary
- treat addresses in a rollapp's PermissionedAddresses list as an override for the MaxSequencers capacity check
- keep non-permissioned callers rejected before bond transfer when a permissioned list exists
- update the sequencer invariant so permissioned override registrations do not mark the rollapp broken while non-permissioned registrations remain capped
- add coverage for the case where public slots are already full before a permissioned sequencer joins

Fixes #1204

## Validation
- go test ./x/sequencer/keeper -run 'TestSequencerKeeperTestSuite/TestPermissionedSequencerCanJoinWhenPublicSlotsAreFull' -count=1 -v
- go test ./x/sequencer/keeper -count=1
- go test ./x/sequencer/... -count=1
- git diff --check

## Bounty payout
Meta Earth bug bounty payout in $MEC via ME Pass wallet: me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j