### PR TITLE
fix: check frozen status when UpdateRollapp

### DIFF
--- a/x/rollapp/keeper/msg_server_update_rollapp.go
+++ b/x/rollapp/keeper/msg_server_update_rollapp.go
@@ -16,6 +16,10 @@ func (k msgServer) UpdateRollapp(goCtx context.Context, msg *types.MsgUpdateRoll
 		return nil, types.ErrUnknownRollappID
 	}
 
+	if rollapp.Frozen {
+		return nil, types.ErrRollappJailed
+	}
+
 	if msg.Creator != rollapp.Creator {
 		return nil, types.ErrUnauthorizedRollappCreator
 	}

--- a/x/rollapp/types/errors.go
+++ b/x/rollapp/types/errors.go
@@ -33,6 +33,7 @@ var (
 	ErrNotFound                       = errorsmod.Register(ModuleName, 1037, "not found")
 	ErrLogic                          = errorsmod.Register(ModuleName, 1038, "internal logic error")
 	ErrInvalidAddress                 = errorsmod.Register(ModuleName, 1040, "invalid address")
+	ErrRollappJailed                  = errorsmod.Register(ModuleName, 1041, "rollapp is jailed")
 
 	/* ------------------------------ fraud related ----------------------------- */
 	ErrDisputeAlreadyFinalized = errorsmod.Register(ModuleName, 2000, "disputed height already finalized")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rollapp updates when the rollapp is frozen, returning a clear “jailed” error instead.
  * Existing update checks still apply when the rollapp is active, including authorization and configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->