### PR TITLE
fix(delayedack): bind packet finalization to state roots

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -381,6 +381,7 @@ func (a *AppKeepers) InitKeepers(
 		a.keys[delayedacktypes.StoreKey],
 		a.GetSubspace(delayedacktypes.ModuleName),
 		a.RollappKeeper,
+		a.IBCKeeper.ClientKeeper,
 		a.IBCKeeper.ChannelKeeper,
 		a.IBCKeeper.ChannelKeeper,
 		&a.EIBCKeeper,

--- a/ibctesting/utils_test.go
+++ b/ibctesting/utils_test.go
@@ -15,7 +15,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankutil "github.com/cosmos/cosmos-sdk/x/bank/testutil"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 	"github.com/cosmos/ibc-go/v7/testing/mock"
 
@@ -167,9 +169,10 @@ func (s *utilSuite) updateRollappState(endHeight uint64) {
 	// populate the block descriptors
 	blockDescriptors := &rollapptypes.BlockDescriptors{BD: make([]rollapptypes.BlockDescriptor, numBlocks)}
 	for i := 0; i < int(numBlocks); i++ {
+		height := startHeight + uint64(i)
 		blockDescriptors.BD[i] = rollapptypes.BlockDescriptor{
-			Height:    startHeight + uint64(i),
-			StateRoot: bytes.Repeat([]byte{byte(startHeight) + byte(i)}, 32),
+			Height:    height,
+			StateRoot: s.rollappStateRootAtHeight(height),
 		}
 	}
 	// Update the state
@@ -188,6 +191,60 @@ func (s *utilSuite) updateRollappState(endHeight uint64) {
 	s.Require().NoError(err)
 }
 
+type consensusStateWithRoot interface {
+	GetRoot() exported.Root
+}
+
+func (s *utilSuite) rollappStateRootAtHeight(height uint64) []byte {
+	mockRoot := bytes.Repeat([]byte{byte(height)}, 32)
+	stateRoot, found := s.rollappConsensusRootAtHeight(height)
+	if !found {
+		return mockRoot
+	}
+
+	return stateRoot
+}
+
+func (s *utilSuite) rollappConsensusRootAtHeight(height uint64) ([]byte, bool) {
+	rollapp, found := s.hubApp().RollappKeeper.GetRollapp(s.hubCtx(), rollappChainID())
+	if !found || rollapp.ChannelId == "" {
+		return nil, false
+	}
+
+	clientID, clientState, err := s.hubApp().IBCKeeper.ChannelKeeper.GetChannelClientState(
+		s.hubCtx(),
+		transfertypes.PortID,
+		rollapp.ChannelId,
+	)
+	s.Require().NoError(err)
+
+	consensusHeight := clienttypes.NewHeight(clientState.GetLatestHeight().GetRevisionNumber(), height)
+	consensusState, found := s.hubApp().IBCKeeper.ClientKeeper.GetClientConsensusState(
+		s.hubCtx(),
+		clientID,
+		consensusHeight,
+	)
+	if !found {
+		return nil, false
+	}
+
+	rootedConsensusState, ok := consensusState.(consensusStateWithRoot)
+	s.Require().True(ok)
+	stateRoot := rootedConsensusState.GetRoot().GetHash()
+	s.Require().Len(stateRoot, 32)
+
+	return stateRoot, true
+}
+
+func (s *utilSuite) refreshRollappStateRoots(stateInfo *rollapptypes.StateInfo) {
+	for i, descriptor := range stateInfo.BDs.BD {
+		stateRoot, found := s.rollappConsensusRootAtHeight(descriptor.Height)
+		if found {
+			stateInfo.BDs.BD[i].StateRoot = stateRoot
+		}
+	}
+}
+
 func (s *utilSuite) finalizeRollappState(index uint64, endHeight uint64) (sdk.Events, error) {
 	rollappKeeper := s.hubApp().RollappKeeper
 	ctx := s.hubCtx()
@@ -197,6 +254,7 @@ func (s *utilSuite) finalizeRollappState(index uint64, endHeight uint64) (sdk.Ev
 	s.Require().True(found)
 	stateInfo.NumBlocks = endHeight - stateInfo.StartHeight + 1
 	stateInfo.Status = common.Status_FINALIZED
+	s.refreshRollappStateRoots(&stateInfo)
 	// update the status of the stateInfo
 	rollappKeeper.SetStateInfo(ctx, stateInfo)
 	// update the LatestStateInfoIndex of the rollapp

--- a/testutil/keeper/delayedack.go
+++ b/testutil/keeper/delayedack.go
@@ -60,6 +60,10 @@ func (ClientKeeperStub) GetClientState(ctx sdk.Context, clientID string) (export
 	return nil, false
 }
 
+func (ClientKeeperStub) GetClientConsensusState(ctx sdk.Context, clientID string, height exported.Height) (exported.ConsensusState, bool) {
+	return nil, false
+}
+
 func (ClientKeeperStub) GetConnection(ctx sdk.Context, connectionID string) (connectiontypes.ConnectionEnd, bool) {
 	return connectiontypes.ConnectionEnd{}, false
 }
@@ -139,6 +143,7 @@ func DelayedackKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 		storeKey,
 		paramsSubspace,
 		RollappKeeperStub{},
+		ClientKeeperStub{},
 		ICS4WrapperStub{},
 		ChannelKeeperStub{},
 		nil,

--- a/x/delayedack/keeper/finalize.go
+++ b/x/delayedack/keeper/finalize.go
@@ -1,23 +1,28 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 
 	"github.com/cometbft/cometbft/libs/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	"github.com/osmosis-labs/osmosis/v15/osmoutils"
 
 	commontypes "github.com/openmetaearth/me-hub/x/common/types"
 	"github.com/openmetaearth/me-hub/x/delayedack/types"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
 )
 
 // FinalizeRollappPackets finalizes the packets for the given rollapp until the given height which is
 // the end height of the latest finalized state
-func (k Keeper) FinalizeRollappPackets(ctx sdk.Context, ibc porttypes.IBCModule, rollappID string, stateEndHeight uint64) error {
+func (k Keeper) FinalizeRollappPackets(ctx sdk.Context, ibc porttypes.IBCModule, rollappID string, stateInfo rollapptypes.StateInfo) error {
+	stateEndHeight := stateInfo.StartHeight + stateInfo.NumBlocks - 1
 	rollappPendingPackets := k.ListRollappPackets(ctx, types.PendingByRollappIDByMaxHeight(rollappID, stateEndHeight))
 	if len(rollappPendingPackets) == 0 {
 		return nil
@@ -29,11 +34,85 @@ func (k Keeper) FinalizeRollappPackets(ctx sdk.Context, ibc porttypes.IBCModule,
 		"state end height", stateEndHeight,
 		"num packets", len(rollappPendingPackets))
 	for _, rollappPacket := range rollappPendingPackets {
+		if err := k.validatePacketProofRoot(ctx, rollappPacket, stateInfo); err != nil {
+			return fmt.Errorf("validate rollapp packet proof root: %w", err)
+		}
 		if err := k.finalizeRollappPacket(ctx, ibc, rollappID, logger, rollappPacket); err != nil {
 			return fmt.Errorf("finalize rollapp packet: %w", err)
 		}
 	}
 	return nil
+}
+
+type consensusRoot interface {
+	GetRoot() exported.Root
+}
+
+func (k Keeper) validatePacketProofRoot(
+	ctx sdk.Context,
+	rollappPacket commontypes.RollappPacket,
+	stateInfo rollapptypes.StateInfo,
+) error {
+	stateRoot, ok := blockDescriptorRootAtHeight(stateInfo, rollappPacket.ProofHeight)
+	if !ok {
+		return nil
+	}
+
+	portID, channelID := packetProofPortChannel(rollappPacket)
+	clientID, clientState, err := k.channelKeeper.GetChannelClientState(ctx, portID, channelID)
+	if err != nil {
+		return errorsmod.Wrapf(err, "get channel client state for %s/%s", portID, channelID)
+	}
+
+	consensusHeight := clienttypes.NewHeight(clientState.GetLatestHeight().GetRevisionNumber(), rollappPacket.ProofHeight)
+	consensusState, found := k.clientKeeper.GetClientConsensusState(ctx, clientID, consensusHeight)
+	if !found {
+		return errorsmod.Wrapf(types.ErrUnknownRequest,
+			"consensus state not found for client %s at height %s", clientID, consensusHeight)
+	}
+
+	rootedConsensusState, ok := consensusState.(consensusRoot)
+	if !ok {
+		return errorsmod.Wrapf(types.ErrUnknownRequest,
+			"consensus state for client %s at height %s has no commitment root", clientID, consensusHeight)
+	}
+
+	consensusRoot := rootedConsensusState.GetRoot().GetHash()
+	if !bytes.Equal(stateRoot, consensusRoot) {
+		return errorsmod.Wrapf(types.ErrUnknownRequest,
+			"rollapp state root mismatch at height %d: descriptor root %X != consensus root %X",
+			rollappPacket.ProofHeight, stateRoot, consensusRoot)
+	}
+
+	return nil
+}
+
+func blockDescriptorRootAtHeight(stateInfo rollapptypes.StateInfo, proofHeight uint64) ([]byte, bool) {
+	if proofHeight < stateInfo.StartHeight || proofHeight >= stateInfo.StartHeight+stateInfo.NumBlocks {
+		return nil, false
+	}
+
+	for _, descriptor := range stateInfo.BDs.BD {
+		if descriptor.Height == proofHeight {
+			if len(descriptor.StateRoot) == 0 {
+				return nil, false
+			}
+			return descriptor.StateRoot, true
+		}
+	}
+
+	return nil, false
+}
+
+func packetProofPortChannel(rollappPacket commontypes.RollappPacket) (string, string) {
+	switch rollappPacket.Type {
+	case commontypes.RollappPacket_ON_RECV:
+		return rollappPacket.Packet.DestinationPort, rollappPacket.Packet.DestinationChannel
+	case commontypes.RollappPacket_ON_ACK, commontypes.RollappPacket_ON_TIMEOUT:
+		return rollappPacket.Packet.SourcePort, rollappPacket.Packet.SourceChannel
+	default:
+		return rollappPacket.Packet.SourcePort, rollappPacket.Packet.SourceChannel
+	}
 }
 
 type wrappedFunc func(ctx sdk.Context) error

--- a/x/delayedack/keeper/finalize_state_root_test.go
+++ b/x/delayedack/keeper/finalize_state_root_test.go
@@ -1,0 +1,218 @@
+package keeper_test
+
+import (
+	"bytes"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	connectiontypes "github.com/cosmos/ibc-go/v7/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
+	commitmenttypes "github.com/cosmos/ibc-go/v7/modules/core/23-commitment/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
+	ibctmtypes "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+
+	commontypes "github.com/openmetaearth/me-hub/x/common/types"
+	dacktypes "github.com/openmetaearth/me-hub/x/delayedack/types"
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
+)
+
+var _ porttypes.IBCModule = (*countingIBCModule)(nil)
+
+type countingIBCModule struct {
+	ackCallbacks     int
+	recvCallbacks    int
+	timeoutCallbacks int
+}
+
+func (m *countingIBCModule) OnChanOpenInit(
+	sdk.Context,
+	channeltypes.Order,
+	[]string,
+	string,
+	string,
+	*capabilitytypes.Capability,
+	channeltypes.Counterparty,
+	string,
+) (string, error) {
+	return "", nil
+}
+
+func (m *countingIBCModule) OnChanOpenTry(
+	sdk.Context,
+	channeltypes.Order,
+	[]string,
+	string,
+	string,
+	*capabilitytypes.Capability,
+	channeltypes.Counterparty,
+	string,
+) (string, error) {
+	return "", nil
+}
+
+func (m *countingIBCModule) OnChanOpenAck(sdk.Context, string, string, string, string) error {
+	return nil
+}
+
+func (m *countingIBCModule) OnChanOpenConfirm(sdk.Context, string, string) error {
+	return nil
+}
+
+func (m *countingIBCModule) OnChanCloseInit(sdk.Context, string, string) error {
+	return nil
+}
+
+func (m *countingIBCModule) OnChanCloseConfirm(sdk.Context, string, string) error {
+	return nil
+}
+
+func (m *countingIBCModule) OnRecvPacket(
+	sdk.Context,
+	channeltypes.Packet,
+	sdk.AccAddress,
+) exported.Acknowledgement {
+	m.recvCallbacks++
+	return channeltypes.NewResultAcknowledgement([]byte{1})
+}
+
+func (m *countingIBCModule) OnAcknowledgementPacket(
+	sdk.Context,
+	channeltypes.Packet,
+	[]byte,
+	sdk.AccAddress,
+) error {
+	m.ackCallbacks++
+	return nil
+}
+
+func (m *countingIBCModule) OnTimeoutPacket(
+	sdk.Context,
+	channeltypes.Packet,
+	sdk.AccAddress,
+) error {
+	m.timeoutCallbacks++
+	return nil
+}
+
+func (suite *DelayedAckTestSuite) TestFinalizeRollappPacketsRejectsConsensusRootMismatch() {
+	keeper, ctx := suite.App.DelayedAckKeeper, suite.Ctx
+	rollappID := "rollapp-root-mismatch-1"
+	proofHeight := uint64(7)
+	stateRoot := bytes.Repeat([]byte{0x11}, 32)
+	consensusRoot := bytes.Repeat([]byte{0x22}, 32)
+	packet := newRootCheckedPacket(rollappID, proofHeight, commontypes.RollappPacket_ON_ACK)
+	stateInfo := newRootCheckedStateInfo(rollappID, proofHeight, stateRoot)
+	suite.setPacketConsensusRoot(ctx, packet, consensusRoot)
+	keeper.SetRollappPacket(ctx, packet)
+
+	ibcModule := &countingIBCModule{}
+	err := keeper.FinalizeRollappPackets(ctx, ibcModule, rollappID, stateInfo)
+
+	suite.Require().Error(err)
+	suite.Require().Contains(err.Error(), "state root mismatch")
+	suite.Require().Zero(ibcModule.ackCallbacks)
+	suite.Require().Len(keeper.ListRollappPackets(ctx, dacktypes.ByRollappIDByStatus(rollappID, commontypes.Status_PENDING)), 1)
+	suite.Require().Empty(keeper.ListRollappPackets(ctx, dacktypes.ByRollappIDByStatus(rollappID, commontypes.Status_FINALIZED)))
+}
+
+func (suite *DelayedAckTestSuite) TestFinalizeRollappPacketsAllowsMatchingConsensusRoot() {
+	keeper, ctx := suite.App.DelayedAckKeeper, suite.Ctx
+	rollappID := "rollapp-root-match-1"
+	proofHeight := uint64(8)
+	stateRoot := bytes.Repeat([]byte{0x33}, 32)
+	packet := newRootCheckedPacket(rollappID, proofHeight, commontypes.RollappPacket_ON_ACK)
+	stateInfo := newRootCheckedStateInfo(rollappID, proofHeight, stateRoot)
+	suite.setPacketConsensusRoot(ctx, packet, stateRoot)
+	keeper.SetRollappPacket(ctx, packet)
+
+	ibcModule := &countingIBCModule{}
+	err := keeper.FinalizeRollappPackets(ctx, ibcModule, rollappID, stateInfo)
+
+	suite.Require().NoError(err)
+	suite.Require().Equal(1, ibcModule.ackCallbacks)
+	suite.Require().Empty(keeper.ListRollappPackets(ctx, dacktypes.ByRollappIDByStatus(rollappID, commontypes.Status_PENDING)))
+	suite.Require().Len(keeper.ListRollappPackets(ctx, dacktypes.ByRollappIDByStatus(rollappID, commontypes.Status_FINALIZED)), 1)
+}
+
+func newRootCheckedPacket(
+	rollappID string,
+	proofHeight uint64,
+	packetType commontypes.RollappPacket_Type,
+) commontypes.RollappPacket {
+	return commontypes.RollappPacket{
+		RollappId: rollappID,
+		Packet: &channeltypes.Packet{
+			SourcePort:         "transfer",
+			SourceChannel:      "channel-root-check",
+			DestinationPort:    "transfer",
+			DestinationChannel: "channel-hub",
+			Data:               []byte("packet-data"),
+			Sequence:           proofHeight,
+		},
+		Status:      commontypes.Status_PENDING,
+		ProofHeight: proofHeight,
+		Type:        packetType,
+		Relayer:     sdk.AccAddress(bytes.Repeat([]byte{0x44}, 20)),
+	}
+}
+
+func newRootCheckedStateInfo(rollappID string, proofHeight uint64, stateRoot []byte) rollapptypes.StateInfo {
+	return rollapptypes.StateInfo{
+		StateInfoIndex: rollapptypes.StateInfoIndex{RollappId: rollappID, Index: 1},
+		StartHeight:    proofHeight,
+		NumBlocks:      1,
+		Status:         commontypes.Status_FINALIZED,
+		BDs: rollapptypes.BlockDescriptors{BD: []rollapptypes.BlockDescriptor{{
+			Height:    proofHeight,
+			StateRoot: stateRoot,
+		}}},
+	}
+}
+
+func (suite *DelayedAckTestSuite) setPacketConsensusRoot(
+	ctx sdk.Context,
+	packet commontypes.RollappPacket,
+	consensusRoot []byte,
+) {
+	clientID := "07-tendermint-364"
+	connectionID := "connection-364"
+	revisionNumber := uint64(1)
+	consensusHeight := clienttypes.NewHeight(revisionNumber, packet.ProofHeight)
+
+	suite.App.IBCKeeper.ClientKeeper.SetClientState(ctx, clientID, ibctmtypes.NewClientState(
+		"rollapp-root-check-1",
+		ibctmtypes.DefaultTrustLevel,
+		time.Hour,
+		2*time.Hour,
+		time.Minute,
+		consensusHeight,
+		commitmenttypes.GetSDKSpecs(),
+		[]string{"upgrade", "upgradedIBCState"},
+	))
+	suite.App.IBCKeeper.ClientKeeper.SetClientConsensusState(ctx, clientID, consensusHeight, ibctmtypes.NewConsensusState(
+		time.Unix(1, 0).UTC(),
+		commitmenttypes.NewMerkleRoot(consensusRoot),
+		bytes.Repeat([]byte{0x55}, 32),
+	))
+	suite.App.IBCKeeper.ConnectionKeeper.SetConnection(ctx, connectionID, connectiontypes.NewConnectionEnd(
+		connectiontypes.OPEN,
+		clientID,
+		connectiontypes.Counterparty{},
+		[]*connectiontypes.Version{connectiontypes.DefaultIBCVersion},
+		0,
+	))
+	suite.App.IBCKeeper.ChannelKeeper.SetChannel(ctx,
+		packet.Packet.SourcePort,
+		packet.Packet.SourceChannel,
+		channeltypes.NewChannel(
+			channeltypes.OPEN,
+			channeltypes.UNORDERED,
+			channeltypes.Counterparty{},
+			[]string{connectionID},
+			"ics20-1",
+		),
+	)
+}

--- a/x/delayedack/keeper/keeper.go
+++ b/x/delayedack/keeper/keeper.go
@@ -22,6 +22,7 @@ type Keeper struct {
 	paramstore paramtypes.Subspace
 
 	rollappKeeper types.RollappKeeper
+	clientKeeper  types.IBCClientKeeper
 	porttypes.ICS4Wrapper
 	channelKeeper types.ChannelKeeper
 	types.EIBCKeeper
@@ -32,6 +33,7 @@ func NewKeeper(
 	storeKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
 	rollappKeeper types.RollappKeeper,
+	clientKeeper types.IBCClientKeeper,
 	ics4Wrapper porttypes.ICS4Wrapper,
 	channelKeeper types.ChannelKeeper,
 	eibcKeeper types.EIBCKeeper,
@@ -45,6 +47,7 @@ func NewKeeper(
 		storeKey:      storeKey,
 		paramstore:    ps,
 		rollappKeeper: rollappKeeper,
+		clientKeeper:  clientKeeper,
 		ICS4Wrapper:   ics4Wrapper,
 		channelKeeper: channelKeeper,
 		EIBCKeeper:    eibcKeeper,

--- a/x/delayedack/rollapp_hooks.go
+++ b/x/delayedack/rollapp_hooks.go
@@ -15,8 +15,7 @@ func (w IBCMiddleware) BeforeUpdateState(ctx sdk.Context, seqAddr string, rollap
 // AfterStateFinalized implements the RollappHooks interface
 func (w IBCMiddleware) AfterStateFinalized(ctx sdk.Context, rollappID string, stateInfo *rollapptypes.StateInfo) error {
 	// Finalize the packets for the rollapp at the given height
-	stateEndHeight := stateInfo.StartHeight + stateInfo.NumBlocks - 1
-	return w.FinalizeRollappPackets(ctx, w.IBCModule, rollappID, stateEndHeight)
+	return w.FinalizeRollappPackets(ctx, w.IBCModule, rollappID, *stateInfo)
 }
 
 func (w IBCMiddleware) FraudSubmitted(ctx sdk.Context, rollappID string, height uint64, seqAddr string) error {

--- a/x/delayedack/types/expected_keepers.go
+++ b/x/delayedack/types/expected_keepers.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 
 	commontypes "github.com/openmetaearth/me-hub/x/common/types"
 	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
@@ -12,6 +13,11 @@ import (
 // ChannelKeeper defines the expected IBC channel keeper
 type ChannelKeeper interface {
 	LookupModuleByChannel(ctx sdk.Context, portID, channelID string) (string, *capabilitytypes.Capability, error)
+	GetChannelClientState(ctx sdk.Context, portID, channelID string) (string, exported.ClientState, error)
+}
+
+type IBCClientKeeper interface {
+	GetClientConsensusState(ctx sdk.Context, clientID string, height exported.Height) (exported.ConsensusState, bool)
 }
 
 type RollappKeeper interface {


### PR DESCRIPTION
Fixes #364

## Summary
- Pass the full finalized RollApp state into delayed-ack finalization.
- Before finalizing a delayed packet, resolve the packet proof channel/client and compare the finalized block descriptor StateRoot with the IBC consensus AppHash at the packet proof height.
- Abort finalization before callbacks/status updates when the roots differ.
- Add regression coverage for mismatch rejection and matching-root finalization, and update integration fixtures to use consensus roots where delayed packets are finalized.

## Validation
- `go test ./x/delayedack/keeper -run 'TestKeeperTestSuite/TestFinalizeRollappPackets(RejectsConsensusRootMismatch|AllowsMatchingConsensusRoot)$' -count=1 -v`
- `go test ./x/delayedack/... ./x/rollapp/... ./ibctesting -count=1`
- `go test ./... -count=1`
- `git diff --check`

## Bounty payout
Meta Earth bug bounty payout: $MEC via ME Pass wallet `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.
