### PR TITLE
fix: gate gravity attestations on observed relayers

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -78,8 +78,10 @@ func (k Keeper) Attest(ctx sdk.Context, relayerAddr sdk.AccAddress, claim types.
 func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim types.ExternalClaim) {
 	// If the attestation has not yet been Observed, sum up the votes and see if it is ready to apply to the state.
 	// This conditional stops the attestation from accidentally being applied twice.
-	// Sum the current powers of all validators who have voted and see if it passes the current threshold
-	totalPower := k.GetLastTotalPower(ctx)
+	// Sum the powers trusted by the external bridge. After the first relayer
+	// set has been observed, local relayer changes are not trusted for
+	// external claims until the bridge observes that new set.
+	observedRelayerPowers, totalPower, useObservedRelayerSet := k.attestationObservedRelayerPowers(ctx)
 	if !totalPower.IsPositive() {
 		k.Logger(ctx).Error("TryAttestation", "non-positive total relayer power", totalPower.String(),
 			"claimEventNonce", claim.GetEventNonce(), "claimType", claim.GetType(), "claimHeight", claim.GetBlockHeight())
@@ -101,6 +103,16 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 			continue
 		}
 		relayerPower := relayer.GetPower()
+		if useObservedRelayerSet {
+			observedPower, trusted := observedRelayerPowers[relayer.ExternalAddress]
+			if !trusted {
+				k.Logger(ctx).Info("TryAttestation", "relayer not in last observed relayer set", relayerAddr.String(),
+					"externalAddress", relayer.ExternalAddress, "claimEventNonce", claim.GetEventNonce(),
+					"claimType", claim.GetType(), "claimHeight", claim.GetBlockHeight())
+				continue
+			}
+			relayerPower = observedPower
+		}
 		// Add it to the attestation power's sum
 		attestationPower = attestationPower.Add(relayerPower)
 		if attestationPower.LT(requiredPower) {
@@ -128,6 +140,26 @@ func (k Keeper) TryAttestation(ctx sdk.Context, att *types.Attestation, claim ty
 		}
 		break
 	}
+}
+
+func (k Keeper) attestationObservedRelayerPowers(ctx sdk.Context) (map[string]sdkmath.Int, sdkmath.Int, bool) {
+	lastObservedRelayerSet := k.GetLastObservedRelayerSet(ctx)
+	if lastObservedRelayerSet == nil || len(lastObservedRelayerSet.Members) == 0 {
+		return nil, k.GetLastTotalPower(ctx), false
+	}
+
+	powers := make(map[string]sdkmath.Int, len(lastObservedRelayerSet.Members))
+	totalPower := sdkmath.ZeroInt()
+	for _, member := range lastObservedRelayerSet.Members {
+		power := sdkmath.NewIntFromUint64(member.Power)
+		if !power.IsPositive() {
+			continue
+		}
+		powers[member.ExternalAddress] = power
+		totalPower = totalPower.Add(power)
+	}
+
+	return powers, totalPower, true
 }
 
 // processAttestation actually applies the attestation to the consensus state

--- a/x/gravity/keeper/audit_findings_test.go
+++ b/x/gravity/keeper/audit_findings_test.go
@@ -11,6 +11,7 @@ package keeper_test
 //   GRAV-001  Attest must reject historical-nonce claims (no backward rewind)
 //   GRAV-004  Failed AttestationHandler must not advance lastObservedEventNonce
 //   GRAV-005  Zero-total-power attestations must not satisfy quorum
