### PR TITLE
ci: add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+## Summary
+
+<!-- Describe what changed and why. Keep this focused on behavior and impact. -->
+
+- 
+
+## Related Issues
+
+<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->
+
+- Fixes #
+
+## Type of Change
+
+- [ ] `feat` New feature
+- [ ] `fix` Bug fix
+- [ ] `refactor` Internal refactor
+- [ ] `docs` Documentation only
+- [ ] `test` Test-only change
+- [ ] `chore` Build, tooling, or maintenance
+
+## Validation
+
+<!-- List what you ran locally and any important results. -->
+
+- [ ] `make test`
+- [ ] `make lint`
+- [ ] Manual verification completed
+- [ ] Not applicable
+
+### Validation Notes
+
+<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->
+
+- 
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
+- [ ] I self-reviewed the diff
+- [ ] I updated tests for changed behavior, or explained why tests are not needed
+- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
+- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
+- [ ] I called out breaking changes, migrations, or operator impact below
+
+## Breaking Changes / Migration Notes
+
+<!-- Describe required migration, config, state, API, or deployment follow-up. -->
+
+- None
+
+## Additional Context
+
+<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->
+
+- 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,123 @@
+name: Auto Changelog Update
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_changelog_auto:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Check if "auto-changelog-update-do-not-create-manually" branch exists
+        id: check_branch
+        run: |
+          if [ -n "$(git ls-remote --heads origin auto-changelog-update-do-not-create-manually)" ]; then
+            git fetch origin auto-changelog-update-do-not-create-manually
+            echo "branch_exists=true" >> $GITHUB_ENV
+          else
+            echo "branch_exists=false" >> $GITHUB_ENV
+          fi
+
+      - name: Generate Changelog Update and update if branch exists
+        run: |
+          npm install -g conventional-changelog-cli
+          if [ "$branch_exists" == "true" ]; then
+            git checkout auto-changelog-update-do-not-create-manually
+            git merge main --strategy-option theirs --allow-unrelated-histories --no-edit
+            conventional-changelog -p angular -i CHANGELOG.md -s -r 0 
+            sed -i '1i # Changelog\n## [Unreleased]\n' CHANGELOG.md
+            git add CHANGELOG.md
+            git commit -m "Update CHANGELOG.md [skip ci]"
+            git push origin auto-changelog-update-do-not-create-manually
+            exit 0
+          else
+            git checkout main
+            git checkout -b auto-changelog-update-do-not-create-manually
+            conventional-changelog -p angular -i CHANGELOG.md -s -r 0
+            sed -i '1i # Changelog\n## [Unreleased]\n' CHANGELOG.md
+            git add CHANGELOG.md
+            git commit -m "Update CHANGELOG.md [skip ci]"
+            git push origin auto-changelog-update-do-not-create-manually
+          fi
+
+      - name: Create Pull Request
+        if: env.branch_exists == 'false'
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update CHANGELOG.md [skip ci]"
+          title: "Chore(changelog): Automated Changelog Update [skip ci]"
+          body: "Update the CHANGELOG.md with recent pushes to branch main."
+          base: "main"
+          branch: "auto-changelog-update-do-not-create-manually"
+          delete-branch: true
+
+      - name: Check outputs
+        if: env.branch_exists == 'false'
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+
+      - name: Log if PR updated
+        if: steps.cpr.outputs.pull-request-operation == 'updated'
+        run: |
+          echo "Changelog PR updated due to new commit to main."
+
+  update_changelog_manually:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout the repository
+          uses: actions/checkout@v6
+          with:
+            fetch-depth: 0
+        
+        - name: Setup Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version: '18'
+        
+        - name: Configure Git
+          run: |
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+        
+        - name: Check if "manually-changelog-update" branch exists
+          id: check_branch
+          run: |
+            if [ -n "$(git ls-remote --heads origin manually-changelog-update)" ]; then
+              git branch -d manually-changelog-update
+              echo "branch_exists=true" >> $GITHUB_ENV
+            else
+              echo "branch_exists=false" >> $GITHUB_ENV
+            fi
+        
+        - name: Generate Changelog Update and update if branch exists
+          run: |
+            npm install -g conventional-changelog-cli
+            git checkout -b manually-changelog-update
+            conventional-changelog -p angular -i CHANGELOG.md -s -r 0
+            sed -i '1i # Changelog\n## [Unreleased]\n' CHANGELOG.md
+            git add CHANGELOG.md
+            git commit -m "Update CHANGELOG.md [skip ci]"
+            git push origin manually-changelog-update
+            


### PR DESCRIPTION
## Summary

- add a default `.github/pull_request_template.md` to standardize pull request descriptions for `me-hub`
- add `.github/workflows/changelog.yml` to automate `CHANGELOG.md` update PR creation on pushes to `main` and support manual triggering
- align contributor workflow expectations with the repository's existing Conventional Commit and validation conventions

## Related Issues

- None

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [x] `chore` Build, tooling, or maintenance

## Validation

- [ ] `make test`
- [ ] `make lint`
- [x] Manual verification completed
- [ ] Not applicable

### Validation Notes

- reviewed the PR template structure against the repository's PR title and review expectations
- reviewed the changelog workflow trigger conditions, branch handling, and PR creation steps
- confirmed GitHub checks are passing on this PR: `Cleanup caches by a branch`, `Lint PR`, `Tests`

## Checklist

- [x] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [x] I self-reviewed the diff
- [x] I updated tests for changed behavior, or explained why tests are not needed
- [x] I updated docs/comments if user-facing behavior or developer workflow changed
- [x] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [x] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

- None

## Additional Context

- this PR only changes GitHub collaboration and automation files; it does not modify chain runtime behavior
