### PR TITLE
fix(did): implement Validate() for GenesisState to enforce invariants and prevent panics

### DIFF
--- a/x/did/genesis_test.go
+++ b/x/did/genesis_test.go
@@ -15,9 +15,10 @@ func TestInitExportGenesis(t *testing.T) {
 	genesisState := types.GenesisState{
 		Infos: []types.DidInfo{
 			types.DidInfo{
-				Did:    "1000000000000001",
-				Pubkey: "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}",
-				Status: types.DID_STATUS_ACTIVE,
+				Did:     "1000000000001",
+				Address: "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4",
+				Pubkey:  "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}",
+				Status:  types.DID_STATUS_ACTIVE,
 			},
 		},
 		Svcs: []types.Service{
@@ -25,13 +26,13 @@ func TestInitExportGenesis(t *testing.T) {
 				Sid:         "kyc",
 				Name:        "kyc",
 				Description: "this is kyc test service.",
-				Issuers:     []string{"00000000000001"},
+				Issuers:     []string{"1000000000001"},
 				Status:      types.SERVICE_STATUS_ACTIVE,
 			},
 		},
 		Vcs: []types.Credential{
 			types.Credential{
-				Did:  "1000000000000001",
+				Did:  "1000000000001",
 				Sid:  "kyc",
 				Hash: "0000000000000000001",
 				Uri:  "http://metaearth.com/files/0001.vc",
@@ -40,7 +41,7 @@ func TestInitExportGenesis(t *testing.T) {
 		},
 		Flogs: []types.FilterLogger{
 			types.FilterLogger{
-				Did: "000000000000001",
+				Did: "1000000000001",
 				Sid: "kyc",
 				Filters: [][]byte{
 					[]byte("A0"),

--- a/x/did/types/genesis.go
+++ b/x/did/types/genesis.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
@@ -12,5 +17,117 @@ func DefaultGenesis() *GenesisState {
 
 // Validate performs basic genesis state validation returning an error upon any failure.
 func (gs *GenesisState) Validate() error {
+	// 1. Validate Infos
+	didMap := make(map[string]bool)
+	addrMap := make(map[string]bool)
+	for _, info := range gs.Infos {
+		if len(info.Did) != DidLength {
+			return fmt.Errorf("DID length must be equal to %d", DidLength)
+		}
+		if info.Pubkey == "" {
+			return fmt.Errorf("pubkey must not be nil/empty")
+		}
+		if _, err := sdk.AccAddressFromBech32(info.Address); err != nil {
+			return fmt.Errorf("invalid address %s: %s", info.Address, err)
+		}
+		if info.Status != DID_STATUS_INACTIVE && info.Status != DID_STATUS_ACTIVE {
+			return fmt.Errorf("invalid DID status: %d", info.Status)
+		}
+		if didMap[info.Did] {
+			return fmt.Errorf("duplicate DID info found: %s", info.Did)
+		}
+		didMap[info.Did] = true
+		if addrMap[info.Address] {
+			return fmt.Errorf("duplicate DID address found: %s", info.Address)
+		}
+		addrMap[info.Address] = true
+	}
+
+	// 2. Validate Svcs
+	svcMap := make(map[string]bool)
+	for _, svc := range gs.Svcs {
+		if len(svc.Sid) < 2 || len(svc.Sid) > 8 {
+			return fmt.Errorf("sid length must be between 2 and 8")
+		}
+		if len(svc.Name) == 0 || len(svc.Name) > 20 {
+			return fmt.Errorf("name length must be between 1 and 20")
+		}
+		if len(svc.Description) > 1024 {
+			return fmt.Errorf("description length exceeds 1024")
+		}
+		if svc.Status != SERVICE_STATUS_INACTIVE && svc.Status != SERVICE_STATUS_ACTIVE {
+			return fmt.Errorf("invalid service status: %d", svc.Status)
+		}
+		if svcMap[svc.Sid] {
+			return fmt.Errorf("duplicate service found: %s", svc.Sid)
+		}
+		svcMap[svc.Sid] = true
+
+		for _, issuer := range svc.Issuers {
+			if len(issuer) != DidLength {
+				return fmt.Errorf("issuer length must be equal to %d", DidLength)
+			}
+			if !didMap[issuer] {
+				return fmt.Errorf("issuer DID %s does not exist in DID Infos", issuer)
+			}
+		}
+	}
+
+	// 3. Validate Vcs
+	type credKey struct {
+		Did string
+		Sid string
+	}
+	vcMap := make(map[credKey]bool)
+	for _, vc := range gs.Vcs {
+		if len(vc.Did) != DidLength {
+			return fmt.Errorf("DID length in credential must be equal to %d", DidLength)
+		}
+		if len(vc.Sid) < 2 || len(vc.Sid) > 8 {
+			return fmt.Errorf("sid length in credential must be between 2 and 8")
+		}
+		if len(vc.Hash) == 0 || len(vc.Hash) > 128 {
+			return fmt.Errorf("hash length must be between 1 and 128")
+		}
+		if len(vc.Uri) > 1024 {
+			return fmt.Errorf("uri length exceeds 1024")
+		}
+		if !didMap[vc.Did] {
+			return fmt.Errorf("credential DID %s does not exist in DID Infos", vc.Did)
+		}
+		if !svcMap[vc.Sid] {
+			return fmt.Errorf("credential Sid %s does not exist in Services", vc.Sid)
+		}
+		key := credKey{Did: vc.Did, Sid: vc.Sid}
+		if vcMap[key] {
+			return fmt.Errorf("duplicate credential found for did %s and sid %s", vc.Did, vc.Sid)
+		}
+		vcMap[key] = true
+	}
+
+	// 4. Validate Flogs
+	flogMap := make(map[credKey]bool)
+	for _, flog := range gs.Flogs {
+		if len(flog.Did) != DidLength {
+			return fmt.Errorf("DID length in filter logger must be equal to %d", DidLength)
+		}
+		if len(flog.Sid) < 2 || len(flog.Sid) > 8 {
+			return fmt.Errorf("sid length in filter logger must be between 2 and 8")
+		}
+		for _, filter := range flog.Filters {
+			if len(filter) > 1024 {
+				return fmt.Errorf("filter length exceeds 1024")
+			}
+		}
+		key := credKey{Did: flog.Did, Sid: flog.Sid}
+		if !vcMap[key] {
+			return fmt.Errorf("filter logger references non-existent credential [did: %s, sid: %s]", flog.Did, flog.Sid)
+		}
+		if flogMap[key] {
+			return fmt.Errorf("duplicate filter logger found for did %s and sid %s", flog.Did, flog.Sid)
+		}
+		flogMap[key] = true
+	}
+
 	return nil
 }

--- a/x/did/types/genesis_test.go
+++ b/x/did/types/genesis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/evmos/ethermint/crypto/ethsecp256k1"
+	_ "github.com/openmetaearth/me-hub/app/params"
 	"github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/stretchr/testify/require"
 )
@@ -12,9 +13,10 @@ func TestGenesisState_Validate(t *testing.T) {
 	test := types.GenesisState{
 		Infos: []types.DidInfo{
 			types.DidInfo{
-				Did:    "1000000000001",
-				Pubkey: "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}",
-				Status: types.DID_STATUS_ACTIVE,
+				Did:     "1000000000001",
+				Address: "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4",
+				Pubkey:  "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}",
+				Status:  types.DID_STATUS_ACTIVE,
 			},
 		},
 		Svcs: []types.Service{
@@ -37,7 +39,7 @@ func TestGenesisState_Validate(t *testing.T) {
 		},
 		Flogs: []types.FilterLogger{
 			types.FilterLogger{
-				Did: "000000000001",
+				Did: "1000000000001",
 				Sid: "kyc",
 				Filters: [][]byte{
 					[]byte("A0"),
@@ -48,4 +50,104 @@ func TestGenesisState_Validate(t *testing.T) {
 
 	err := test.Validate()
 	require.NoError(t, err)
+}
+
+func TestGenesisState_Validate_Errors(t *testing.T) {
+	validDid := "1000000000001"
+	validAddr := "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4"
+	validPubkey := "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}"
+
+	tests := []struct {
+		name string
+		gen  types.GenesisState
+	}{
+		{
+			name: "invalid did length",
+			gen: types.GenesisState{
+				Infos: []types.DidInfo{
+					{Did: "short", Address: validAddr, Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+				},
+			},
+		},
+		{
+			name: "invalid status value",
+			gen: types.GenesisState{
+				Infos: []types.DidInfo{
+					{Did: validDid, Address: validAddr, Pubkey: validPubkey, Status: 99},
+				},
+			},
+		},
+		{
+			name: "invalid bech32 address",
+			gen: types.GenesisState{
+				Infos: []types.DidInfo{
+					{Did: validDid, Address: "invalid_bech32", Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+				},
+			},
+		},
+		{
+			name: "duplicate did",
+			gen: types.GenesisState{
+				Infos: []types.DidInfo{
+					{Did: validDid, Address: validAddr, Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+					{Did: validDid, Address: "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk5", Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+				},
+			},
+		},
+		{
+			name: "duplicate address",
+			gen: types.GenesisState{
+				Infos: []types.DidInfo{
+					{Did: validDid, Address: validAddr, Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+					{Did: "1000000000002", Address: validAddr, Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+				},
+			},
+		},
+		{
+			name: "invalid service name length",
+			gen: types.GenesisState{
+				Infos: []types.DidInfo{
+					{Did: validDid, Address: validAddr, Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+				},
+				Svcs: []types.Service{
+					{Sid: "kyc", Name: "", Description: "desc", Issuers: []string{validDid}, Status: types.SERVICE_STATUS_ACTIVE},
+				},
+			},
+		},
+		{
+			name: "phantom issuer reference",
+			gen: types.GenesisState{
+				Infos: []types.DidInfo{
+					{Did: validDid, Address: validAddr, Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+				},
+				Svcs: []types.Service{
+					{Sid: "kyc", Name: "kyc", Description: "desc", Issuers: []string{"1000000000009"}, Status: types.SERVICE_STATUS_ACTIVE},
+				},
+			},
+		},
+		{
+			name: "phantom credential references from filter logger",
+			gen: types.GenesisState{
+				Infos: []types.DidInfo{
+					{Did: validDid, Address: validAddr, Pubkey: validPubkey, Status: types.DID_STATUS_ACTIVE},
+				},
+				Svcs: []types.Service{
+					{Sid: "kyc", Name: "kyc", Description: "desc", Issuers: []string{validDid}, Status: types.SERVICE_STATUS_ACTIVE},
+				},
+				Vcs: []types.Credential{
+					{Did: validDid, Sid: "kyc", Hash: "some_hash", Uri: "some_uri"},
+				},
+				Flogs: []types.FilterLogger{
+					{Did: validDid, Sid: "other_svc", Filters: [][]byte{[]byte("filter")}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.gen.Validate()
+			require.Error(t, err)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #1095.

This PR implements strict validation checks for `GenesisState.Validate()` in the `did` module. Specifically, it checks:
1. `infos` (DID Infos): checks for correct length, non-empty pubkey, valid Bech32 address format, and duplicate DIDs or addresses.
2. `svcs` (Services): validates Sid length, Name length, Description length, and check duplicate Sids. Also verifies that each service issuer exists in the DID Infos list.
3. `vcs` (Credentials): checks DID length, Sid length, Hash length, Uri length, and verifies that the credential DID and Sid exist in DID Infos and Services respectively, with no duplicate credential mapping.
4. `flogs` (Filter Loggers): checks DID length, Sid length, Filter length, and verifies that the referenced credential exists, with no duplicate filter logger mappings.

Also includes unit tests covering both valid scenarios and various invalid/corrupt genesis state scenarios.

Payment Info: PayPal: https://paypal.me/sureshc26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened genesis validation for DID data, including checks for duplicates, missing references, invalid lengths, and unsupported values.
  * Improved consistency of exported genesis test data by aligning identifier values across related entries.
* **Tests**
  * Added coverage for multiple invalid genesis-state scenarios to confirm validation errors are returned as expected.
  * Updated the main validation test data to match the new identifier format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->