### PR TITLE
fix(gravity): lock removed relayer unbonding until externally untrusted

### DIFF
--- a/x/gravity/keeper/abci_test.go
+++ b/x/gravity/keeper/abci_test.go
@@ -451,6 +451,72 @@ func (s *KeeperTestSuite) TestRelayerDelete() {
 	s.Require().False(found)
 }
 
+func (s *KeeperTestSuite) TestRemovedRelayerCannotUnbondUntilExternallyUntrusted() {
+	for i := 0; i < len(s.relayerAddrs); i++ {
+		msgBondedRelayer := &types.MsgBondedRelayer{
+			RelayerAddress:  s.relayerAddrs[i].String(),
+			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[i].PublicKey),
+			DelegateAmount:  sdk.NewCoin(params.BaseDenom, sdk.NewInt(10*1e8)),
+			ChainName:       s.chainName,
+		}
+		s.Require().NoError(msgBondedRelayer.ValidateBasic())
+		_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msgBondedRelayer)
+		s.Require().NoError(err)
+	}
+	s.App.EndBlock(abci.RequestEndBlock{Height: s.Ctx.BlockHeight()})
+	s.Ctx = s.Ctx.WithBlockHeight(s.Ctx.BlockHeight() + 1)
+
+	initialRelayerSet := s.Keeper().GetLastRelayerSet(s.Ctx)
+	s.Require().NotNil(initialRelayerSet)
+	s.Keeper().SetLastObservedRelayerSet(s.Ctx, initialRelayerSet)
+
+	externalAddress := s.PubKeyToExternalAddr(s.externalPris[0].PublicKey)
+	s.Require().True(relayerSetContainsExternalAddress(initialRelayerSet, externalAddress))
+
+	newRelayerAddressList := make([]string, 0, len(s.relayerAddrs)-1)
+	for _, address := range s.relayerAddrs[1:] {
+		newRelayerAddressList = append(newRelayerAddressList, address.String())
+	}
+	_, err := s.MsgServer().ProposalRelayers(s.Ctx, &types.MsgProposalRelayers{
+		Relayers:  newRelayerAddressList,
+		Authority: s.Dao.GlobalDao,
+		ChainName: s.chainName,
+	})
+	s.Require().NoError(err)
+	s.Ctx = s.Ctx.WithBlockHeight(s.Ctx.BlockHeight() + 1)
+	s.App.EndBlock(abci.RequestEndBlock{Height: s.Ctx.BlockHeight()})
+
+	latestRelayerSet := s.Keeper().GetLastRelayerSet(s.Ctx)
+	s.Require().NotNil(latestRelayerSet)
+	s.Require().False(relayerSetContainsExternalAddress(latestRelayerSet, externalAddress))
+
+	_, err = s.MsgServer().UnbondedRelayer(s.Ctx, &types.MsgUnbondedRelayer{
+		ChainName:      s.chainName,
+		RelayerAddress: s.relayerAddrs[0].String(),
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "last observed relayer set")
+
+	relayer, found := s.Keeper().GetRelayer(s.Ctx, s.relayerAddrs[0])
+	s.Require().True(found)
+	s.Require().False(relayer.Online)
+	relayerAddr, found := s.Keeper().GetRelayerByExternalAddress(s.Ctx, externalAddress)
+	s.Require().True(found)
+	s.Require().Equal(s.relayerAddrs[0].String(), relayerAddr.String())
+
+	s.Keeper().SetLastObservedRelayerSet(s.Ctx, latestRelayerSet)
+	_, err = s.MsgServer().UnbondedRelayer(s.Ctx, &types.MsgUnbondedRelayer{
+		ChainName:      s.chainName,
+		RelayerAddress: s.relayerAddrs[0].String(),
+	})
+	s.Require().NoError(err)
+
+	_, found = s.Keeper().GetRelayer(s.Ctx, s.relayerAddrs[0])
+	s.Require().False(found)
+	_, found = s.Keeper().GetRelayerByExternalAddress(s.Ctx, externalAddress)
+	s.Require().False(found)
+}
+
 func (s *KeeperTestSuite) TestRelayerSetSlash() {
 	for i := 0; i < len(s.relayerAddrs); i++ {
 		msgBondedRelayer := &types.MsgBondedRelayer{
@@ -552,4 +618,13 @@ func (s *KeeperTestSuite) TestSlashRelayer() {
 		// not online, not change
 		s.Require().Equal(int64(1), relayer.SlashTimes)
 	}
+}
+
+func relayerSetContainsExternalAddress(relayerSet *types.RelayerSet, externalAddress string) bool {
+	for _, member := range relayerSet.Members {
+		if member.ExternalAddress == externalAddress {
+			return true
+		}
+	}
+	return false
 }

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -148,6 +148,10 @@ func (s MsgServer) UnbondedRelayer(c context.Context, msg *types.MsgUnbondedRela
 		return nil, errorsmod.Wrap(types.ErrInvalid, "relayer on line")
 	}
 
+	if s.relayerExternalAddressInLastObservedSet(ctx, relayer.ExternalAddress) {
+		return nil, errorsmod.Wrapf(types.ErrInvalid, "relayer external address %s is still trusted by the last observed relayer set", relayer.ExternalAddress)
+	}
+
 	slashAmount := relayer.GetSlashAmount(s.GetSlashFraction(ctx))
 	if slashAmount.IsPositive() {
 		if err := s.bankKeeper.SendCoinsFromModuleToModule(ctx, s.moduleName, types.SlashingModuleAccount, sdk.NewCoins(slashAmount)); err != nil {

--- a/x/gravity/keeper/relayer_set.go
+++ b/x/gravity/keeper/relayer_set.go
@@ -263,6 +263,20 @@ func (k Keeper) GetLastObservedRelayerSet(ctx sdk.Context) *types.RelayerSet {
 	return &relayerSet
 }
 
+func (k Keeper) relayerExternalAddressInLastObservedSet(ctx sdk.Context, externalAddress string) bool {
+	lastObserved := k.GetLastObservedRelayerSet(ctx)
+	if lastObserved == nil {
+		return false
+	}
+
+	for _, member := range lastObserved.Members {
+		if member.ExternalAddress == externalAddress {
+			return true
+		}
+	}
+	return false
+}
+
 // SetLastObservedRelayerSet updates the last observed relayer set in the store
 func (k Keeper) SetLastObservedRelayerSet(ctx sdk.Context, relayerSet *types.RelayerSet) {
 	store := ctx.KVStore(k.storeKey)


### PR DESCRIPTION
Fixes #303

## Summary
- reject `MsgUnbondedRelayer` while the relayer's external signing key is still present in `LastObservedRelayerSet`
- keep bonded stake, relayer state, external-address mapping, and last-event nonce intact when the external bridge still trusts the key
- allow unbonding after the externally observed relayer set advances to one that no longer contains the removed key
- add a keeper regression for the unsafe transition window and the safe release path

## Validation
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestRemovedRelayerCannotUnbondUntilExternallyUntrusted' -count=1 -v`
- `go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(RelayerDelete|RemovedRelayerCannotUnbondUntilExternallyUntrusted|RelayerSetSlash|SlashRelayer)$' -count=1 -v`
- `go test ./x/gravity/keeper -count=1`
- `go test ./x/gravity/... -count=1`
- `go test ./... -count=1`
- `git diff --check`

## Bounty
Meta Earth bug bounty payout in `$MEC` via ME Pass wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`
