### PR TITLE
fix: relayer not online when confirm

### DIFF
--- a/x/gravity/keeper/claim.go
+++ b/x/gravity/keeper/claim.go
@@ -1,9 +1,10 @@
 package keeper
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	"encoding/hex"
 	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 	trontypes "github.com/openmetaearth/me-hub/x/tron/types"
@@ -33,6 +34,10 @@ func (s MsgServer) confirmHandlerCommon(ctx sdk.Context, relayerAddr sdk.AccAddr
 	relayer, found := s.GetRelayer(ctx, relayerAddr)
 	if !found {
 		return types.ErrNotFoundRelayer
+	}
+
+	if !relayer.Online {
+		return types.ErrRelayerNotOnline
 	}
 
 	if relayer.ExternalAddress != signatureAddr {

--- a/x/gravity/keeper/relayer.go
+++ b/x/gravity/keeper/relayer.go
@@ -193,7 +193,7 @@ func (s Keeper) checkIsRelayer(ctx sdk.Context, addr sdk.AccAddress) error {
 		return types.ErrNotFoundRelayer
 	}
 	if !relayer.Online {
-		return types.ErrRelayerNotOnLine
+		return types.ErrRelayerNotOnline
 	}
 	return nil
 }

--- a/x/gravity/types/errors.go
+++ b/x/gravity/types/errors.go
@@ -15,7 +15,7 @@ var (
 	ErrNotProposedRelayer      = errorsmod.Register(ModuleName, 8, "not a proposed relayer")
 	ErrNotFoundRelayer         = errorsmod.Register(ModuleName, 9, "not found relayer")
 	ErrExternalAddressNotMatch = errorsmod.Register(ModuleName, 10, "external address not match relayer")
-	ErrRelayerNotOnLine        = errorsmod.Register(ModuleName, 11, "relayer not on line")
+	ErrRelayerNotOnline        = errorsmod.Register(ModuleName, 11, "relayer not online")
 
 	ErrDelegateAmountBelowMinimum  = errorsmod.Register(ModuleName, 12, "delegate amount must be greater than relayer stake threshold")
 	ErrDelegateAmountAboveMaximum  = errorsmod.Register(ModuleName, 13, "delegate amount must be less than relayer stake threshold")

--- a/x/tron/keeper/grpc_query_test.go
+++ b/x/tron/keeper/grpc_query_test.go
@@ -369,7 +369,7 @@ func (s *KeeperTestSuite) TestQuery_BatchConfirms() {
 		{
 			"set correct batch confirm",
 			func() {
-				relayer, externalKey := s.NewRelayer()
+				relayer, externalKey := s.NewRelayer(true)
 				bridgeTokens := s.NewBridgeToken(helpers.GenHexAddress().Bytes())
 				request = &types.QueryBatchConfirmsRequest{
 					ChainName:     trontypes.ModuleName,
@@ -509,7 +509,7 @@ func (s *KeeperTestSuite) TestQuery_GetRelayerByExternalAddr() {
 		{
 			name: "normal external address",
 			malleate: func() {
-				bridger, externalKey := s.NewRelayer()
+				bridger, externalKey := s.NewRelayer(true)
 				request = &types.QueryRelayerRequest{
 					ChainName:       trontypes.ModuleName,
 					ExternalAddress: helpers.HexAddrToTronAddr(externalKey.PubKey().Address().String()),

--- a/x/tron/keeper/keeper_test.go
+++ b/x/tron/keeper/keeper_test.go
@@ -135,13 +135,14 @@ func (s *KeeperTestSuite) NewOutgoingTxBatch() *gravitytypes.OutgoingTxBatch {
 	return newOutgoingTx
 }
 
-func (s *KeeperTestSuite) NewRelayer() (sdk.AccAddress, cryptotypes.PrivKey) {
+func (s *KeeperTestSuite) NewRelayer(online bool) (sdk.AccAddress, cryptotypes.PrivKey) {
 	relayer := helpers.GenAccAddress()
 	externalKey := helpers.NewEthPrivKey()
 	externalAddress := helpers.HexAddrToTronAddr(externalKey.PubKey().Address().String())
 	newRelayer := gravitytypes.Relayer{
 		RelayerAddress:  relayer.String(),
 		ExternalAddress: externalAddress,
+		Online:          online,
 	}
 	s.App.TronKeeper.SetRelayer(s.Ctx, relayer, newRelayer)
 	s.App.TronKeeper.SetRelayerByExternalAddress(s.Ctx, externalAddress, relayer)

--- a/x/tron/keeper/msg_server_test.go
+++ b/x/tron/keeper/msg_server_test.go
@@ -41,7 +41,7 @@ func (s *KeeperTestSuite) Test_msgServer_ConfirmBatch() {
 			},
 			expPass: false,
 		},
-			{
+		{
 			name: "relayer not online",
 			malleate: func() {
 				newOutgoingTx := s.NewOutgoingTxBatch()

--- a/x/tron/keeper/msg_server_test.go
+++ b/x/tron/keeper/msg_server_test.go
@@ -41,11 +41,24 @@ func (s *KeeperTestSuite) Test_msgServer_ConfirmBatch() {
 			},
 			expPass: false,
 		},
+			{
+			name: "relayer not online",
+			malleate: func() {
+				newOutgoingTx := s.NewOutgoingTxBatch()
+				relayer, _ := s.NewRelayer(false)
+				msg = &gravitytypes.MsgConfirmBatch{
+					Nonce:          newOutgoingTx.BatchNonce,
+					TokenContract:  newOutgoingTx.TokenContract,
+					RelayerAddress: relayer.String(),
+				}
+			},
+			expPass: false,
+		},
 		{
 			name: "signature decoding failed",
 			malleate: func() {
 				newOutgoingTx := s.NewOutgoingTxBatch()
-				relayer, externalKey := s.NewRelayer()
+				relayer, externalKey := s.NewRelayer(true)
 				msg = &gravitytypes.MsgConfirmBatch{
 					Nonce:           newOutgoingTx.BatchNonce,
 					TokenContract:   newOutgoingTx.TokenContract,
@@ -60,7 +73,7 @@ func (s *KeeperTestSuite) Test_msgServer_ConfirmBatch() {
 			name: "confirm batch",
 			malleate: func() {
 				newOutgoingTx := s.NewOutgoingTxBatch()
-				relayer, externalKey := s.NewRelayer()
+				relayer, externalKey := s.NewRelayer(true)
 				params, err := s.queryServer.Params(sdk.WrapSDKContext(s.Ctx), &gravitytypes.QueryParamsRequest{ChainName: trontypes.ModuleName})
 				s.Require().NoError(err)
 				batchHash, err := trontypes.GetCheckpointConfirmBatch(newOutgoingTx, params.Params.GravityId)
@@ -125,7 +138,7 @@ func (s *KeeperTestSuite) Test_msgServer_RelayerSetConfirm() {
 		{
 			name: "signature decoding",
 			malleate: func() {
-				relayer, externalKey := s.NewRelayer()
+				relayer, externalKey := s.NewRelayer(true)
 				currentRelayerSet := s.CurrentRelayerSet(externalKey)
 				msg = &gravitytypes.MsgRelayerSetConfirm{
 					Nonce:           currentRelayerSet.Nonce,
@@ -139,7 +152,7 @@ func (s *KeeperTestSuite) Test_msgServer_RelayerSetConfirm() {
 		{
 			name: "relayer set confirm",
 			malleate: func() {
-				relayer, externalKey := s.NewRelayer()
+				relayer, externalKey := s.NewRelayer(true)
 				currentRelayerSet := s.CurrentRelayerSet(externalKey)
 				key, err := externalKey.(*ethsecp256k1.PrivKey).ToECDSA()
 				s.Require().NoError(err)


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->


## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #940

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [x] `make test`
- [x] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Confirmations now fail when the relayer is offline, before any signature/address validation.
  * Offline relayer error messaging was updated to consistently use “not online”.

* **Tests**
  * Updated relayer test helpers and test cases to explicitly cover both online and offline relayer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->