### PR TITLE
fix: deduct region delegate interest when settlement interest

### DIFF
--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"github.com/openmetaearth/me-hub/x/wstaking"
 	"strings"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -14,6 +13,7 @@ import (
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
 	wminttypes "github.com/openmetaearth/me-hub/x/wmint/types"
+	"github.com/openmetaearth/me-hub/x/wstaking"
 	wstakingtypes "github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"github.com/openmetaearth/me-hub/x/wstaking"
 	"strings"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -154,6 +155,8 @@ func (s *KeeperTestSuite) TestUpdate() {
 	s.Require().Equal(delegation.ValidatorAddress, s.meEarthValidator.OperatorAddress)
 
 	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wminttypes.OneDayTotalBlocks + 1).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wstaking.BeginBlock(s.Ctx, s.App.StakingKeeper)
 	// transfer kyc region
 	_, err = s.msgServer.Update(s.Ctx, &types.MsgUpdate{
 		Issuer:   s.Dao.GlobalDao,

--- a/x/wstaking/keeper/kyc_region_test.go
+++ b/x/wstaking/keeper/kyc_region_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
 	wmintTypes "github.com/openmetaearth/me-hub/x/wmint/types"
+	"github.com/openmetaearth/me-hub/x/wstaking"
 	"github.com/openmetaearth/me-hub/x/wstaking/types"
 )
 
@@ -59,6 +60,8 @@ func (s *KeeperTestSuite) TestTransferKycRegion() {
 	s.Require().Equal(delegation.ValidatorAddress, s.meEarthValidator.OperatorAddress)
 
 	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wmintTypes.OneDayTotalBlocks + 1).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wstaking.BeginBlock(s.Ctx, s.Keeper())
 
 	// transfer kyc region
 	err = s.Keeper().TransferKycRegion(s.Ctx, kycAccount, s.Dao.GlobalDao, s.meEarthValidator.Description.RegionID, s.usaValidator.Description.RegionID)

--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -107,6 +107,13 @@ func (k Keeper) RemoveKycReward(ctx sdk.Context, account sdk.AccAddress, regionI
 		return types.ErrCalculateInterest.Wrap(err.Error())
 	}
 
+	if region.DelegateInterest.GTE(rewards) {
+		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
+	} else {
+		return fmt.Errorf("RemoveKycReward err,region(%s) total interest not enough.need pay %s,only have %s",
+			region.RegionId, rewards.String(), region.DelegateInterest.String())
+	}
+
 	// settle interest
 	err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
 		sdk.MustAccAddressFromBech32(region.RegionTreasureAddr),
@@ -182,21 +189,27 @@ func (k Keeper) sendKycRewards(ctx sdk.Context, delAddr sdk.AccAddress, validato
 		if err != nil {
 			return types.ErrCalculateInterest.Wrap(err.Error())
 		}
+
+		if experienceRegion.DelegateInterest.GTE(interest) {
+			experienceRegion.DelegateInterest = experienceRegion.DelegateInterest.Sub(interest)
+		} else {
+			return fmt.Errorf("sendKycRewards err,region(%s) total interest not enough.need pay %s,only have %s",
+				experienceRegion.RegionId, interest.String(), experienceRegion.DelegateInterest.String())
+		}
+
 		// add coins to user account
 		if interest.GT(sdk.ZeroDec()) {
 			err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
 				sdk.MustAccAddressFromBech32(experienceRegion.RegionTreasureAddr),
 				sdk.MustAccAddressFromBech32(delegation.DelegatorAddress),
 				sdk.NewCoins(sdk.NewCoin(params.BaseDenom, interest.TruncateInt())),
-				fmt.Sprintf("ApproveKyc_SettlementInterest_%s", region.RegionId),
+				fmt.Sprintf("ApproveKyc_SettlementInterest_%s", experienceRegion.RegionId),
 			)
 			if err != nil {
 				return err
 			}
 		}
-		if experienceRegion.DelegateInterest.GTE(interest) {
-			experienceRegion.DelegateInterest = experienceRegion.DelegateInterest.Sub(interest)
-		}
+
 		experienceRegion.DelegateAmount = experienceRegion.DelegateAmount.Sub(delegation.UnMeidAmount)
 		k.SetRegion(ctx, experienceRegion)
 
@@ -428,6 +441,9 @@ func (k Keeper) transferUnRegisterMeid(ctx sdk.Context, delAddr sdk.AccAddress, 
 
 	if region.DelegateInterest.GTE(rewards) {
 		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
+	} else {
+		return amount, fmt.Errorf("transferUnRegisterMeid err,region(%s) total interest not enough.need pay %s,only have %s",
+			region.RegionId, rewards.String(), region.DelegateInterest.String())
 	}
 
 	if delegation.Unmovable.LTE(sdk.ZeroInt()) {

--- a/x/wstaking/keeper/kyc_reward.go
+++ b/x/wstaking/keeper/kyc_reward.go
@@ -107,12 +107,11 @@ func (k Keeper) RemoveKycReward(ctx sdk.Context, account sdk.AccAddress, regionI
 		return types.ErrCalculateInterest.Wrap(err.Error())
 	}
 
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
-	} else {
+	if region.DelegateInterest.LT(rewards) {
 		return fmt.Errorf("RemoveKycReward err,region(%s) total interest not enough.need pay %s,only have %s",
 			region.RegionId, rewards.String(), region.DelegateInterest.String())
 	}
+	region.DelegateInterest = region.DelegateInterest.Sub(rewards)
 
 	// settle interest
 	err = k.bankKeeper.Extend().SendCoinsWithTag(ctx,
@@ -123,10 +122,6 @@ func (k Keeper) RemoveKycReward(ctx sdk.Context, account sdk.AccAddress, regionI
 	)
 	if err != nil {
 		return fmt.Errorf("settle interest error: %w", err)
-	}
-
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
 	}
 
 	if delegation.Unmovable.LTE(sdk.ZeroInt()) {
@@ -190,12 +185,11 @@ func (k Keeper) sendKycRewards(ctx sdk.Context, delAddr sdk.AccAddress, validato
 			return types.ErrCalculateInterest.Wrap(err.Error())
 		}
 
-		if experienceRegion.DelegateInterest.GTE(interest) {
-			experienceRegion.DelegateInterest = experienceRegion.DelegateInterest.Sub(interest)
-		} else {
+		if experienceRegion.DelegateInterest.LT(interest) {
 			return fmt.Errorf("sendKycRewards err,region(%s) total interest not enough.need pay %s,only have %s",
 				experienceRegion.RegionId, interest.String(), experienceRegion.DelegateInterest.String())
 		}
+		experienceRegion.DelegateInterest = experienceRegion.DelegateInterest.Sub(interest)
 
 		// add coins to user account
 		if interest.GT(sdk.ZeroDec()) {
@@ -439,12 +433,11 @@ func (k Keeper) transferUnRegisterMeid(ctx sdk.Context, delAddr sdk.AccAddress, 
 		return amount, err
 	}
 
-	if region.DelegateInterest.GTE(rewards) {
-		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
-	} else {
+	if region.DelegateInterest.LT(rewards) {
 		return amount, fmt.Errorf("transferUnRegisterMeid err,region(%s) total interest not enough.need pay %s,only have %s",
 			region.RegionId, rewards.String(), region.DelegateInterest.String())
 	}
+	region.DelegateInterest = region.DelegateInterest.Sub(rewards)
 
 	if delegation.Unmovable.LTE(sdk.ZeroInt()) {
 		return amount, errors.New("UnRegisterMeid err: delegation UnMovable <= 0")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - KYC reward settlement now validates “sufficient delegate interest” earlier and returns explicit errors when coverage is insufficient.
  - Reward settlement now deducts the required interest up front before sending settlement coins, avoiding inconsistent partial settlement behavior.
  - Unregistration KYC now errors out when delegate interest is too low instead of continuing with subsequent settlement logic.

- **Tests**
  - Updated KYC region transfer tests to initialize the staking module at the correct block height.
  - Updated KYC update message server tests to begin staking during the updated block height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->