### PR TITLE
fix: MintNFT not allows leading-zero token IDs to bypass class TotalS…

### DIFF
--- a/x/wnft/keeper/msg_server.go
+++ b/x/wnft/keeper/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"strconv"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -98,9 +99,9 @@ func (k Keeper) MintNFT(goCtx context.Context, msg *types.MsgMintNFT) (*types.Ms
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not the creator of class %s", msg.Creator, msg.ClassId)
 	}
 
-	tokenId, err := types.ParseCanonicalTokenId(msg.TokenId)
+	tokenId, err := strconv.ParseUint(msg.TokenId, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
 	}
 
 	if tokenId < 1 || tokenId > class.TotalSupply {

--- a/x/wnft/keeper/msg_server.go
+++ b/x/wnft/keeper/msg_server.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"strconv"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -99,13 +98,17 @@ func (k Keeper) MintNFT(goCtx context.Context, msg *types.MsgMintNFT) (*types.Ms
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not the creator of class %s", msg.Creator, msg.ClassId)
 	}
 
-	tokenId, err := strconv.ParseUint(msg.TokenId, 10, 64)
+	tokenId, err := types.ParseCanonicalTokenId(msg.TokenId)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
+		return nil, err
 	}
 
 	if tokenId < 1 || tokenId > class.TotalSupply {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
+	}
+
+	if k.GetTotalSupply(ctx, msg.ClassId) >= class.TotalSupply {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "total supply exceeded")
 	}
 	receiver, err := sdk.AccAddressFromBech32(msg.Receiver)
 	if err != nil {

--- a/x/wnft/keeper/msg_server_test.go
+++ b/x/wnft/keeper/msg_server_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	cometbftproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/nft"
@@ -63,6 +64,7 @@ func TestMintNFTRejectsLeadingZeroTokenID(t *testing.T) {
 		Receiver: receiver.String(),
 	})
 	require.Error(t, err)
+	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
 	require.ErrorContains(t, err, "invalid token id")
 
 	_, found := helper.App.WNFTKeeper.GetNFT(helper.Ctx, "class-leading-zero", "01")
@@ -109,6 +111,7 @@ func TestMintNFTEnforcesClassTotalSupplyByMintCount(t *testing.T) {
 		Receiver: receiver.String(),
 	})
 	require.Error(t, err)
+	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
 	require.ErrorContains(t, err, "invalid token id")
 
 	_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
@@ -120,6 +123,7 @@ func TestMintNFTEnforcesClassTotalSupplyByMintCount(t *testing.T) {
 		Receiver: receiver.String(),
 	})
 	require.Error(t, err)
+	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
 	require.ErrorContains(t, err, "invalid token id")
 
 	err = helper.App.WNFTKeeper.Keeper.Mint(helper.Ctx, nft.NFT{
@@ -140,5 +144,6 @@ func TestMintNFTEnforcesClassTotalSupplyByMintCount(t *testing.T) {
 		Receiver: receiver.String(),
 	})
 	require.Error(t, err)
+	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
 	require.ErrorContains(t, err, "total supply exceeded")
 }

--- a/x/wnft/keeper/msg_server_test.go
+++ b/x/wnft/keeper/msg_server_test.go
@@ -38,39 +38,6 @@ func setupMsgServer(t *testing.T) (*apptesting.KeeperTestHelper, types.MsgServer
 	return helper, keeper.NewMsgServerImpl(app.WNFTKeeper, app.WNFTKeeper.Keeper)
 }
 
-func TestMintNFTRejectsLeadingZeroTokenID(t *testing.T) {
-	helper, msgServer := setupMsgServer(t)
-	creator, _ := helper.NewAccount()
-	receiver, _ := helper.NewAccount()
-
-	_, err := msgServer.NewClass(helper.Ctx, &types.MsgNewClass{
-		ClassId:     "class-leading-zero",
-		Sender:      creator.String(),
-		Name:        "Leading Zero",
-		Symbol:      "LZ",
-		Description: "test",
-		Uri:         "ipfs://class",
-		UriHash:     "classhash",
-		TotalSupply: 2,
-	})
-	require.NoError(t, err)
-
-	_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
-		ClassId:  "class-leading-zero",
-		TokenId:  "01",
-		Uri:      "ipfs://token-01",
-		UriHash:  "hash-01",
-		Creator:  creator.String(),
-		Receiver: receiver.String(),
-	})
-	require.Error(t, err)
-	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
-	require.ErrorContains(t, err, "invalid token id")
-
-	_, found := helper.App.WNFTKeeper.GetNFT(helper.Ctx, "class-leading-zero", "01")
-	require.False(t, found)
-}
-
 func TestMintNFTEnforcesClassTotalSupplyByMintCount(t *testing.T) {
 	helper, msgServer := setupMsgServer(t)
 	creator, _ := helper.NewAccount()

--- a/x/wnft/keeper/msg_server_test.go
+++ b/x/wnft/keeper/msg_server_test.go
@@ -104,18 +104,6 @@ func TestMintNFTEnforcesClassTotalSupplyByMintCount(t *testing.T) {
 
 	_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
 		ClassId:  "class-total-supply",
-		TokenId:  "01",
-		Uri:      "ipfs://token-01",
-		UriHash:  "hash-01",
-		Creator:  creator.String(),
-		Receiver: receiver.String(),
-	})
-	require.Error(t, err)
-	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
-	require.ErrorContains(t, err, "invalid token id")
-
-	_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
-		ClassId:  "class-total-supply",
 		TokenId:  "3",
 		Uri:      "ipfs://token-3",
 		UriHash:  "hash-3",

