### PR TITLE
fix: optimize kyc and megroup genesis

### DIFF
--- a/x/kyc/genesis.go
+++ b/x/kyc/genesis.go
@@ -18,7 +18,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 		addr := sdk.MustAccAddressFromBech32(issuer.Address)
 
 		if _, found := k.GetDID(ctx, addr); found {
-			panic(fmt.Errorf("issuer %s already exists", addr.String()))
+			continue
 		}
 
 		k.SetDID(ctx, addr, issuer.Did)

--- a/x/megroup/genesis.go
+++ b/x/megroup/genesis.go
@@ -9,52 +9,12 @@ import (
 
 // InitGenesis initializes the module's state from a provided genesis state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
-	// Set all the group
-	// todo:稍后在做，等宁那边确定格式后
-	return
-	/*
-		for _, elem := range genState.GroupList {
-			if err := k.AppendGroup(ctx, &elem);err != nil{
-
-			}
-		}
-
-		// Set group count
-		k.SetGroupCount(ctx, genState.GroupCount)
-		// Set all the groupMember
-		for _, elem := range genState.GroupMemberList {
-			k.LoadMemberStoreByGroupID(ctx, elem.GroupID).SetGroupMember(elem)
-		}
-
-		// Set all the memberJoined
-		for _, elem := range genState.MemberJoinedList {
-			k.SetMemberJoined(ctx, elem)
-		}
-		// Set all the groupMemberCount
-		for _, elem := range genState.GroupMemberCountList {
-			k.SetGroupMemberCount(ctx, elem)
-		}
-		// this line is used by starport scaffolding # genesis/module/init
-		k.SetParams(ctx, genState.Params)
-
-	*/
+	// todo
 }
 
 // ExportGenesis returns the module's exported genesis
 func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
-	//todo:稍后在做，等宁那边确定格式后
-	/*
-		genesis.Params = k.GetParams(ctx)
-
-		genesis.GroupList = k.GetAllGroup(ctx)
-		genesis.GroupCount = k.GetGroupCount(ctx)
-		genesis.GroupMemberList = k.GetAllGroupMember(ctx)
-		genesis.MemberJoinedList = k.GetAllMemberJoined(ctx)
-		genesis.GroupMemberCountList = k.GetAllGroupMemberCount(ctx)
-		// this line is used by starport scaffolding # genesis/module/export
-
-	*/
-
+	// todo
 	return genesis
 }


### PR DESCRIPTION
optimize kyc and megroup genesis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Genesis initialization now skips duplicate issuer entries instead of failing, allowing valid entries to be applied normally.
  * One module’s genesis processing now uses a default fallback path, avoiding unexpected state population during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->