### PR TITLE
fix(ante): enforce base fee in deliver tx

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -97,7 +97,7 @@ func (suite *AnteTestSuite) TestCosmosAnteHandlerEip712() {
 	suite.mockDaoKeeper.EXPECT().GetGlobalDaoFeePoolAddr(gomock.Any()).Return(devOperator.GetAddress())
 	suite.mockDaoKeeper.EXPECT().CheckFreeGasAccount(gomock.Any(), addr.Address).Return(false)
 
-	amt := sdk.NewInt(100)
+	amt := sdk.NewInt(10001)
 	err := testutil.FundAccount(
 		suite.app.BankKeeper,
 		suite.ctx,
@@ -123,7 +123,7 @@ func (suite *AnteTestSuite) CreateTestEIP712CosmosTxBuilder(
 	priv cryptotypes.PrivKey, msgs []sdk.Msg,
 ) client.TxBuilder {
 	txConfig := suite.clientCtx.TxConfig
-	coinAmount := sdk.NewCoin(params.BaseDenom, sdk.NewInt(20))
+	coinAmount := sdk.NewCoin(params.BaseDenom, sdk.NewInt(10000))
 	fees := sdk.NewCoins(coinAmount)
 
 	pc, err := ethermint.ParseChainID(suite.ctx.ChainID())

--- a/app/ante/fee_checker_test.go
+++ b/app/ante/fee_checker_test.go
@@ -1,0 +1,54 @@
+package ante
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/stretchr/testify/require"
+)
+
+type feeCheckerTx struct {
+	fee sdk.Coins
+	gas uint64
+}
+
+func (tx feeCheckerTx) GetMsgs() []sdk.Msg         { return nil }
+func (tx feeCheckerTx) ValidateBasic() error       { return nil }
+func (tx feeCheckerTx) GetGas() uint64             { return tx.gas }
+func (tx feeCheckerTx) GetFee() sdk.Coins          { return tx.fee }
+func (tx feeCheckerTx) FeePayer() sdk.AccAddress   { return nil }
+func (tx feeCheckerTx) FeeGranter() sdk.AccAddress { return nil }
+
+func TestFeeCheckerRequiresMinimumBaseFeeInDeliverTx(t *testing.T) {
+	foreignFeeTx := feeCheckerTx{
+		fee: sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(100))),
+		gas: 200000,
+	}
+
+	for _, isCheckTx := range []bool{true, false} {
+		t.Run(map[bool]string{true: "check_tx", false: "deliver_tx"}[isCheckTx], func(t *testing.T) {
+			_, _, err := checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(isCheckTx), foreignFeeTx)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "fee must greater than or equal 10000"+params.BaseDenom)
+		})
+	}
+
+	baseFeeTx := feeCheckerTx{
+		fee: sdk.NewCoins(sdk.NewCoin(params.BaseDenom, sdk.NewInt(10000))),
+		gas: 200000,
+	}
+
+	fees, _, err := checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(false), baseFeeTx)
+	require.NoError(t, err)
+	require.Equal(t, baseFeeTx.fee, fees)
+
+	zeroFeeTx := feeCheckerTx{
+		fee: sdk.Coins{sdk.NewCoin("stake", sdk.ZeroInt())},
+		gas: 200000,
+	}
+
+	fees, _, err = checkTxFeeWithValidatorMinGasPrices(sdk.Context{}.WithIsCheckTx(false), zeroFeeTx)
+	require.NoError(t, err)
+	require.Equal(t, zeroFeeTx.fee, fees)
+}

--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -347,13 +347,14 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 	feeCoins := feeTx.GetFee()
 	gas := feeTx.GetGas()
 
+	if !feeCoins.IsZero() && !feeCoins.IsAllGTE(minimumFee) {
+		return sdk.Coins{}, 0, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "fee must greater than or equal %s: got %s", minimumFee.String(), feeCoins.String())
+	}
+
 	// Ensure that the provided fees meet a minimum threshold for the validator,
 	// if this is a CheckTx. This is only for local mempool purposes, and thus
 	// is only ran on check tx.
 	if ctx.IsCheckTx() {
-		if !feeCoins.IsAllGTE(minimumFee) {
-			return sdk.Coins{}, 0, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "fee must greater than or equal %s: got %s", minimumFee.String(), feeCoins.String())
-		}
 		minGasPrices := ctx.MinGasPrices()
 		if !minGasPrices.IsZero() {
 			requiredFees := make(sdk.Coins, len(minGasPrices))


### PR DESCRIPTION
Fixes #430

## Summary
- enforce the app-level `10000umec` minimum fee for non-zero fees in both CheckTx and DeliverTx
- keep validator `MinGasPrices` enforcement scoped to CheckTx/local mempool policy
- preserve existing zero-fee DeliverTx fixture behavior while rejecting foreign-only fees such as `100foo`
- add a regression proving foreign-only fees are rejected in both modes while valid `10000umec` and zero-fee DeliverTx compatibility cases still pass

## Validation
- `go test ./app/ante -run TestFeeCheckerRequiresMinimumBaseFeeInDeliverTx -count=1 -v`
- `go test ./ibctesting -run TestTransfersEnabledTestSuite/TestHubToRollappDisabled -count=1 -v`
- `go test ./app/ante -run 'Test(FeeCheckerRequiresMinimumBaseFeeInDeliverTx|AnteTestSuite/TestCosmosAnteHandlerEip712)$' -count=1 -v`
- `make test`
- `git diff --check`

Meta Earth bug bounty payout: `$MEC` via ME Pass wallet `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.
