### PR TITLE
fix: fix rollapp packet prefix collisions

### DIFF
--- a/x/delayedack/types/rollapp_packets_list_filter.go
+++ b/x/delayedack/types/rollapp_packets_list_filter.go
@@ -17,6 +17,12 @@ type Prefix struct {
 
 var bypassFilter = func(packet commontypes.RollappPacket) bool { return true }
 
+func byRollappIDFilter(rollappID string) func(packet commontypes.RollappPacket) bool {
+	return func(packet commontypes.RollappPacket) bool {
+		return packet.RollappId == rollappID
+	}
+}
+
 func PendingByRollappIDByMaxHeight(
 	rollappID string,
 	maxProofHeight uint64,
@@ -29,7 +35,7 @@ func PendingByRollappIDByMaxHeight(
 				End:   commontypes.RollappPacketByStatusByRollappIDByProofHeightPrefix(rollappID, status, maxProofHeight+1), // inclusive end
 			},
 		},
-		FilterFunc: bypassFilter,
+		FilterFunc: byRollappIDFilter(rollappID),
 	}
 }
 
@@ -40,7 +46,7 @@ func ByRollappIDByStatus(rollappID string, status ...commontypes.Status) Rollapp
 	}
 	return RollappPacketListFilter{
 		Prefixes:   prefixes,
-		FilterFunc: bypassFilter,
+		FilterFunc: byRollappIDFilter(rollappID),
 	}
 }
 
@@ -48,7 +54,7 @@ func ByRollappIDByTypeByStatus(rollappID string, packetType commontypes.RollappP
 	filter := ByRollappIDByStatus(rollappID, status...)
 	if packetType != commontypes.RollappPacket_UNDEFINED {
 		filter.FilterFunc = func(packet commontypes.RollappPacket) bool {
-			return packet.Type == packetType
+			return packet.RollappId == rollappID && packet.Type == packetType
 		}
 	}
 	return filter

--- a/x/delayedack/types/rollapp_packets_list_filter_test.go
+++ b/x/delayedack/types/rollapp_packets_list_filter_test.go
@@ -301,3 +301,33 @@ var testRollappPackets = []commontypes.RollappPacket{
 		Type:      commontypes.RollappPacket_ON_TIMEOUT,
 	},
 }
+
+func TestByRollappIDByStatusFiltersExactRollappID(t *testing.T) {
+	filter := types.ByRollappIDByStatus("parent", commontypes.Status_PENDING)
+
+	require.True(t, filter.FilterFunc(rollappPacketForFilter("parent", commontypes.RollappPacket_ON_RECV)))
+	require.False(t, filter.FilterFunc(rollappPacketForFilter("parent/child", commontypes.RollappPacket_ON_RECV)))
+}
+
+func TestPendingByRollappIDByMaxHeightFiltersExactRollappID(t *testing.T) {
+	filter := types.PendingByRollappIDByMaxHeight("parent", 10)
+
+	require.True(t, filter.FilterFunc(rollappPacketForFilter("parent", commontypes.RollappPacket_ON_RECV)))
+	require.False(t, filter.FilterFunc(rollappPacketForFilter("parent/child", commontypes.RollappPacket_ON_RECV)))
+}
+
+func TestByRollappIDByTypeByStatusFiltersExactRollappIDAndType(t *testing.T) {
+	filter := types.ByRollappIDByTypeByStatus("parent", commontypes.RollappPacket_ON_ACK, commontypes.Status_PENDING)
+
+	require.True(t, filter.FilterFunc(rollappPacketForFilter("parent", commontypes.RollappPacket_ON_ACK)))
+	require.False(t, filter.FilterFunc(rollappPacketForFilter("parent", commontypes.RollappPacket_ON_RECV)))
+	require.False(t, filter.FilterFunc(rollappPacketForFilter("parent/child", commontypes.RollappPacket_ON_ACK)))
+}
+
+func rollappPacketForFilter(rollappID string, packetType commontypes.RollappPacket_Type) commontypes.RollappPacket {
+	return commontypes.RollappPacket{
+		RollappId: rollappID,
+		Type:      packetType,
+		Status:    commontypes.Status_PENDING,
+	}
+}

--- a/x/rollapp/types/chain_id.go
+++ b/x/rollapp/types/chain_id.go
@@ -42,6 +42,10 @@ func NewChainID(id string) (ChainID, error) {
 		return ChainID{}, errorsmod.Wrapf(ErrInvalidRollappID, "exceeds 48 chars: %s: len: %d", chainID, len(chainID))
 	}
 
+	if strings.Contains(chainID, "/") {
+		return ChainID{}, errorsmod.Wrapf(ErrInvalidRollappID, "contains reserved key separator '/'")
+	}
+
 	eip155, err := getEIP155ID(chainID)
 	if err != nil {
 		return ChainID{}, err

--- a/x/rollapp/types/chain_id_test.go
+++ b/x/rollapp/types/chain_id_test.go
@@ -1,0 +1,22 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmetaearth/me-hub/testutil/sample"
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+)
+
+func TestNewChainIDRejectsKeySeparator(t *testing.T) {
+	_, err := types.NewChainID("parent/child")
+	require.Error(t, err)
+}
+
+func TestMsgCreateRollappValidateBasicRejectsKeySeparator(t *testing.T) {
+	msg := types.NewMsgCreateRollapp(sample.AccAddress(), "parent/child", 1, nil)
+
+	err := msg.ValidateBasic()
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened rollapp packet matching so filters now require an exact rollapp ID, preventing parent/child ID mismatches.
  * Improved chain ID validation by rejecting values containing the reserved `/` separator.
* **Tests**
  * Added coverage for exact rollapp ID filtering across multiple packet lookups.
  * Added validation tests for invalid chain IDs and rollapp creation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->