### PR TITLE
fix: unwrap authz.MsgExec for contract creator fee share

### DIFF
--- a/app/ante/fee_deduct.go
+++ b/app/ante/fee_deduct.go
@@ -9,6 +9,7 @@ import (
 	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -76,36 +77,49 @@ func (dfd DeductFeeDecorator) ParseWasmMsgContractCreator(ctx sdk.Context, tx sd
 	// to be considered as a wasm transaction
 	// this criterion is coarse, refine it later!
 
-	allwasm := true
-	var contract string
-	for _, msg := range tx.GetMsgs() {
-		switch msg := msg.(type) {
-		case *wasmtypes.MsgExecuteContract:
-			contract = msg.Contract
-		case *wasmtypes.MsgMigrateContract:
-			contract = msg.Contract
-		case *wasmtypes.MsgUpdateAdmin:
-			contract = msg.Contract
-		case *wasmtypes.MsgClearAdmin:
-			contract = msg.Contract
-		case *wasmtypes.MsgSudoContract:
-			contract = msg.Contract
-		default:
-			allwasm = false
-		}
+	msgs := tx.GetMsgs()
+	if len(msgs) != 1 {
+		return "", false
 	}
 
-	if allwasm {
-		addr, err := sdk.AccAddressFromBech32(contract)
-		if err != nil {
+	contract, ok := dfd.extractWasmContract(msgs[0])
+	if !ok {
+		return "", false
+	}
+
+	addr, err := sdk.AccAddressFromBech32(contract)
+	if err != nil {
+		return "", false
+	}
+	contractInfo := dfd.wasmKeeper.GetContractInfo(ctx, addr)
+	if contractInfo == nil {
+		return "", false
+	}
+	admin := contractInfo.Creator
+	return admin, true
+}
+
+func (dfd DeductFeeDecorator) extractWasmContract(msg sdk.Msg) (string, bool) {
+	switch msg := msg.(type) {
+	case *wasmtypes.MsgExecuteContract:
+		return msg.Contract, true
+	case *wasmtypes.MsgMigrateContract:
+		return msg.Contract, true
+	case *wasmtypes.MsgUpdateAdmin:
+		return msg.Contract, true
+	case *wasmtypes.MsgClearAdmin:
+		return msg.Contract, true
+	case *wasmtypes.MsgSudoContract:
+		return msg.Contract, true
+	case *authz.MsgExec:
+		if len(msg.Msgs) != 1 {
 			return "", false
 		}
-		contractInfo := dfd.wasmKeeper.GetContractInfo(ctx, addr)
-		if contractInfo == nil {
+		inner, err := msg.GetMessages()
+		if err != nil || len(inner) != 1 {
 			return "", false
 		}
-		admin := contractInfo.Creator
-		return admin, true
+		return dfd.extractWasmContract(inner[0].Msg)
 	}
 	return "", false
 }


### PR DESCRIPTION
## Summary

ParseWasmMsgContractCreator only checked top-level tx messages for wasm types. A MsgExecuteContract wrapped inside authz.MsgExec was treated as non-wasm, so the 40% creator fee share went to the global DAO fee pool instead of the contract creator.

## Changes

- app/ante/fee_deduct.go: Added recursive extractWasmContract helper that unwraps a single authz.MsgExec containing a single inner message
- ParseWasmMsgContractCreator now requires exactly one top-level message and uses the helper to detect wasm contracts

## Impact

Contract creators now correctly receive their 40% fee share when users execute wasm calls through authz.MsgExec. Multi-message or mixed authz/direct transactions still fall through to the global DAO pool.

Fixes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved Wasm contract creator detection for transactions involving authorization wrappers, ensuring the correct contract is identified when a transaction contains a single supported CosmWasm message (including supported nested execution cases).
* Added stricter validation for transaction structure, so unsupported or ambiguous message layouts no longer produce incorrect contract creator/admin results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->