### PR TITLE
fix(wstaking): queue regular delegation unbonding

### DIFF
--- a/x/wstaking/keeper/delegation.go
+++ b/x/wstaking/keeper/delegation.go
@@ -22,29 +22,17 @@ const unbondingTime = time.Hour * 24 * 7
 // an unbonding object and inserting it into the unbonding queue which will be
 // processed during the staking EndBlocker.
 func (k Keeper) Undelegate(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, isMeid bool, amount math.Int, delegation stakingtypes.Delegation) (time.Time, math.Int, error) {
-	if !isMeid {
-		if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
-			return time.Time{}, amount, stakingtypes.ErrMaxUnbondingDelegationEntries
-		}
+	if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
+		return time.Time{}, amount, stakingtypes.ErrMaxUnbondingDelegationEntries
 	}
 	returnAmount, err := k.Unbond(ctx, amount, isMeid, delegation)
 	if err != nil {
 		return time.Time{}, amount, err
 	}
-	completionTime := ctx.BlockHeader().Time
-	// transfer the validator tokens to the not bonded pool
-	if !isMeid {
-		k.bondedTokensToNotBonded(ctx, returnAmount)
-		completionTime = ctx.BlockHeader().Time.Add(unbondingTime)
-		ubd := k.SetUnbondingDelegationEntry(ctx, delAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
-		k.InsertUBDQueue(ctx, ubd, completionTime)
-	} else {
-		amt := sdk.NewCoin(params.BaseDenom, returnAmount)
-		err = k.bankKeeper.UndelegateCoinsFromModuleToAccount(ctx, stakingtypes.BondedPoolName, delAddr, sdk.NewCoins(amt))
-		if err != nil {
-			return completionTime, returnAmount, err
-		}
-	}
+	k.bondedTokensToNotBonded(ctx, returnAmount)
+	completionTime := ctx.BlockHeader().Time.Add(unbondingTime)
+	ubd := k.SetUnbondingDelegationEntry(ctx, delAddr, valAddr, ctx.BlockHeight(), completionTime, returnAmount)
+	k.InsertUBDQueue(ctx, ubd, completionTime)
 	return completionTime, returnAmount, nil
 }
 

--- a/x/wstaking/keeper/msg_server_delegate_test.go
+++ b/x/wstaking/keeper/msg_server_delegate_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"time"
+
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	mintypes "github.com/cosmos/cosmos-sdk/x/mint/types"
@@ -164,4 +166,62 @@ func (s *KeeperTestSuite) TestUnDelegate() {
 			}
 		})
 	}
+}
+
+func (s *KeeperTestSuite) TestUnDelegateRegularDelegationUsesUnbondingQueue() {
+	s.SetupTest()
+
+	newMeEarthRegion := types.MsgNewRegion{
+		Creator:         s.Dao.GlobalDao,
+		Name:            types.MeEarthRegionName,
+		OperatorAddress: s.meEarthValidator.OperatorAddress,
+	}
+	_, err := s.msgServer.NewRegion(s.Ctx, &newMeEarthRegion)
+	s.Require().NoError(err)
+
+	region, found := s.App.StakingKeeper.GetRegion(s.Ctx, types.MeEarthRegionId)
+	s.Require().True(found)
+
+	err = s.App.BankKeeper.SendCoinsFromModuleToAccount(
+		s.Ctx,
+		mintypes.ModuleName,
+		sdk.MustAccAddressFromBech32(region.GetRegionTreasureAddr()),
+		sdk.Coins{sdk.NewInt64Coin(params.BaseDenom, 1000000000000)},
+	)
+	s.Require().NoError(err)
+
+	blockTime := time.Unix(1000, 0).UTC()
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{Time: blockTime}).WithBlockHeight(5).WithChainID(apptesting.TestChainID)
+
+	delegatorAddr := sdk.MustAccAddressFromBech32(s.Dao.GlobalDao)
+	valAddr, err := sdk.ValAddressFromBech32(s.meEarthValidator.OperatorAddress)
+	s.Require().NoError(err)
+
+	amount := sdk.NewCoin(params.BaseDenom, sdk.NewInt(1000000))
+	_, err = s.msgServer.Delegate(s.Ctx, &stakingtypes.MsgDelegate{
+		DelegatorAddress: s.Dao.GlobalDao,
+		ValidatorAddress: "",
+		Amount:           amount,
+	})
+	s.Require().NoError(err)
+
+	balanceAfterDelegate := s.App.BankKeeper.GetBalance(s.Ctx, delegatorAddr, params.BaseDenom)
+	resp, err := s.msgServer.Undelegate(s.Ctx, &stakingtypes.MsgUndelegate{
+		DelegatorAddress: s.Dao.GlobalDao,
+		ValidatorAddress: "",
+		Amount:           amount,
+	})
+	s.Require().NoError(err)
+
+	expectedCompletion := blockTime.Add(7 * 24 * time.Hour)
+	s.Require().Equal(expectedCompletion, resp.CompletionTime)
+
+	balanceAfterUndelegate := s.App.BankKeeper.GetBalance(s.Ctx, delegatorAddr, params.BaseDenom)
+	s.Require().Equal(balanceAfterDelegate.Amount.String(), balanceAfterUndelegate.Amount.String())
+
+	ubd, found := s.Keeper().GetUnbondingDelegation(s.Ctx, delegatorAddr, valAddr)
+	s.Require().True(found)
+	s.Require().Len(ubd.Entries, 1)
+	s.Require().Equal(amount.Amount.String(), ubd.Entries[0].Balance.String())
+	s.Require().Equal(expectedCompletion, ubd.Entries[0].CompletionTime)
 }


### PR DESCRIPTION
Fixes #53

## Summary
- route regular non-Experience delegation undelegations through the standard unbonding queue instead of returning bonded-pool funds immediately
- enforce max unbonding delegation entries for every queued undelegation path
- add a regression test proving regular delegation principal stays locked and matures after the 7-day completion time

## Validation
- go test ./x/wstaking/keeper -run TestKeeperTestSuite/TestUnDelegateRegularDelegationUsesUnbondingQueue -count=1
- go test ./x/wstaking/keeper -count=1
- go test ./x/wstaking/... -count=1
- go test ./... -count=1

## Payout
Meta Earth bug-bounty payout in $MEC via ME Pass wallet: me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j