### PR TITLE
fix: guard wstaking undelegate counters

### DIFF
--- a/x/wstaking/keeper/msg_server_delegate_test.go
+++ b/x/wstaking/keeper/msg_server_delegate_test.go
@@ -165,3 +165,101 @@ func (s *KeeperTestSuite) TestUnDelegate() {
 		})
 	}
 }
+
+func (s *KeeperTestSuite) TestUndelegateRejectsNegativeRegionDelegateAmount() {
+	amount := sdk.NewCoin(params.BaseDenom, sdk.NewInt(1000000))
+	region, validator := s.setupMeEarthDelegation(amount)
+	corruptedRegionAmount := amount.Amount.Sub(sdk.NewInt(1))
+
+	region.DelegateAmount = corruptedRegionAmount
+	s.Keeper().SetRegion(s.Ctx, region)
+
+	undelegateMsg := stakingtypes.MsgUndelegate{
+		DelegatorAddress: s.Dao.GlobalDao,
+		ValidatorAddress: "",
+		Amount:           amount,
+	}
+	_, err := s.msgServer.Undelegate(s.Ctx, &undelegateMsg)
+	s.Require().ErrorIs(err, types.ErrRegion)
+
+	delegation, found := s.Keeper().GetDelegation(s.Ctx, sdk.MustAccAddressFromBech32(s.Dao.GlobalDao), sdk.ValAddress{})
+	s.Require().True(found)
+	s.Require().Equal(amount.Amount.String(), delegation.Amount.String())
+
+	storedRegion, found := s.Keeper().GetRegion(s.Ctx, types.MeEarthRegionId)
+	s.Require().True(found)
+	s.Require().Equal(corruptedRegionAmount.String(), storedRegion.DelegateAmount.String())
+
+	valAddr, err := sdk.ValAddressFromBech32(s.meEarthValidator.OperatorAddress)
+	s.Require().NoError(err)
+	storedValidator, found := s.Keeper().GetValidator(s.Ctx, valAddr)
+	s.Require().True(found)
+	s.Require().Equal(validator.DelegationAmount.String(), storedValidator.DelegationAmount.String())
+}
+
+func (s *KeeperTestSuite) TestUndelegateRejectsNegativeValidatorDelegationAmount() {
+	amount := sdk.NewCoin(params.BaseDenom, sdk.NewInt(1000000))
+	region, validator := s.setupMeEarthDelegation(amount)
+	corruptedValidatorAmount := amount.Amount.Sub(sdk.NewInt(1))
+
+	valAddr, err := sdk.ValAddressFromBech32(s.meEarthValidator.OperatorAddress)
+	s.Require().NoError(err)
+	validator.DelegationAmount = corruptedValidatorAmount
+	s.Keeper().SetValidator(s.Ctx, validator)
+
+	undelegateMsg := stakingtypes.MsgUndelegate{
+		DelegatorAddress: s.Dao.GlobalDao,
+		ValidatorAddress: "",
+		Amount:           amount,
+	}
+	_, err = s.msgServer.Undelegate(s.Ctx, &undelegateMsg)
+	s.Require().ErrorIs(err, types.ErrValidatorDelegationAmount)
+
+	delegation, found := s.Keeper().GetDelegation(s.Ctx, sdk.MustAccAddressFromBech32(s.Dao.GlobalDao), sdk.ValAddress{})
+	s.Require().True(found)
+	s.Require().Equal(amount.Amount.String(), delegation.Amount.String())
+
+	storedRegion, found := s.Keeper().GetRegion(s.Ctx, types.MeEarthRegionId)
+	s.Require().True(found)
+	s.Require().Equal(region.DelegateAmount.String(), storedRegion.DelegateAmount.String())
+
+	storedValidator, found := s.Keeper().GetValidator(s.Ctx, valAddr)
+	s.Require().True(found)
+	s.Require().Equal(corruptedValidatorAmount.String(), storedValidator.DelegationAmount.String())
+}
+
+func (s *KeeperTestSuite) setupMeEarthDelegation(amount sdk.Coin) (types.Region, stakingtypes.Validator) {
+	s.SetupTest()
+
+	newMeEarthRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            types.MeEarthRegionName,
+		OperatorAddress: s.meEarthValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newMeEarthRegion)
+	s.Require().NoError(err)
+
+	region, found := s.Keeper().GetRegion(s.Ctx, types.MeEarthRegionId)
+	s.Require().True(found)
+
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, mintypes.ModuleName, sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()), sdk.Coins{sdk.NewInt64Coin(params.BaseDenom, 1000000000000)})
+	s.Require().NoError(err)
+
+	delegateMsg := stakingtypes.MsgDelegate{
+		DelegatorAddress: s.Dao.GlobalDao,
+		ValidatorAddress: "",
+		Amount:           amount,
+	}
+	_, err = s.msgServer.Delegate(s.Ctx, &delegateMsg)
+	s.Require().NoError(err)
+
+	region, found = s.Keeper().GetRegion(s.Ctx, types.MeEarthRegionId)
+	s.Require().True(found)
+
+	valAddr, err := sdk.ValAddressFromBech32(s.meEarthValidator.OperatorAddress)
+	s.Require().NoError(err)
+	validator, found := s.Keeper().GetValidator(s.Ctx, valAddr)
+	s.Require().True(found)
+
+	return region, validator
+}

