### PR TITLE
fix(gravity): defer batch cancellation until after iteration

### DIFF
--- a/x/gravity/keeper/abci.go
+++ b/x/gravity/keeper/abci.go
@@ -143,14 +143,26 @@ func (k Keeper) batchSlashing(ctx sdk.Context, relayers types.Relayers, signedWi
 //	AND any deposit or withdraw has occurred to update the Ethereum block height.
 func (k Keeper) cleanupTimedOutBatches(ctx sdk.Context) {
 	externalBlockHeight := k.GetLastObservedBlockHeight(ctx).ExternalBlockHeight
+	type batchRef struct {
+		tokenContract string
+		nonce         uint64
+	}
+	var batchesToCancel []batchRef
+
 	k.IterateOutgoingTxBatches(ctx, func(batch *types.OutgoingTxBatch) bool {
 		if batch.BatchTimeout < externalBlockHeight {
-			if err := k.CancelOutgoingTxBatch(ctx, batch.TokenContract, batch.BatchNonce); err != nil {
-				k.Logger(ctx).Error("failed to cancel timed out batch", "tokenContract", batch.TokenContract, "nonce", batch.BatchNonce, "error", err)
-			}
+			batchesToCancel = append(batchesToCancel, batchRef{
+				tokenContract: batch.TokenContract,
+				nonce:         batch.BatchNonce,
+			})
 		}
 		return false
 	})
+	for _, batchToCancel := range batchesToCancel {
+		if err := k.CancelOutgoingTxBatch(ctx, batchToCancel.tokenContract, batchToCancel.nonce); err != nil {
+			k.Logger(ctx).Error("failed to cancel timed out batch", "tokenContract", batchToCancel.tokenContract, "nonce", batchToCancel.nonce, "error", err)
+		}
+	}
 }
 
 func (k Keeper) pruneRelayerSet(ctx sdk.Context, signedRelayerSetsWindow uint64) {

--- a/x/gravity/keeper/batch.go
+++ b/x/gravity/keeper/batch.go
@@ -111,16 +111,29 @@ func (k Keeper) OutgoingTxBatchExecuted(ctx sdk.Context, contractAddress string,
 		panic(fmt.Sprintf("unknown batch nonce for outgoing tx batch %s %d", contractAddress, batchNonce))
 	}
 
-	// Iterate through remaining batches
+	type batchRef struct {
+		tokenContract string
+		nonce         uint64
+	}
+	var batchesToCancel []batchRef
+
+	// Iterate through remaining batches. Do not cancel from inside the
+	// iterator, because CancelOutgoingTxBatch deletes from the same prefix.
 	k.IterateOutgoingTxBatches(ctx, func(iterBatch *types.OutgoingTxBatch) bool {
 		// If the iterated batches nonce is lower than the one that was just executed, cancel it
 		if iterBatch.BatchNonce < batch.BatchNonce && iterBatch.TokenContract == contractAddress {
-			if err := k.CancelOutgoingTxBatch(ctx, contractAddress, iterBatch.BatchNonce); err != nil {
-				panic(fmt.Sprintf("Failed cancel out batch %s-%d while trying to execute failed: %s", batch.TokenContract, batch.BatchNonce, err))
-			}
+			batchesToCancel = append(batchesToCancel, batchRef{
+				tokenContract: iterBatch.TokenContract,
+				nonce:         iterBatch.BatchNonce,
+			})
 		}
 		return false
 	})
+	for _, batchToCancel := range batchesToCancel {
+		if err := k.CancelOutgoingTxBatch(ctx, batchToCancel.tokenContract, batchToCancel.nonce); err != nil {
+			panic(fmt.Sprintf("Failed cancel out batch %s-%d while trying to execute failed: %s", batch.TokenContract, batch.BatchNonce, err))
+		}
+	}
 
 	// Delete batch since it is finished
 	k.DeleteBatch(ctx, batch)

--- a/x/gravity/keeper/batch_test.go
+++ b/x/gravity/keeper/batch_test.go
@@ -118,6 +118,60 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteBatchConfirm() {
 	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, batch.TokenContract, batch.BatchNonce))
 }
 
