### PR TITLE
fix(wstaking): report added delegation shares

### DIFF
--- a/x/wstaking/keeper/delegation.go
+++ b/x/wstaking/keeper/delegation.go
@@ -157,7 +157,7 @@ func (k Keeper) Delegate(
 	delegation.StartHeight = ctx.BlockHeight()
 	k.SetDelegation(ctx, delegation)
 
-	return sdk.NewDecFromInt(delegation.Amount), nil
+	return sdk.NewDecFromInt(bondAmt), nil
 }
 
 // WithdrawDelegationRewards withdraw rewards from a delegation

--- a/x/wstaking/keeper/msg_server_delegate_test.go
+++ b/x/wstaking/keeper/msg_server_delegate_test.go
@@ -96,6 +96,31 @@ func (s *KeeperTestSuite) TestDelegate() {
 	}
 }
 
+func (s *KeeperTestSuite) TestDelegateExperienceRegionEmitsAddedShares() {
+	s.SetupTest()
+
+	delegator := sdk.MustAccAddressFromBech32(s.Dao.AirdropAddress)
+	delegateAmount := sdk.NewInt(1000000)
+	msg := stakingtypes.MsgDelegate{
+		DelegatorAddress: delegator.String(),
+		ValidatorAddress: s.experienceValidator.OperatorAddress,
+		Amount:           sdk.NewCoin(params.BaseDenom, delegateAmount),
+	}
+
+	_, err := s.msgServer.Delegate(s.Ctx, &msg)
+	s.Require().NoError(err)
+
+	delegation, found := s.App.StakingKeeper.GetDelegation(s.Ctx, delegator, s.experienceValidator.GetOperator())
+	s.Require().True(found)
+	s.Require().Equal(delegateAmount.String(), delegation.UnMeidAmount.String())
+	s.Require().Equal(sdk.ZeroInt().String(), delegation.Amount.String())
+
+	delegateEvent, found := s.FindLastEventOfType(s.Ctx.EventManager().Events(), stakingtypes.EventTypeDelegate)
+	s.Require().True(found)
+	attrs := s.ExtractAttributes(delegateEvent)
+	s.Require().Equal(sdk.NewDecFromInt(delegateAmount).String(), attrs[types.AttributeKeyNewShares])
+}
+
 func (s *KeeperTestSuite) TestUnDelegate() {
 	s.SetupTest()
 


### PR DESCRIPTION
Fixes #1254

## Summary
- return the shares added by the current delegation from `Keeper.Delegate` instead of the stored `delegation.Amount` total
- keep experience-region delegation accounting in `UnMeidAmount` while emitting the correct `new_shares` value
- add a regression for the public delegate message path that checks stored experience-region delegation state and the emitted event

## Validation
- `go test ./x/wstaking/keeper -run TestKeeperTestSuite/TestDelegateExperienceRegionEmitsAddedShares -count=1 -v`
- `go test ./x/wstaking/keeper -count=1`
- `go test ./x/wstaking/... -count=1`
- `go test ./... -count=1`
- `git diff --check`

Meta Earth bug bounty payout: $MEC via ME Pass wallet `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`