--- a/x/wnft/keeper/msg_server_test.go
+++ b/x/wnft/keeper/msg_server_test.go
@@ -1,0 +1,144 @@
+package keeper_test
+
+import (
+	"testing"
+
+	cometbftproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/cosmos-sdk/x/nft"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmetaearth/me-hub/app/apptesting"
+	"github.com/openmetaearth/me-hub/app/params"
+	"github.com/openmetaearth/me-hub/x/wnft/keeper"
+	"github.com/openmetaearth/me-hub/x/wnft/types"
+)
+
+func setupMsgServer(t *testing.T) (*apptesting.KeeperTestHelper, types.MsgServer) {
+	t.Helper()
+
+	app := apptesting.Setup(t, false)
+	ctx := app.GetBaseApp().NewContext(false, cometbftproto.Header{})
+
+	err := app.AccountKeeper.SetParams(ctx, authtypes.DefaultParams())
+	require.NoError(t, err)
+
+	err = app.BankKeeper.SetParams(ctx, banktypes.DefaultParams())
+	require.NoError(t, err)
+
+	stakingParams := stakingtypes.DefaultParams()
+	stakingParams.BondDenom = params.BaseDenom
+	err = app.StakingKeeper.SetParams(ctx, stakingParams)
+	require.NoError(t, err)
+
+	helper := &apptesting.KeeperTestHelper{App: app, Ctx: ctx}
+	return helper, keeper.NewMsgServerImpl(app.WNFTKeeper, app.WNFTKeeper.Keeper)
+}
+
+func TestMintNFTRejectsLeadingZeroTokenID(t *testing.T) {
+	helper, msgServer := setupMsgServer(t)
+	creator, _ := helper.NewAccount()
+	receiver, _ := helper.NewAccount()
+
+	_, err := msgServer.NewClass(helper.Ctx, &types.MsgNewClass{
+		ClassId:     "class-leading-zero",
+		Sender:      creator.String(),
+		Name:        "Leading Zero",
+		Symbol:      "LZ",
+		Description: "test",
+		Uri:         "ipfs://class",
+		UriHash:     "classhash",
+		TotalSupply: 2,
+	})
+	require.NoError(t, err)
+
+	_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
+		ClassId:  "class-leading-zero",
+		TokenId:  "01",
+		Uri:      "ipfs://token-01",
+		UriHash:  "hash-01",
+		Creator:  creator.String(),
+		Receiver: receiver.String(),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid token id")
+
+	_, found := helper.App.WNFTKeeper.GetNFT(helper.Ctx, "class-leading-zero", "01")
+	require.False(t, found)
+}
+
+func TestMintNFTEnforcesClassTotalSupplyByMintCount(t *testing.T) {
+	helper, msgServer := setupMsgServer(t)
+	creator, _ := helper.NewAccount()
+	receiver, _ := helper.NewAccount()
+
+	_, err := msgServer.NewClass(helper.Ctx, &types.MsgNewClass{
+		ClassId:     "class-total-supply",
+		Sender:      creator.String(),
+		Name:        "Total Supply",
+		Symbol:      "TS",
+		Description: "test",
+		Uri:         "ipfs://class",
+		UriHash:     "classhash",
+		TotalSupply: 2,
+	})
+	require.NoError(t, err)
+
+	for _, tokenID := range []string{"1", "2"} {
+		_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
+			ClassId:  "class-total-supply",
+			TokenId:  tokenID,
+			Uri:      "ipfs://token-" + tokenID,
+			UriHash:  "hash-" + tokenID,
+			Creator:  creator.String(),
+			Receiver: receiver.String(),
+		})
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, uint64(2), helper.App.WNFTKeeper.GetTotalSupply(helper.Ctx, "class-total-supply"))
+
+	_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
+		ClassId:  "class-total-supply",
+		TokenId:  "01",
+		Uri:      "ipfs://token-01",
+		UriHash:  "hash-01",
+		Creator:  creator.String(),
+		Receiver: receiver.String(),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid token id")
+
+	_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
+		ClassId:  "class-total-supply",
+		TokenId:  "3",
+		Uri:      "ipfs://token-3",
+		UriHash:  "hash-3",
+		Creator:  creator.String(),
+		Receiver: receiver.String(),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid token id")
+
+	err = helper.App.WNFTKeeper.Keeper.Mint(helper.Ctx, nft.NFT{
+		ClassId: "class-total-supply",
+		Id:      "100",
+		Uri:     "ipfs://token-100",
+		UriHash: "hash-100",
+	}, receiver)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), helper.App.WNFTKeeper.GetTotalSupply(helper.Ctx, "class-total-supply"))
+
+	_, err = msgServer.MintNFT(helper.Ctx, &types.MsgMintNFT{
+		ClassId:  "class-total-supply",
+		TokenId:  "1",
+		Uri:      "ipfs://token-1b",
+		UriHash:  "hash-1b",
+		Creator:  creator.String(),
+		Receiver: receiver.String(),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "total supply exceeded")
+}

