### PR TITLE
fix: validate wstaking stake messages

### DIFF
--- a/x/wstaking/keeper/msg_server_stake.go
+++ b/x/wstaking/keeper/msg_server_stake.go
@@ -19,6 +19,10 @@ import (
 func (k MsgServer) Stake(goCtx context.Context, msg *types.MsgStake) (*types.MsgStakeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	if !k.daoKeeper.IsGlobalDao(ctx, msg.StakerAddress) {
 		return nil, types.ErrCheckGlobalDao
 	}
@@ -90,6 +94,10 @@ func (k MsgServer) Stake(goCtx context.Context, msg *types.MsgStake) (*types.Msg
 // Unstake defines a method for performing an unstake from a stake and a validator
 func (k MsgServer) Unstake(goCtx context.Context, msg *types.MsgUnstake) (*types.MsgUnstakeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
 
 	stakerAddress, err := sdk.AccAddressFromBech32(msg.StakerAddress)
 	if err != nil {

--- a/x/wstaking/keeper/msg_server_stake_test.go
+++ b/x/wstaking/keeper/msg_server_stake_test.go
@@ -60,6 +60,12 @@ func (s *KeeperTestSuite) TestStake() {
 			amount:          sdk.NewCoin(params.BaseDenom, sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(params.BaseDenomUnit-1), nil))),
 			expErr:          sdkerrors.ErrInvalidRequest,
 		}, {
+			name:            "zero amount",
+			staker:          s.Dao.GlobalDao,
+			operatorAddress: s.meEarthValidator.OperatorAddress,
+			amount:          sdk.Coin{Denom: params.BaseDenom, Amount: sdk.ZeroInt()},
+			expErr:          sdkerrors.ErrInvalidRequest,
+		}, {
 			name:            "No error",
 			staker:          s.Dao.GlobalDao,
 			operatorAddress: s.meEarthValidator.OperatorAddress,
@@ -165,6 +171,12 @@ func (s *KeeperTestSuite) TestUnStake() {
 			operatorAddress: "mevaloper139mq752delxv78jvtmwxhasyrycufsvr707ate",
 			amount:          stakeAmount,
 			expErr:          stakingtypes.ErrNoValidatorFound,
+		}, {
+			name:            "zero amount",
+			staker:          s.Dao.GlobalDao,
+			operatorAddress: s.meEarthValidator.OperatorAddress,
+			amount:          sdk.Coin{Denom: params.BaseDenom, Amount: sdk.ZeroInt()},
+			expErr:          sdkerrors.ErrInvalidRequest,
 		}, {
 			name:            "No error",
 			staker:          s.Dao.GlobalDao,


### PR DESCRIPTION
## Summary

- Call `ValidateBasic()` in `MsgServer.Stake` before keeper state checks and staking logic.
- Call `ValidateBasic()` in `MsgServer.Unstake` before address parsing and unstaking logic.
- Add zero-amount regression cases for stake and unstake so invalid staking messages fail with `ErrInvalidRequest`.

## Related Issues

- Fixes #1355

## Type of Change

- [ ] `feat` New feature
- [x] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

- [ ] `make test` (not run locally)
- [ ] `make lint` (not run locally)
- [x] `go version`
- [x] GitHub Actions `Tests` workflow
- [x] GitHub Actions `golangci-lint` workflow
- [x] GitHub Actions `CodeQL` workflow
- [x] GitHub Actions `Gosec` workflow
- [ ] `go test ./x/wstaking/keeper/... -count=1` (blocked locally by Windows cgo toolchain)
- [ ] `go test ./x/wstaking/... -count=1` (blocked locally by Windows cgo toolchain)

### Validation Notes

- Rebased successfully onto latest `origin/main` (`d8bd4d1a` fetched on 2026-06-22).
- `git diff --check origin/main..HEAD` passed.
- Installed and used Go `go1.24.7`, matching the repository toolchain requirement.
- `go version` passed: `go version go1.24.7 windows/amd64`.
- `go test ./x/wstaking/keeper/... -count=1` was attempted on Windows and failed while building upstream dependency `github.com/openmetaearth/ethermint/app/ante` because `github.com/ethereum/go-ethereum/crypto/secp256k1` exposes `RecoverPubkey` and `VerifySignature` only with cgo enabled. This Windows environment has no C compiler, so Go reports `CGO_ENABLED=0`.
- `go test ./x/wstaking/... -count=1` was also attempted. `x/wstaking` and `x/wstaking/types` passed, but `x/wstaking/keeper` failed at the same upstream `secp256k1` cgo dependency build step.
- WSL was checked as the Linux fallback, but this machine currently has no WSL distribution installed. I did not modify business code to work around the Windows-only dependency build issue.
- After maintainer approval, the GitHub Actions `Tests`, `golangci-lint`, `CodeQL`, and `Gosec` workflows all passed on the PR. CodeRabbit also passed.

## Checklist

- [x] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [x] I self-reviewed the diff
- [x] I updated tests for changed behavior, or explained why tests are not needed
- [x] I updated docs/comments if user-facing behavior or developer workflow changed
- [x] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [x] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

- None

## Additional Context

- The issue references `x/staking`, but the current implementation path for this behavior is `x/wstaking`.
- The change is intentionally limited to message-level validation and regression coverage for invalid zero-amount stake/unstake requests.
