### PR TITLE
fix: check user credential in RemoveVC

### DIFF
--- a/x/did/keeper/msg_server.go
+++ b/x/did/keeper/msg_server.go
@@ -220,6 +220,12 @@ func (m msgServer) RemoveVC(goCtx context.Context, msg *types.MsgRemoveVC) (*typ
 		return &types.MsgRemoveVCResponse{}, types.ErrServiceNotActive
 	}
 
+	// check user credential
+	found = m.HasCredential(ctx, msg.Did, msg.Sid)
+	if !found {
+		return &types.MsgRemoveVCResponse{}, types.ErrCredentialNotFound
+	}
+
 	// check issuer did
 	issuer, found := m.GetDID(ctx, sdk.MustAccAddressFromBech32(msg.Issuer))
 	if !found || !slices.Contains(svc.Issuers, issuer) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential removal handling by returning a clear “credential not found” error when the credential is missing.
  * Prevents the operation from continuing when the target credential does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->