### PR TITLE
fix(eibc): make order fulfillment atomic

### DIFF
--- a/x/eibc/keeper/msg_server.go
+++ b/x/eibc/keeper/msg_server.go
@@ -51,19 +51,23 @@ func (m msgServer) FulfillOrder(goCtx context.Context, msg *types.MsgFulfillOrde
 		return nil, types.ErrFulfillerAddressDoesNotExist
 	}
 
+	cacheCtx, writeCache := ctx.CacheContext()
+
 	// Send the funds from the fulfiller to the eibc packet original recipient
-	err = m.bk.SendCoins(ctx, fulfillerAccount.GetAddress(), demandOrder.GetRecipientBech32Address(), demandOrder.Price)
+	err = m.bk.SendCoins(cacheCtx, fulfillerAccount.GetAddress(), demandOrder.GetRecipientBech32Address(), demandOrder.Price)
 	if err != nil {
 		logger.Error("Failed to send coins", "error", err)
 		return nil, err
 	}
 	// Fulfill the order by updating the order status and underlying packet recipient
-	err = m.Keeper.SetOrderFulfilled(ctx, demandOrder, fulfillerAccount.GetAddress())
+	err = m.Keeper.SetOrderFulfilled(cacheCtx, demandOrder, fulfillerAccount.GetAddress())
 	if err != nil {
 		return nil, err
 	}
 
-	return &types.MsgFulfillOrderResponse{}, err
+	writeCache()
+
+	return &types.MsgFulfillOrderResponse{}, nil
 }
 
 // UpdateDemandOrder implements types.MsgServer.

--- a/x/eibc/keeper/msg_server_test.go
+++ b/x/eibc/keeper/msg_server_test.go
@@ -144,6 +144,34 @@ func (suite *KeeperTestSuite) TestMsgFulfillOrder() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestFulfillOrderRollsBackWhenFulfillmentHookFails() {
+	testAddresses := apptesting.AddTestAddrs(suite.App, suite.Ctx, 2, sdk.NewInt(1000))
+	eibcSupplyAddr := testAddresses[0]
+	eibcDemandAddr := testAddresses[1]
+
+	price := math.NewInt(200)
+	fee := math.NewInt(50)
+	demandOrder := types.NewDemandOrder(*rollappPacket, price, fee, params.BaseDenom, eibcSupplyAddr.String())
+	err := suite.App.EIBCKeeper.SetDemandOrder(suite.Ctx, demandOrder)
+	suite.Require().NoError(err)
+
+	supplyBalanceBefore := suite.App.BankKeeper.GetBalance(suite.Ctx, eibcSupplyAddr, params.BaseDenom)
+	demandBalanceBefore := suite.App.BankKeeper.GetBalance(suite.Ctx, eibcDemandAddr, params.BaseDenom)
+
+	suite.Ctx = suite.Ctx.WithEventManager(sdk.NewEventManager())
+	msg := types.NewMsgFulfillOrder(eibcDemandAddr.String(), demandOrder.Id, fee.String())
+	_, err = suite.msgServer.FulfillOrder(suite.Ctx, msg)
+	suite.Require().ErrorIs(err, dacktypes.ErrRollappPacketDoesNotExist)
+
+	storedOrder, err := suite.App.EIBCKeeper.GetDemandOrder(suite.Ctx, commontypes.Status_PENDING, demandOrder.Id)
+	suite.Require().NoError(err)
+	suite.Require().False(storedOrder.IsFulfilled())
+
+	suite.Require().Equal(supplyBalanceBefore, suite.App.BankKeeper.GetBalance(suite.Ctx, eibcSupplyAddr, params.BaseDenom))
+	suite.Require().Equal(demandBalanceBefore, suite.App.BankKeeper.GetBalance(suite.Ctx, eibcDemandAddr, params.BaseDenom))
+	suite.AssertEventEmitted(suite.Ctx, eibcEventType, 0)
+}
+
 // TestFulfillOrderEvent tests the event upon fulfilling a demand order
 func (suite *KeeperTestSuite) TestFulfillOrderEvent() {
 	// Create and fund the account


### PR DESCRIPTION
Fixes #1350

## Summary
- execute the eIBC fulfillment transfer and order/hook update inside a cache context
- commit the transfer only after `SetOrderFulfilled` and the delayedack fulfillment hook succeed
- add regression coverage for hook failure proving balances, order state, and fulfillment events are rolled back

## Validation
- `go test ./x/eibc/keeper -run TestKeeperTestSuite/TestFulfillOrderRollsBackWhenFulfillmentHookFails -count=1 -v`
- `go test ./x/eibc/keeper -count=1`
- `go test ./x/eibc/... -count=1`
- `go test ./... -count=1`
- `git diff --check`

## Bounty payout
MEC wallet: `me1ya82w6cjflk9r2qeyfeu64sm7gxtfr7mu62w9j`