--- a/x/wstaking/keeper/msg_server_undelegate.go
+++ b/x/wstaking/keeper/msg_server_undelegate.go
@@ -78,10 +78,22 @@ func (k MsgServer) Undelegate(goCtx context.Context, msg *stakingtypes.MsgUndele
 		isMeid = false
 	}
 
+	expectedReturnAmount, err := expectedUndelegateReturnAmount(msg.Amount.Amount, isMeid, delegation)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateUndelegateCounterAmounts(region, val, expectedReturnAmount); err != nil {
+		return nil, err
+	}
+
 	completionTime, returnAmount, err := k.Keeper.Undelegate(ctx, delegatorAddress, valAddr, isMeid, msg.Amount.Amount, delegation)
 	if err != nil {
 		return nil, err
 	}
+	if err := validateUndelegateCounterAmounts(region, val, returnAmount); err != nil {
+		return nil, err
+	}
+
 	region.DelegateAmount = region.DelegateAmount.Sub(returnAmount)
 	k.SetRegion(ctx, region)
 	val.DelegationAmount = val.DelegationAmount.Sub(returnAmount)
@@ -123,4 +135,41 @@ func (k MsgServer) Undelegate(goCtx context.Context, msg *stakingtypes.MsgUndele
 	return &stakingtypes.MsgUndelegateResponse{
 		CompletionTime: completionTime,
 	}, nil
+}
+
+func expectedUndelegateReturnAmount(amount sdk.Int, isMeid bool, delegation stakingtypes.Delegation) (sdk.Int, error) {
+	if amount.LTE(sdk.ZeroInt()) {
+		return sdk.ZeroInt(), types.ErrAmountNotPositive
+	}
+
+	delegatedAmount := delegation.Amount
+	if !isMeid {
+		delegatedAmount = delegation.UnMeidAmount
+	}
+	if delegatedAmount.LTE(sdk.ZeroInt()) {
+		return sdk.ZeroInt(), types.ErrNotEnoughDelegationAmount
+	}
+
+	if amount.GTE(delegatedAmount) {
+		return delegatedAmount, nil
+	}
+
+	remainingAmount := delegatedAmount.Sub(amount)
+	if err := types.CheckMinDelegate(remainingAmount); err != nil {
+		return delegatedAmount, nil
+	}
+
+	return amount, nil
+}
+
+func validateUndelegateCounterAmounts(region types.Region, validator stakingtypes.Validator, returnAmount sdk.Int) error {
+	if region.DelegateAmount.Sub(returnAmount).LT(sdk.ZeroInt()) {
+		return types.ErrRegion.Wrapf("delegate amount: %s, requested undelegation return: %s",
+			region.DelegateAmount.String(), returnAmount.String())
+	}
+	if validator.DelegationAmount.Sub(returnAmount).LT(sdk.ZeroInt()) {
+		return types.ErrValidatorDelegationAmount.Wrapf("validator amount: %s, requested undelegation return: %s",
+			validator.DelegationAmount.String(), returnAmount.String())
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes #1309

## Summary
- Preflight the effective wstaking undelegation return amount, including minimum-delegation rollover behavior.
- Reject undelegations that would make `Region.DelegateAmount` or `Validator.DelegationAmount` negative before mutating delegation state.
- Add regression coverage for corrupted region and validator aggregate counters.

## Root cause
`MsgServer.Undelegate` subtracted the returned amount from aggregate delegation counters without first proving those counters could cover the effective return amount. Because `Unbond` can return more than the requested amount when the remaining delegation falls below the minimum, the check needs to use the same effective return calculation before store mutation.

## Validation
- `go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestUndelegateRejectsNegative' -count=1 -v`
- `go test ./x/wstaking/keeper -count=1`
- `go test ./x/wstaking/... -count=1`
- `go test ./... -count=1`

## Bounty payout
ME Pass wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`