### PR TITLE
fix: make wgov tally query read-only

### DIFF
--- a/x/wgov/keeper/query.go
+++ b/x/wgov/keeper/query.go
@@ -42,7 +42,8 @@ func (q Keeper) MeTallyResult(c context.Context, req *types.QueryMeTallyResultRe
 
 	default:
 		// proposal is in voting period
-		_, _, tallyResult = q.Tally(ctx, proposal)
+		cacheCtx, _ := ctx.CacheContext()
+		_, _, tallyResult = q.Tally(cacheCtx, proposal)
 	}
 
 	return &types.QueryMeTallyResultResponse{Tally: &tallyResult}, nil

--- a/x/wgov/keeper/query_test.go
+++ b/x/wgov/keeper/query_test.go
@@ -1,0 +1,71 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	"github.com/openmetaearth/me-hub/x/wgov/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type KeeperTestSuite struct {
+	apptesting.KeeperTestHelper
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (s *KeeperTestSuite) SetupTest() {
+	app := apptesting.Setup(s.T(), false)
+	ctx := app.GetBaseApp().NewContext(false, tmproto.Header{}).WithChainID(apptesting.TestChainID)
+
+	s.Require().NoError(app.AccountKeeper.SetParams(ctx, authtypes.DefaultParams()))
+	s.Require().NoError(app.BankKeeper.SetParams(ctx, banktypes.DefaultParams()))
+	s.Require().NoError(app.GovKeeper.SetParams(ctx, govv1.DefaultParams()))
+
+	s.App = app
+	s.Ctx = ctx
+}
+
+func (s *KeeperTestSuite) TestMeTallyResultDoesNotDeleteVotesForActiveProposal() {
+	voter := s.NewAccounts(1)[0]
+	now := s.Ctx.BlockTime()
+	votingEnd := now.Add(time.Hour)
+	emptyTally := govv1.EmptyTallyResult()
+	const proposalID uint64 = 230
+
+	s.App.GovKeeper.SetProposal(s.Ctx, govv1.Proposal{
+		Id:               proposalID,
+		Status:           govv1.StatusVotingPeriod,
+		FinalTallyResult: &emptyTally,
+		SubmitTime:       &now,
+		DepositEndTime:   &votingEnd,
+		TotalDeposit:     sdk.Coins{},
+		VotingStartTime:  &now,
+		VotingEndTime:    &votingEnd,
+		Title:            "active proposal",
+		Summary:          "active proposal",
+		Proposer:         voter.String(),
+	})
+
+	vote := govv1.NewVote(proposalID, voter, govv1.NewNonSplitVoteOption(govv1.OptionYes), "")
+	s.App.GovKeeper.SetVote(s.Ctx, vote)
+
+	_, found := s.App.GovKeeper.GetVote(s.Ctx, proposalID, voter)
+	s.Require().True(found)
+
+	_, err := s.App.GovKeeper.MeTallyResult(sdk.WrapSDKContext(s.Ctx), &types.QueryMeTallyResultRequest{
+		ProposalId: proposalID,
+	})
+	s.Require().NoError(err)
+
+	_, found = s.App.GovKeeper.GetVote(s.Ctx, proposalID, voter)
+	s.Require().True(found, "MeTallyResult is a query and must not delete stored votes")
+}


### PR DESCRIPTION
/claim #230

## Summary
- Run `MeTallyResult` active-proposal tally in a cached context so the query cannot commit `Tally` side effects such as `DeleteVote`.
- Preserve the existing EndBlock tally path, where vote cleanup still happens on the real context.
- Add a regression that seeds an active proposal and vote, calls the query, and verifies the vote remains stored.

## Validation
- `go test ./x/wgov/keeper -run TestKeeperTestSuite/TestMeTallyResultDoesNotDeleteVotesForActiveProposal -count=1 -v`
- `go test ./x/wgov/... -count=1`
- `go test ./... -count=1`
- `git diff --check`
- `git diff --cached --check`

## Bug bounty payout
Meta Earth bug bounty payout in `$MEC` via ME Pass wallet:
`me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`