--- a/x/wnft/types/msgs.go
+++ b/x/wnft/types/msgs.go
@@ -78,19 +78,6 @@ func NewMsgNewClass(classId, sender, name, symbol, description, uri, uriHash str
 	}
 }
 
-func ParseCanonicalTokenId(tokenID string) (uint64, error) {
-	parsedTokenID, err := strconv.ParseUint(tokenID, 10, 64)
-	if err != nil || parsedTokenID < 1 {
-		return 0, errors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
-	}
-
-	if tokenID != strconv.FormatUint(parsedTokenID, 10) {
-		return 0, errors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
-	}
-
-	return parsedTokenID, nil
-}
-
 // ValidateBasic implements the Msg.ValidateBasic method.
 func (m MsgMintNFT) ValidateBasic() error {
 	if len(m.ClassId) == 0 {
@@ -101,15 +88,16 @@ func (m MsgMintNFT) ValidateBasic() error {
 		return ErrEmptyTokenId
 	}
 
-	if _, err := ParseCanonicalTokenId(m.TokenId); err != nil {
-		return err
+	parsedTokenID, err := strconv.ParseUint(m.TokenId, 10, 64)
+	if err != nil || parsedTokenID < 1 || m.TokenId != strconv.FormatUint(parsedTokenID, 10) {
+		return errors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
 	}
 
 	if len(m.Uri) == 0 {
 		return ErrEmptyURI
 	}
 
-	_, err := sdk.AccAddressFromBech32(m.Creator)
+	_, err = sdk.AccAddressFromBech32(m.Creator)
 	if err != nil {
 		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid mint address (%s)", m.Creator)
 	}

--- a/x/wnft/types/msgs.go
+++ b/x/wnft/types/msgs.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strconv"
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -77,6 +78,19 @@ func NewMsgNewClass(classId, sender, name, symbol, description, uri, uriHash str
 	}
 }
 
+func ParseCanonicalTokenId(tokenID string) (uint64, error) {
+	parsedTokenID, err := strconv.ParseUint(tokenID, 10, 64)
+	if err != nil || parsedTokenID < 1 {
+		return 0, errors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
+	}
+
+	if tokenID != strconv.FormatUint(parsedTokenID, 10) {
+		return 0, errors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
+	}
+
+	return parsedTokenID, nil
+}
+
 // ValidateBasic implements the Msg.ValidateBasic method.
 func (m MsgMintNFT) ValidateBasic() error {
 	if len(m.ClassId) == 0 {
@@ -85,6 +99,10 @@ func (m MsgMintNFT) ValidateBasic() error {
 
 	if len(m.TokenId) == 0 {
 		return ErrEmptyTokenId
+	}
+
+	if _, err := ParseCanonicalTokenId(m.TokenId); err != nil {
+		return err
 	}
 
 	if len(m.Uri) == 0 {

--- a/x/wnft/types/msgs_test.go
+++ b/x/wnft/types/msgs_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/openmetaearth/me-hub/testutil/sample"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openmetaearth/me-hub/testutil/sample"
 )
 
 func validMsgMintNFT(tokenID string) MsgMintNFT {

--- a/x/wnft/types/msgs_test.go
+++ b/x/wnft/types/msgs_test.go
@@ -1,0 +1,69 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/stretchr/testify/require"
+)
+
+func validMsgMintNFT(tokenID string) MsgMintNFT {
+	return MsgMintNFT{
+		ClassId:  "class1",
+		TokenId:  tokenID,
+		Uri:      "ipfs://token",
+		UriHash:  "hash",
+		Creator:  sample.AccAddress(),
+		Receiver: sample.AccAddress(),
+	}
+}
+
+func TestMsgMintNFTValidateBasicRejectsNonCanonicalTokenIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		tokenID string
+		err     error
+	}{
+		{
+			name:    "valid",
+			tokenID: "1",
+		},
+		{
+			name:    "leading zero",
+			tokenID: "01",
+			err:     sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:    "multiple leading zeros",
+			tokenID: "001",
+			err:     sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:    "zero",
+			tokenID: "0",
+			err:     sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:    "not numeric",
+			tokenID: "one",
+			err:     sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name:    "empty",
+			tokenID: "",
+			err:     ErrEmptyTokenId,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validMsgMintNFT(tt.tokenID).ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

fix mint nft token id

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #937

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened `MsgMintNFT` token ID validation to require a canonical base-10 value (rejects leading zeros and non-numeric inputs, and `0`).
  * Enforced a per-class minting supply cap so minting stops once the class total supply is reached.
  * Improved consistency of error handling with clearer `invalid token id` and `total supply exceeded` responses.

* **Tests**
  * Added unit tests for non-canonical token ID rejection.
  * Added message-server coverage for supply-cap enforcement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->