### PR TITLE
fix: use request chain name for BridgeChainList and LastObservedRelayer

### DIFF
--- a/x/gravity/keeper/grpc_query_router.go
+++ b/x/gravity/keeper/grpc_query_router.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	bsctypes "github.com/openmetaearth/me-hub/x/bsc/types"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -220,7 +219,7 @@ func (k RouterKeeper) ClaimsByEventNonce(c context.Context, req *types.QueryClai
 }
 
 func (k RouterKeeper) BridgeChainList(c context.Context, req *types.QueryBridgeChainListRequest) (*types.QueryBridgeChainListResponse, error) {
-	if queryServer, err := k.getQueryServerByChainName(bsctypes.ModuleName); err != nil {
+	if queryServer, err := k.getQueryServerByChainName(req.ChainName); err != nil {
 		return nil, err
 	} else {
 		return queryServer.BridgeChainList(c, req)
@@ -228,7 +227,7 @@ func (k RouterKeeper) BridgeChainList(c context.Context, req *types.QueryBridgeC
 }
 
 func (k RouterKeeper) LastObservedRelayer(c context.Context, req *types.QueryLastObservedRelayer) (*types.QueryLastObservedRelayerResponse, error) {
-	if queryServer, err := k.getQueryServerByChainName(bsctypes.ModuleName); err != nil {
+	if queryServer, err := k.getQueryServerByChainName(req.ChainName); err != nil {
 		return nil, err
 	} else {
 		return queryServer.LastObservedRelayer(c, req)


### PR DESCRIPTION
## Summary

`BridgeChainList` and `LastObservedRelayer` query handlers in the router were hardcoding `bsctypes.ModuleName` when routing to the backend query server. This completely ignored the chain context from the request, causing all non-BSC chains to receive BSC data.

## Changes

- `x/gravity/keeper/grpc_query_router.go`: Changed both handlers to use `req.ChainName` instead of `bsctypes.ModuleName`, consistent with all other query handlers in the file. Removed unused `bsctypes` import.

## Impact

Non-BSC chains (e.g., TRON) now correctly serve `BridgeChainList` and `LastObservedRelayer` queries through the router.

## Closes

Closes #240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal query routing logic for better chain-based request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->