### PR TITLE
fix(wstaking): clean up old consensus signing info

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -286,7 +286,7 @@ func (a *AppKeepers) InitKeepers(
 		a.StakingKeeper,
 		govModuleAddress,
 	)
-	a.StakingKeeper.SetSlashingKeeper(a.SlashingKeeper)
+	a.StakingKeeper.SetSlashingKeeper(a.SlashingKeeper, a.keys[slashingtypes.StoreKey])
 
 	a.FeeGrantKeeper = feegrantkeeper.NewKeeper(
 		appCodec,

--- a/x/wstaking/keeper/keeper.go
+++ b/x/wstaking/keeper/keeper.go
@@ -10,24 +10,26 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 
 type Keeper struct {
 	*stakingkeeper.Keeper
-	cdc            codec.BinaryCodec
-	storeKey       storetypes.StoreKey
-	authKeeper     banktypes.AccountKeeper
-	bankKeeper     types.BankKeeper
-	daoKeeper      types.DaoKeeper
-	mintKeeper     types.MintKeeper
-	nftKeeper      types.NFTKeeper
-	wstakingHooks  types.WstakingHooks
-	kycKeeper      types.KycKeeper
-	didKeeper      types.DidKeeper
-	groupKeeper    types.GroupKeeper
-	slashingKeeper slashingkeeper.Keeper
+	cdc              codec.BinaryCodec
+	storeKey         storetypes.StoreKey
+	authKeeper       banktypes.AccountKeeper
+	bankKeeper       types.BankKeeper
+	daoKeeper        types.DaoKeeper
+	mintKeeper       types.MintKeeper
+	nftKeeper        types.NFTKeeper
+	wstakingHooks    types.WstakingHooks
+	kycKeeper        types.KycKeeper
+	didKeeper        types.DidKeeper
+	groupKeeper      types.GroupKeeper
+	slashingKeeper   slashingkeeper.Keeper
+	slashingStoreKey storetypes.StoreKey
 }
 
 func NewKeeper(
@@ -66,8 +68,20 @@ func (k *Keeper) SetDidKeeper(keeper types.DidKeeper) {
 	k.didKeeper = keeper
 }
 
-func (k *Keeper) SetSlashingKeeper(keeper slashingkeeper.Keeper) {
+func (k *Keeper) SetSlashingKeeper(keeper slashingkeeper.Keeper, storeKey ...storetypes.StoreKey) {
 	k.slashingKeeper = keeper
+	if len(storeKey) > 0 {
+		k.slashingStoreKey = storeKey[0]
+	}
+}
+
+func (k Keeper) deleteValidatorSigningInfo(ctx sdk.Context, consAddr sdk.ConsAddress) {
+	if k.slashingStoreKey == nil {
+		return
+	}
+
+	store := ctx.KVStore(k.slashingStoreKey)
+	store.Delete(slashingtypes.ValidatorSigningInfoKey(consAddr))
 }
 
 // Logger returns a module-specific logger.

--- a/x/wstaking/keeper/update_pub_key.go
+++ b/x/wstaking/keeper/update_pub_key.go
@@ -100,17 +100,19 @@ func (k Keeper) UpdateValidatorPubKey(ctx sdk.Context) (*types.ReplaceNodePubKey
 			}, nil
 
 		} else if ctx.BlockHeight() == (updateInfo.UpdateAtHeight + 2) { //delay remove old cons addr because of distribution rewards delayed by one block
-			k.RemoveValidatorByConsAddr(ctx, sdk.ConsAddress(updateInfo.OldConsAddress))
+			oldConsAddr := sdk.ConsAddress(updateInfo.OldConsAddress)
+			k.RemoveValidatorByConsAddr(ctx, oldConsAddr)
+			k.deleteValidatorSigningInfo(ctx, oldConsAddr)
 			k.DeleteReplaceConsensusPubKey(ctx)
 			ctx.EventManager().EmitEvent(
 				sdk.NewEvent(types.EventTypeDelayRemoveOldConsAddr,
 					sdk.NewAttribute(types.AttributeKeyOperatorAddress, updateInfo.OperatorAddress),
-					sdk.NewAttribute(types.AttributeKeyOldConsAddr, sdk.ConsAddress(updateInfo.OldConsAddress).String()),
+					sdk.NewAttribute(types.AttributeKeyOldConsAddr, oldConsAddr.String()),
 					sdk.NewAttribute(types.AttributeKeyUpdateAtHeight, fmt.Sprintf("%d", updateInfo.UpdateAtHeight)),
 					sdk.NewAttribute("height", fmt.Sprintf("%d", ctx.BlockHeight()))),
 			)
 			k.Logger(ctx).Info("completed delayed removed old cons addr from index", "old_cons_addr",
-				sdk.ConsAddress(updateInfo.OldConsAddress).String(), "height", ctx.BlockHeight())
+				oldConsAddr.String(), "height", ctx.BlockHeight())
 			return nil, nil
 
 		} else if ctx.BlockHeight() == (updateInfo.UpdateAtHeight + 1) {

--- a/x/wstaking/keeper/update_pub_key_test.go
+++ b/x/wstaking/keeper/update_pub_key_test.go
@@ -1,0 +1,75 @@
+package keeper_test
+
+import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
+)
+
+func (s *KeeperTestSuite) TestUpdateValidatorPubKeyDeletesOldSigningInfo() {
+	s.SetupTest()
+
+	validatorAddr, err := sdk.ValAddressFromBech32(s.meEarthValidator.OperatorAddress)
+	s.Require().NoError(err)
+
+	validator, found := s.Keeper().GetValidator(s.Ctx, validatorAddr)
+	s.Require().True(found)
+
+	oldConsAddr, err := validator.GetConsAddr()
+	s.Require().NoError(err)
+
+	oldSigningInfo := slashingtypes.NewValidatorSigningInfo(
+		oldConsAddr,
+		1,
+		7,
+		time.Unix(100, 0),
+		false,
+		3,
+	)
+	s.App.SlashingKeeper.SetValidatorSigningInfo(s.Ctx, oldConsAddr, oldSigningInfo)
+
+	newPubKey := ed25519.GenPrivKey().PubKey().(*ed25519.PubKey)
+	newPubKeyBytes, err := newPubKey.Marshal()
+	s.Require().NoError(err)
+	newConsAddr := sdk.GetConsAddress(newPubKey)
+	s.Require().NotEqual(oldConsAddr.String(), newConsAddr.String())
+
+	err = s.Keeper().SetReplacePubKeyInfo(s.Ctx, &wstakingtypes.UpdatePubKeyInfo{
+		OperatorAddress: validator.OperatorAddress,
+		OldConsAddress:  oldConsAddr.Bytes(),
+		PubKey:          newPubKeyBytes,
+		UpdateAtHeight:  20,
+	})
+	s.Require().NoError(err)
+
+	s.Ctx = s.Ctx.WithBlockHeight(20)
+	replaceInfo, err := s.Keeper().UpdateValidatorPubKey(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().NotNil(replaceInfo)
+
+	_, found = s.App.SlashingKeeper.GetValidatorSigningInfo(s.Ctx, oldConsAddr)
+	s.Require().True(found)
+	_, found = s.App.SlashingKeeper.GetValidatorSigningInfo(s.Ctx, newConsAddr)
+	s.Require().True(found)
+	_, found = s.Keeper().GetValidatorByConsAddr(s.Ctx, newConsAddr)
+	s.Require().True(found)
+
+	s.Ctx = s.Ctx.WithBlockHeight(22)
+	replaceInfo, err = s.Keeper().UpdateValidatorPubKey(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Nil(replaceInfo)
+
+	_, found = s.App.SlashingKeeper.GetValidatorSigningInfo(s.Ctx, oldConsAddr)
+	s.Require().False(found)
+	_, found = s.App.SlashingKeeper.GetValidatorSigningInfo(s.Ctx, newConsAddr)
+	s.Require().True(found)
+	_, found = s.Keeper().GetValidatorByConsAddr(s.Ctx, oldConsAddr)
+	s.Require().False(found)
+
+	updateInfo, err := s.Keeper().GetReplaceConsensusPubKeyInfo(s.Ctx)
+	s.Require().NoError(err)
+	s.Require().Nil(updateInfo)
+}


### PR DESCRIPTION
/claim #1249

## Summary
- keep the slashing store key available to the wstaking keeper during app wiring
- delete the old consensus address signing-info entry when pubkey replacement reaches the delayed cleanup block
- add regression coverage that the old slashing entry is removed while the new consensus address remains tracked

## Tests
- `go test ./x/wstaking/keeper -run 'TestKeeperTestSuite/TestUpdateValidatorPubKeyDeletesOldSigningInfo' -count=1 -v`\n- `go test ./x/wstaking/keeper -count=1`\n- `go test ./x/wstaking/... -count=1`\n- `go test ./... -count=1`\n- `git diff --check`\n\nBounty payout: $MEC via ME Pass wallet `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`