### PR TITLE
fix(wstaking): block region moves with delegations

### DIFF
--- a/x/wstaking/keeper/msg_server_validator_edit.go
+++ b/x/wstaking/keeper/msg_server_validator_edit.go
@@ -48,6 +48,10 @@ func (k MsgServer) UpdateValidator(goCtx context.Context, msg *types.MsgUpdateVa
 				return nil, types.ErrValidatorRegionDuplication
 			}
 		}
+		oldRegion, found := k.GetRegion(ctx, oldRegionId)
+		if found && oldRegion.DelegateAmount.GT(sdk.ZeroInt()) {
+			return nil, types.ErrRegion.Wrapf("cannot reassign validator from region %s with active delegations", oldRegionId)
+		}
 		k.UnBondRegion(ctx, oldRegionId)
 		description.RegionID = msg.Description.RegionID
 		validator.Description = description

--- a/x/wstaking/keeper/msg_server_validator_edit_test.go
+++ b/x/wstaking/keeper/msg_server_validator_edit_test.go
@@ -1,0 +1,126 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestUpdateValidatorRejectsRegionMoveWithDelegations() {
+	s.SetupTest()
+
+	oldRegionID := s.usaValidator.Description.RegionID
+	oldRegion, found := s.Keeper().GetRegion(s.Ctx, oldRegionID)
+	if !found {
+		oldRegion = wstakingtypes.Region{
+			RegionId:        oldRegionID,
+			Name:            "USA",
+			Creator:         s.Dao.GlobalDao,
+			OperatorAddress: s.usaValidator.OperatorAddress,
+			RegionShare:     s.usaValidator.Tokens,
+		}
+	}
+	oldRegion.OperatorAddress = s.usaValidator.OperatorAddress
+	oldRegion.RegionShare = s.usaValidator.Tokens
+	oldRegion.DelegateAmount = sdk.NewInt(100)
+	oldRegion.DelegateInterest = sdk.ZeroDec()
+	oldRegion.FixedDepositAmount = sdk.ZeroInt()
+	s.Keeper().SetRegion(s.Ctx, oldRegion)
+
+	const newRegionID = "can"
+	s.Keeper().SetRegion(s.Ctx, wstakingtypes.Region{
+		RegionId:            newRegionID,
+		Name:                "CAN",
+		Creator:             s.Dao.GlobalDao,
+		OperatorAddress:     "",
+		RegionShare:         sdk.ZeroInt(),
+		DelegateInterest:    sdk.ZeroDec(),
+		DelegateAmount:      sdk.ZeroInt(),
+		FixedDepositAmount:  sdk.ZeroInt(),
+		RegionTreasureAddr:  s.TestAccs[0].String(),
+		DepositInterestAddr: s.TestAccs[1].String(),
+	})
+
+	description := s.usaValidator.Description
+	description.RegionID = newRegionID
+	_, err := s.msgServer.UpdateValidator(s.Ctx, &wstakingtypes.MsgUpdateValidator{
+		Description:     description,
+		StakerAddress:   s.Dao.GlobalDao,
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "active delegations")
+
+	oldRegionAfter, found := s.Keeper().GetRegion(s.Ctx, oldRegionID)
+	s.Require().True(found)
+	s.Require().Equal(s.usaValidator.OperatorAddress, oldRegionAfter.OperatorAddress)
+	s.Require().Equal(sdk.NewInt(100).String(), oldRegionAfter.DelegateAmount.String())
+
+	newRegionAfter, found := s.Keeper().GetRegion(s.Ctx, newRegionID)
+	s.Require().True(found)
+	s.Require().Empty(newRegionAfter.OperatorAddress)
+
+	valAddr, err := sdk.ValAddressFromBech32(s.usaValidator.OperatorAddress)
+	s.Require().NoError(err)
+	validatorAfter, found := s.Keeper().GetValidator(s.Ctx, valAddr)
+	s.Require().True(found)
+	s.Require().Equal(oldRegionID, validatorAfter.Description.RegionID)
+}
+
+func (s *KeeperTestSuite) TestUpdateValidatorMovesRegionWithoutDelegations() {
+	s.SetupTest()
+
+	oldRegionID := s.usaValidator.Description.RegionID
+	oldRegion, found := s.Keeper().GetRegion(s.Ctx, oldRegionID)
+	if !found {
+		oldRegion = wstakingtypes.Region{
+			RegionId:        oldRegionID,
+			Name:            "USA",
+			Creator:         s.Dao.GlobalDao,
+			OperatorAddress: s.usaValidator.OperatorAddress,
+			RegionShare:     s.usaValidator.Tokens,
+		}
+	}
+	oldRegion.OperatorAddress = s.usaValidator.OperatorAddress
+	oldRegion.RegionShare = s.usaValidator.Tokens
+	oldRegion.DelegateAmount = sdk.ZeroInt()
+	oldRegion.DelegateInterest = sdk.ZeroDec()
+	oldRegion.FixedDepositAmount = sdk.ZeroInt()
+	s.Keeper().SetRegion(s.Ctx, oldRegion)
+
+	const newRegionID = "can"
+	s.Keeper().SetRegion(s.Ctx, wstakingtypes.Region{
+		RegionId:            newRegionID,
+		Name:                "CAN",
+		Creator:             s.Dao.GlobalDao,
+		OperatorAddress:     "",
+		RegionShare:         sdk.ZeroInt(),
+		DelegateInterest:    sdk.ZeroDec(),
+		DelegateAmount:      sdk.ZeroInt(),
+		FixedDepositAmount:  sdk.ZeroInt(),
+		RegionTreasureAddr:  s.TestAccs[0].String(),
+		DepositInterestAddr: s.TestAccs[1].String(),
+	})
+
+	description := s.usaValidator.Description
+	description.RegionID = newRegionID
+	_, err := s.msgServer.UpdateValidator(s.Ctx, &wstakingtypes.MsgUpdateValidator{
+		Description:     description,
+		StakerAddress:   s.Dao.GlobalDao,
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	})
+	s.Require().NoError(err)
+
+	oldRegionAfter, found := s.Keeper().GetRegion(s.Ctx, oldRegionID)
+	s.Require().True(found)
+	s.Require().Empty(oldRegionAfter.OperatorAddress)
+
+	newRegionAfter, found := s.Keeper().GetRegion(s.Ctx, newRegionID)
+	s.Require().True(found)
+	s.Require().Equal(s.usaValidator.OperatorAddress, newRegionAfter.OperatorAddress)
+
+	valAddr, err := sdk.ValAddressFromBech32(s.usaValidator.OperatorAddress)
+	s.Require().NoError(err)
+	validatorAfter, found := s.Keeper().GetValidator(s.Ctx, valAddr)
+	s.Require().True(found)
+	s.Require().Equal(newRegionID, validatorAfter.Description.RegionID)
+}


### PR DESCRIPTION
## Summary

Fixes #1230.

This blocks `UpdateValidator` region reassignment when the old region still has active delegated funds. The current flow calls `UnBondRegion(oldRegionId)`, which clears the old region operator before users in that region can safely undelegate, delegate again, or withdraw rewards. Rejecting the reassignment while `DelegateAmount` is non-zero keeps the old region state intact and avoids locking those delegations behind an empty operator address.

A reassignment with no delegated funds still follows the existing path and binds the validator to the new empty region.

## Tests

- `go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestUpdateValidator(RejectsRegionMoveWithDelegations|MovesRegionWithoutDelegations)$' -count=1 -v`
- `go test ./x/wstaking/keeper -count=1`
- `go test ./x/wstaking/... -count=1`
- `git diff --check`

## Bounty payout

Meta Earth bug bounty payout in `$MEC` via ME Pass: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`