+func (suite *KeeperTestSuite) TestOutgoingTxBatchExecutedCancelsEarlierBatchesAfterIteration() {
+	tokenContract := helpers.GenerateAddress().Hex()
+	otherTokenContract := helpers.GenerateAddress().Hex()
+
+	olderBatch := newTestOutgoingBatch(tokenContract, 1, 100, 101, 1001)
+	middleBatch := newTestOutgoingBatch(tokenContract, 2, 100, 102, 1002)
+	executedBatch := newTestOutgoingBatch(tokenContract, 3, 100, 103, 1003)
+	otherTokenBatch := newTestOutgoingBatch(otherTokenContract, 1, 100, 104, 2001)
+
+	suite.Require().NoError(suite.Keeper().StoreBatch(suite.Ctx, olderBatch))
+	suite.Require().NoError(suite.Keeper().StoreBatch(suite.Ctx, middleBatch))
+	suite.Require().NoError(suite.Keeper().StoreBatch(suite.Ctx, executedBatch))
+	suite.Require().NoError(suite.Keeper().StoreBatch(suite.Ctx, otherTokenBatch))
+
+	suite.Keeper().OutgoingTxBatchExecuted(suite.Ctx, tokenContract, executedBatch.BatchNonce)
+
+	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, tokenContract, olderBatch.BatchNonce))
+	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, tokenContract, middleBatch.BatchNonce))
+	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, tokenContract, executedBatch.BatchNonce))
+	suite.NotNil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, otherTokenContract, otherTokenBatch.BatchNonce))
+
+	_, err := suite.Keeper().GetUnbatchedTxById(suite.Ctx, olderBatch.Transactions[0].Id)
+	suite.Require().NoError(err)
+	_, err = suite.Keeper().GetUnbatchedTxById(suite.Ctx, middleBatch.Transactions[0].Id)
+	suite.Require().NoError(err)
+	_, err = suite.Keeper().GetUnbatchedTxById(suite.Ctx, executedBatch.Transactions[0].Id)
+	suite.Require().Error(err)
+}
+
+func (suite *KeeperTestSuite) TestEndBlockerCancelsTimedOutBatchesAfterIteration() {
+	tokenContract := helpers.GenerateAddress().Hex()
+	expiredBatch := newTestOutgoingBatch(tokenContract, 1, 10, 201, 3001)
+	alsoExpiredBatch := newTestOutgoingBatch(tokenContract, 2, 11, 202, 3002)
+	activeBatch := newTestOutgoingBatch(tokenContract, 3, 99, 203, 3003)
+
+	suite.Require().NoError(suite.Keeper().StoreBatch(suite.Ctx, expiredBatch))
+	suite.Require().NoError(suite.Keeper().StoreBatch(suite.Ctx, alsoExpiredBatch))
+	suite.Require().NoError(suite.Keeper().StoreBatch(suite.Ctx, activeBatch))
+	suite.Keeper().SetLastObservedBlockHeight(suite.Ctx, 12, uint64(suite.Ctx.BlockHeight()))
+
+	suite.Keeper().EndBlocker(suite.Ctx)
+
+	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, tokenContract, expiredBatch.BatchNonce))
+	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, tokenContract, alsoExpiredBatch.BatchNonce))
+	suite.NotNil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, tokenContract, activeBatch.BatchNonce))
+
+	_, err := suite.Keeper().GetUnbatchedTxById(suite.Ctx, expiredBatch.Transactions[0].Id)
+	suite.Require().NoError(err)
+	_, err = suite.Keeper().GetUnbatchedTxById(suite.Ctx, alsoExpiredBatch.Transactions[0].Id)
+	suite.Require().NoError(err)
+	_, err = suite.Keeper().GetUnbatchedTxById(suite.Ctx, activeBatch.Transactions[0].Id)
+	suite.Require().Error(err)
+}
+
 func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {
 	index := tmrand.Intn(100)
 	for i := 1; i <= index; i++ {
@@ -154,4 +208,29 @@ func (suite *KeeperTestSuite) TestKeeper_IterateBatch() {
 		},
 	)
 	suite.Equal(len(batchs), index)
+}
+
+func newTestOutgoingBatch(tokenContract string, nonce, timeout, block, txID uint64) *types.OutgoingTxBatch {
+	return &types.OutgoingTxBatch{
+		BatchNonce:   nonce,
+		BatchTimeout: timeout,
+		Transactions: []*types.OutgoingTransferTx{
+			{
+				Id:          txID,
+				Sender:      sdk.AccAddress(helpers.GenerateAddress().Bytes()).String(),
+				DestAddress: helpers.GenerateAddress().Hex(),
+				Token: types.ERC20Token{
+					Contract: tokenContract,
+					Amount:   sdkmath.NewInt(1),
+				},
+				Fee: types.ERC20Token{
+					Contract: tokenContract,
+					Amount:   sdkmath.NewInt(1),
+				},
+			},
+		},
+		TokenContract: tokenContract,
+		Block:         block,
+		FeeReceive:    helpers.GenerateAddress().Hex(),
+	}
 }


### PR DESCRIPTION
## Summary

- Collect outgoing batch identifiers while iterating, then cancel them after the iterator has returned.
- Apply the same deferred-cancellation pattern to timed-out batch cleanup and executed-batch cleanup.
- Add regression coverage for EndBlocker timed-out cleanup and `OutgoingTxBatchExecuted` cancelling earlier batches without touching unrelated token batches.

Fixes #1252

## Validation

- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/(TestOutgoingTxBatchExecutedCancelsEarlierBatchesAfterIteration|TestEndBlockerCancelsTimedOutBatchesAfterIteration|TestKeeper_DeleteBatchConfirm)' -count=1 -v`
- `go test ./x/gravity/keeper -count=1`
- `go test ./x/gravity/... -count=1`
- `go test ./... -count=1`
- `git diff --check`

Meta Earth bug bounty payout: `$MEC` via ME Pass wallet `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.
