### PR TITLE
fix(gravity): avoid relayer power overflow

### DIFF
--- a/x/gravity/keeper/relayer_set.go
+++ b/x/gravity/keeper/relayer_set.go
@@ -25,23 +25,32 @@ import (
 // implementations are involved.
 func (k Keeper) GetCurrentRelayerSet(ctx sdk.Context) *types.RelayerSet {
 	allRelayers := k.GetAllRelayers(ctx, true)
+	type relayerPower struct {
+		power           sdkmath.Int
+		externalAddress string
+	}
+	relayerPowers := make([]relayerPower, 0, len(allRelayers))
 	bridgeValidators := make([]types.BridgeValidator, 0, len(allRelayers))
-	var totalPower uint64
+	totalPower := sdkmath.ZeroInt()
 
 	for _, relayer := range allRelayers {
 		power := relayer.GetPower()
 		if power.LTE(sdkmath.ZeroInt()) {
 			continue
 		}
-		totalPower += power.Uint64()
-		bridgeValidators = append(bridgeValidators, types.BridgeValidator{
-			Power:           power.Uint64(),
-			ExternalAddress: relayer.ExternalAddress,
+		totalPower = totalPower.Add(power)
+		relayerPowers = append(relayerPowers, relayerPower{
+			power:           power,
+			externalAddress: relayer.ExternalAddress,
 		})
 	}
-	for i := range bridgeValidators {
+	powerBase := sdkmath.NewIntFromUint64(types.PowerBase)
+	for _, relayerPower := range relayerPowers {
 		// normalize power, use 10000 as the base, meaning 50.01% is 5001.
-		bridgeValidators[i].Power = sdkmath.NewUint(bridgeValidators[i].Power).MulUint64(types.PowerBase).QuoUint64(totalPower).Uint64()
+		bridgeValidators = append(bridgeValidators, types.BridgeValidator{
+			Power:           relayerPower.power.Mul(powerBase).Quo(totalPower).Uint64(),
+			ExternalAddress: relayerPower.externalAddress,
+		})
 	}
 	relayerSetNonce := k.GetLastRelayerSetNonce(ctx)
 	return types.CurrentRelayerSet(relayerSetNonce, uint64(ctx.BlockHeight()), bridgeValidators)

--- a/x/gravity/keeper/relayer_set_test.go
+++ b/x/gravity/keeper/relayer_set_test.go
@@ -3,7 +3,9 @@ package keeper_test
 import (
 	"encoding/hex"
 	"fmt"
+	"math"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -12,6 +14,30 @@ import (
 	"github.com/openmetaearth/me-hub/testutil/helpers"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 )
+
+func (s *KeeperTestSuite) TestGetCurrentRelayerSetNormalizesLargeTotalPower() {
+	power := sdkmath.NewIntFromUint64(math.MaxUint64/2 + 100)
+	delegateAmount := power.Mul(sdk.DefaultPowerReduction)
+
+	for i := 0; i < 2; i++ {
+		s.Keeper().SetRelayer(s.Ctx, s.relayerAddrs[i], types.Relayer{
+			RelayerAddress:  s.relayerAddrs[i].String(),
+			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[i].PublicKey),
+			DelegateAmount:  delegateAmount,
+			Online:          true,
+		})
+	}
+
+	relayerSet := s.Keeper().GetCurrentRelayerSet(s.Ctx)
+
+	s.Require().Len(relayerSet.Members, 2)
+	var totalNormalizedPower uint64
+	for _, member := range relayerSet.Members {
+		s.Require().EqualValues(types.PowerBase/2, member.Power)
+		totalNormalizedPower += member.Power
+	}
+	s.Require().EqualValues(types.PowerBase, totalNormalizedPower)
+}
 
 func (s *KeeperTestSuite) TestLastPendingRelayerSetRequestByAddr() {
 	testCases := []struct {


### PR DESCRIPTION
## Summary
- keep Gravity relayer total power in `sdkmath.Int` while building the current relayer set
- retain each relayer's source power until the safe total is known, then normalize to `PowerBase`
- add a regression test where individual relayer powers fit in `uint64` but the combined total exceeds `math.MaxUint64`

## Root Cause
`GetCurrentRelayerSet` accumulated online relayer power in a `uint64`. A large configured relayer set could overflow that denominator before normalization, corrupting the bridge validator power distribution or panicking during final conversion.

Fixes #1253.

## Validation
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestGetCurrentRelayerSetNormalizesLargeTotalPower' -count=1 -v`
- `go test ./x/gravity/keeper -count=1`
- `go test ./x/gravity/... -count=1`
- `go test ./... -count=1`
- `git diff --check`

## Bounty Payout
Meta Earth bug bounty payout: `$MEC` via ME Pass wallet `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.