+//   GRAV-006  Newly bonded relayer votes count only after external observation
 
 import (
 	"encoding/hex"
@@ -244,6 +245,81 @@ func (s *KeeperTestSuite) TestGrav005_TryAttestationRejectsZeroTotalPower() {
 }
 
 // ---------------------------------------------------------------------------
+// GRAV-006: Newly bonded relayers must not vote before external observation
+// ---------------------------------------------------------------------------
+//
+// Local bonding updates LastTotalPower immediately, but the external bridge
+// still trusts the last observed relayer set until a relayer-set update claim
+// advances it. External event attestations must therefore use the observed set
+// powers, not the current local relayer powers.
+func (s *KeeperTestSuite) TestGrav006_NewRelayerVoteWaitsForObservedSet() {
+	k := s.Keeper()
+	s.bondGravityRelayerForAuditTest(0, 300_000_000)
+	s.bondGravityRelayerForAuditTest(1, 300_000_000)
+	s.bondGravityRelayerForAuditTest(2, 400_000_000)
+
+	s.Ctx = s.Ctx.WithBlockHeight(1)
+	k.EndBlocker(s.Ctx)
+	observedSet := k.GetLastRelayerSet(s.Ctx)
+	s.Require().NotNil(observedSet)
+	s.Require().Len(observedSet.Members, 3)
+	k.SetLastObservedRelayerSet(s.Ctx, observedSet)
+
+	tokenContract := "0x0000000000000000000000000000000000000403"
+	bridgeToken := types.BridgeToken{
+		ContractAddress: tokenContract,
+		Denom:           "uusdt",
+		Name:            "Tether USD",
+		Symbol:          "USDT",
+		Decimal:         6,
+		Supply:          sdkmath.ZeroInt(),
+	}
+	k.SetBridgeToken(s.Ctx, &bridgeToken)
+
+	s.bondGravityRelayerForAuditTest(3, 200_000_000)
+	s.Ctx = s.Ctx.WithBlockHeight(2)
+	k.EndBlocker(s.Ctx)
+	latestSet := k.GetLastRelayerSet(s.Ctx)
+	s.Require().NotNil(latestSet)
+	s.Require().Len(latestSet.Members, 4)
+
+	receiver := s.relayerAddrs[5]
+	claim := &types.MsgSendToMeClaim{
+		EventNonce:     2,
+		BlockHeight:    2,
+		TokenContract:  tokenContract,
+		Amount:         sdkmath.NewInt(12_345),
+		Sender:         "0x0000000000000000000000000000000000000503",
+		Receiver:       receiver.String(),
+		RelayerAddress: s.relayerAddrs[3].String(),
+		ChainName:      s.chainName,
+	}
+	votes := []string{
+		s.relayerAddrs[0].String(),
+		s.relayerAddrs[1].String(),
+		s.relayerAddrs[3].String(),
+	}
+
+	earlyAttestation := &types.Attestation{Votes: votes}
+	k.TryAttestation(s.Ctx, earlyAttestation, claim)
+
+	s.Require().False(earlyAttestation.Observed,
+		"GRAV-006: new relayer vote must not satisfy quorum before external observation")
+	s.Require().True(s.App.BankKeeper.GetBalance(s.Ctx, receiver, bridgeToken.Denom).Amount.IsZero(),
+		"GRAV-006: send-to-me claim minted before the external bridge trusted the new relayer")
+
+	k.SetLastObservedRelayerSet(s.Ctx, latestSet)
+	observedAttestation := &types.Attestation{Votes: votes}
+	k.TryAttestation(s.Ctx, observedAttestation, claim)
+
+	minted := types.GetMintCoin(claim.Amount, claim.ChainName, &bridgeToken)
+	balance := s.App.BankKeeper.GetBalance(s.Ctx, receiver, minted.Denom)
+	s.Require().True(observedAttestation.Observed,
+		"GRAV-006: same votes should satisfy quorum after the external observed set includes the new relayer")
+	s.Require().Equal(minted.Amount, balance.Amount)
+}
+
+// ---------------------------------------------------------------------------
 // Helper: bond relayers, confirm and observe the initial relayer set.
 // Mirrors the opening of TestRequestBatchBaseFee in msg_server_test.go, but
 // stops before BridgeTokenClaim so the state is a clean "bridge initialized,
@@ -320,4 +396,15 @@ func (s *KeeperTestSuite) setupBondedRelayerSetForAuditTest() {
 		s.Require().NoError(err)
 	}
 	s.Keeper().EndBlocker(s.Ctx)
+}
+
+func (s *KeeperTestSuite) bondGravityRelayerForAuditTest(relayerIndex int, amount int64) {
+	msg := &types.MsgBondedRelayer{
+		RelayerAddress:  s.relayerAddrs[relayerIndex].String(),
+		ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[relayerIndex].PublicKey),
+		DelegateAmount:  sdk.NewCoin(params.BaseDenom, sdkmath.NewInt(amount)),
+		ChainName:       s.chainName,
+	}
+	_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msg)
+	s.Require().NoError(err)
 }


### PR DESCRIPTION
Fixes #403

## Summary
- count external event attestation votes against the last externally observed relayer set once one exists
- ignore votes from locally bonded relayers whose external key is not yet in the observed set
- keep the existing bootstrap fallback for the first observed relayer set
- add regression coverage for the unsafe A+B+D quorum window before and after the observed set advances

## Tests
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/TestGrav006_NewRelayerVoteWaitsForObservedSet' -count=1 -v
- go test ./x/gravity/keeper -run 'TestGravityKeeperTestSuite/Test(Grav006_NewRelayerVoteWaitsForObservedSet|Grav005_TryAttestationRejectsZeroTotalPower|AttestationAfterRelayerUpdate|DepositClaim|ClaimMsgGasConsumed|RelayerDelete|RelayerSetSlash|SlashRelayer)$' -count=1 -v
- go test ./x/gravity/keeper -count=1
- go test ./x/gravity/... -count=1
- go test ./... -count=1
- git diff --check

Payout note: Meta Earth bug bounty payout in $MEC via ME Pass wallet `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.