### PR TITLE
fix(sequencer): add rollapp membership checks in ReplaceProposer validation (fixes #860)

### DIFF
--- a/x/sequencer/keeper/hook_listener.go
+++ b/x/sequencer/keeper/hook_listener.go
@@ -53,6 +53,15 @@ func (hook rollappHook) AfterStateFinalized(ctx sdk.Context, rollappID string, s
 	}
 	if val != nil {
 		if (stateInfo.StartHeight + stateInfo.NumBlocks - 1) >= uint64(val.ReplaceProposer.BlockHeight) {
+			// Rollapp-binding check to prevent stalled finalization / cross-rollapp proposers
+			oldSeq, found := hook.k.GetSequencer(ctx, val.ReplaceProposer.OldProposer)
+			if !found {
+				return types.ErrUnknownSequencer
+			}
+			if oldSeq.RollappId != rollappID {
+				return types.ErrSequencerRollappMismatch
+			}
+
 			err = hook.k.forceRemoveUnbondingSequencer(ctx, val.ReplaceProposer.OldProposer, stateInfo.StartHeight, stateInfo.NumBlocks)
 			if err != nil {
 				hook.k.Logger(ctx).Error("forceRemoveUnbondingSequencer error.", "sequencer", val.ReplaceProposer.OldProposer,

--- a/x/sequencer/keeper/hooks_test.go
+++ b/x/sequencer/keeper/hooks_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"time"
 
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
 )
 
@@ -41,3 +42,71 @@ func (suite *SequencerTestSuite) TestFraudSubmittedHook() {
 		suite.Require().Equal(sequencer.Status, types.Unbonded)
 	}
 }
+
+func (suite *SequencerTestSuite) TestReplaceProposerAfterStateFinalizedRollappBinding() {
+	suite.SetupTest()
+	keeper := suite.App.SequencerKeeper
+
+	rollappId := suite.CreateDefaultRollapp()
+	oldProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	
+	// Set the old proposer as unbonding status so forceRemoveUnbondingSequencer can be run (otherwise it returns ErrInvalidSequencerStatus)
+	oldSeq, found := keeper.GetSequencer(suite.Ctx, oldProposerAddr)
+	suite.Require().True(found)
+	oldSeq.Status = types.Unbonding
+	keeper.SetSequencer(suite.Ctx, oldSeq)
+
+	// Create sequencer on another rollapp
+	otherRollappId := suite.CreateDefaultRollapp()
+	otherProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, otherRollappId)
+	
+	// 1. Valid case matching rollappId
+	replaceProposerMsg := types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: oldProposerAddr,
+		NewProposer: otherProposerAddr,
+		BlockHeight: 10,
+	}
+	err := keeper.SetReplaceProposer(suite.Ctx, &replaceProposerMsg)
+	suite.Require().NoError(err)
+
+	stateInfo := rollapptypes.StateInfo{
+		StateInfoIndex: rollapptypes.StateInfoIndex{RollappId: rollappId, Index: 1},
+		StartHeight:    1,
+		NumBlocks:      15, // BlockHeight 10 <= StartHeight + NumBlocks - 1 (15)
+	}
+
+	err = keeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, &stateInfo)
+	suite.Require().NoError(err)
+
+	// 2. Corrupted ReplaceProposer state matching wrong oldProposer rollapp
+	// Cleanup and set a new one
+	keeper.DeleteReplaceProposer(suite.Ctx, rollappId)
+	
+	// Create another sequencer on the other rollapp
+	otherSeq, found := keeper.GetSequencer(suite.Ctx, otherProposerAddr)
+	suite.Require().True(found)
+	otherSeq.Status = types.Unbonding
+	keeper.SetSequencer(suite.Ctx, otherSeq)
+
+	badReplaceProposerMsg := types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: otherProposerAddr, // Belongs to otherRollappId instead of rollappId
+		NewProposer: oldProposerAddr,
+		BlockHeight: 10,
+	}
+	// Bypass SetReplaceProposer check (which would block it at Tx submission time) to test the hook safety net
+	store := suite.Ctx.KVStore(suite.App.GetKey(types.StoreKey))
+	bz, err := suite.App.AppCodec().Marshal(&types.MsgStoreReplaceProposer{
+		ReplaceProposer: badReplaceProposerMsg,
+		HubBlockHeight:  suite.Ctx.BlockHeight(),
+	})
+	suite.Require().NoError(err)
+	store.Set(types.RepalceRollappProposerKey(rollappId), bz)
+
+	// Trigger hook with the wrong binding
+	err = keeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, &stateInfo)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, types.ErrSequencerRollappMismatch)
+}
+


### PR DESCRIPTION
Closes #860

This PR adds a rollapp-binding safety check to the `AfterStateFinalized` hook in the sequencer module. While the `ReplaceProposer` message handler now validates rollapp membership (merged in #652), the finalization hook path (`hook_listener.go`) still lacked this check — a corrupted store entry referencing a cross-rollapp sequencer could stall finalization permanently.

This patch:
1. Validates that the old proposer referenced in `GetReplaceProposer` actually belongs to the rollapp being finalized, returning `ErrSequencerRollappMismatch` if not.
2. Adds a comprehensive unit test (`TestReplaceProposerAfterStateFinalizedRollappBinding`) covering both the valid case and the corrupted-state rejection path.

Payment Info: PayPal: https://paypal.me/sureshc26