### PR TITLE
fix(wstaking): make kyc region transfer accounting atomic

### DIFF
--- a/x/wstaking/keeper/kyc_region.go
+++ b/x/wstaking/keeper/kyc_region.go
@@ -66,40 +66,42 @@ func (k Keeper) TransferKycRegion(ctx sdk.Context, address sdk.AccAddress, creat
 	if !found {
 		return types.ErrNoDelegatorForAddress
 	}
-	delegation.ValidatorAddress = toRegion.OperatorAddress
-	k.SetDelegation(ctx, delegation)
 
-	// Handling fixed deposits
-	err := k.transferDeposit(ctx, &fromRegion, &toRegion, address.String())
-	if err != nil {
-		return types.ErrTransferRegion.Wrap(err.Error())
-	}
-
-	// fix validator meid amount
-	validator.DelegationAmount = validator.DelegationAmount.Add(delegation.Amount)
-	if validator.Tokens.LT(validator.DelegationAmount) {
+	nextDelegationAmount := validator.DelegationAmount.Add(delegation.Amount)
+	if validator.Tokens.LT(nextDelegationAmount) {
 		return types.ErrNodeLimitExceeded
 	}
-	if validator.MeidAmount.Add(types.Bonus).GT(validator.Tokens) {
+	nextMeidAmount := validator.MeidAmount.Add(types.Bonus)
+	if nextMeidAmount.GT(validator.Tokens) {
 		return types.ErrTransferRegion.Wrap(fmt.Sprintf("meid bonded validator can not hold this meid user, reach meid limit"))
 	}
-	validator.MeidAmount = validator.MeidAmount.Add(types.Bonus)
-	k.SetValidator(ctx, validator)
 
-	err = k.transferRemoveMeid(ctx, address.String(), &fromRegion, delegation)
+	cacheCtx, writeCache := ctx.CacheContext()
+
+	// Handling fixed deposits
+	err := k.transferDeposit(cacheCtx, &fromRegion, &toRegion, address.String())
 	if err != nil {
 		return types.ErrTransferRegion.Wrap(err.Error())
 	}
 
-	err = k.transferNewMeid(ctx, &toRegion, address.String(), valAddr, delegation)
+	err = k.transferRemoveMeid(cacheCtx, address.String(), &fromRegion, delegation)
 	if err != nil {
 		return types.ErrTransferRegion.Wrap(err.Error())
 	}
 
-	k.SetRegion(ctx, fromRegion)
-	k.SetRegion(ctx, toRegion)
+	validator.DelegationAmount = nextDelegationAmount
+	validator.MeidAmount = nextMeidAmount
+	k.SetValidator(cacheCtx, validator)
 
-	ctx.EventManager().EmitEvents(sdk.Events{
+	err = k.transferNewMeid(cacheCtx, &toRegion, address.String(), valAddr, delegation)
+	if err != nil {
+		return types.ErrTransferRegion.Wrap(err.Error())
+	}
+
+	k.SetRegion(cacheCtx, fromRegion)
+	k.SetRegion(cacheCtx, toRegion)
+
+	cacheCtx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			types.EventTransferRegion,
 			sdk.NewAttribute(sdk.AttributeKeySender, creator),
@@ -109,5 +111,6 @@ func (k Keeper) TransferKycRegion(ctx sdk.Context, address sdk.AccAddress, creat
 			sdk.NewAttribute(types.AttributeKeyRewards, types.Bonus.String()+params.BaseDenom),
 		),
 	})
+	writeCache()
 	return nil
 }

--- a/x/wstaking/keeper/kyc_region_test.go
+++ b/x/wstaking/keeper/kyc_region_test.go
@@ -69,3 +69,76 @@ func (s *KeeperTestSuite) TestTransferKycRegion() {
 	s.Require().Equal(delegation.ValidatorAddress, s.usaValidator.OperatorAddress)
 	s.Require().EqualValues(delegation.StartHeight, wmintTypes.OneDayTotalBlocks+1)
 }
+
+func (s *KeeperTestSuite) TestTransferKycRegionDoesNotCommitPartialStateOnError() {
+	s.SetupTest()
+
+	newRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            types.MeEarthRegionName,
+		OperatorAddress: s.meEarthValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	newRegion = types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            "USA",
+		OperatorAddress: s.usaValidator.OperatorAddress,
+	}
+	_, err = s.msgServer.NewRegion(s.Ctx, &newRegion)
+	s.Require().NoError(err)
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+
+	kycAccount := sdk.MustAccAddressFromBech32(s.Dao.DevOperator)
+	err = s.Keeper().KycReward(s.Ctx, kycAccount, s.meEarthValidator.Description.RegionID, s.Dao.GlobalDao)
+	s.Require().NoError(err)
+
+	fromRegion, found := s.Keeper().GetRegion(s.Ctx, strings.ToLower(types.MeEarthRegionName))
+	s.Require().True(found)
+	toRegion, found := s.Keeper().GetRegion(s.Ctx, s.usaValidator.Description.RegionID)
+	s.Require().True(found)
+
+	delegationBefore, found := s.Keeper().GetDelegation(s.Ctx, kycAccount, sdk.ValAddress{})
+	s.Require().True(found)
+
+	fromValAddr, err := sdk.ValAddressFromBech32(fromRegion.OperatorAddress)
+	s.Require().NoError(err)
+	toValAddr, err := sdk.ValAddressFromBech32(toRegion.OperatorAddress)
+	s.Require().NoError(err)
+
+	fromValidatorBefore, found := s.Keeper().GetValidator(s.Ctx, fromValAddr)
+	s.Require().True(found)
+	toValidatorBefore, found := s.Keeper().GetValidator(s.Ctx, toValAddr)
+	s.Require().True(found)
+
+	fromRegion.DelegateAmount = sdk.ZeroInt()
+	s.Keeper().SetRegion(s.Ctx, fromRegion)
+	corruptedFromRegion := fromRegion
+
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks + 1).WithChainID(apptesting.TestChainID)
+
+	err = s.Keeper().TransferKycRegion(s.Ctx, kycAccount, s.Dao.GlobalDao, s.meEarthValidator.Description.RegionID, s.usaValidator.Description.RegionID)
+	s.Require().Error(err)
+
+	delegationAfter, found := s.Keeper().GetDelegation(s.Ctx, kycAccount, sdk.ValAddress{})
+	s.Require().True(found)
+	s.Require().Equal(delegationBefore, delegationAfter)
+
+	fromRegionAfter, found := s.Keeper().GetRegion(s.Ctx, strings.ToLower(types.MeEarthRegionName))
+	s.Require().True(found)
+	s.Require().Equal(corruptedFromRegion, fromRegionAfter)
+	toRegionAfter, found := s.Keeper().GetRegion(s.Ctx, s.usaValidator.Description.RegionID)
+	s.Require().True(found)
+	s.Require().Equal(toRegion, toRegionAfter)
+
+	fromValidatorAfter, found := s.Keeper().GetValidator(s.Ctx, fromValAddr)
+	s.Require().True(found)
+	s.Require().Equal(fromValidatorBefore, fromValidatorAfter)
+	toValidatorAfter, found := s.Keeper().GetValidator(s.Ctx, toValAddr)
+	s.Require().True(found)
+	s.Require().Equal(toValidatorBefore, toValidatorAfter)
+}


### PR DESCRIPTION
Fixes #103

## Summary
- stop updating the delegation and target validator before the KYC region transfer has completed
- validate target validator capacity up front, then apply fixed deposits, source removal, target validator accounting, destination region accounting, and delegation movement through a cache context
- add regression coverage proving a late transfer failure does not persist partial delegation, validator, or region state

## Validation
- `go test ./x/wstaking/keeper`
- `go test ./x/wstaking/... ./x/kyc/...`
- `git diff --check`

Meta Earth bug bounty payout: `$MEC` via ME Pass wallet `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`.
