### PR TITLE
fix: reject zero Ethereum address in external address validation

### DIFF
--- a/utils/eth_validation.go
+++ b/utils/eth_validation.go
@@ -45,6 +45,9 @@ func ValidateEthereumAddress(address string) error {
 	if !common.IsHexAddress(address) {
 		return errors.New("doesn't pass format validation")
 	}
+	if IsZeroEthereumAddress(address) {
+		return errors.New("zero address is not allowed")
+	}
 	expectAddress := common.HexToAddress(address).Hex()
 	if expectAddress != address {
 		return fmt.Errorf("mismatch expected: %s, got: %s", expectAddress, address)

--- a/utils/eth_validation_test.go
+++ b/utils/eth_validation_test.go
@@ -70,7 +70,7 @@ func TestValidateEthereumAddress(t *testing.T) {
 			"invalid address", "0x", true,
 		},
 		{
-			"zero address", common.Address{}.String(), false,
+			"zero address", common.Address{}.String(), true,
 		},
 		{
 			"valid address", helpers.GenerateAddress().Hex(), false,


### PR DESCRIPTION
## Summary

ValidateEthereumAddress was accepting the zero address as a valid external address. A relayer bonding with this address would enter the relayer set but could never produce a valid signature, poisoning the set.

## Changes

- utils/eth_validation.go: Added zero address check using existing IsZeroEthereumAddress helper
- utils/eth_validation_test.go: Updated test to expect zero address to be rejected

## Impact

MsgBondedRelayer (and any other caller of ValidateExternalAddr for Ethereum chains) now rejects the zero address at validation time, preventing poisoned relayer sets.

Fixes #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ethereum address validation now rejects zero addresses, preventing potential invalid transaction issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->