### PR TITLE
fix(cmd): use tendermint flag instead of positional arg

### DIFF
--- a/cmd/med/cmd/inspect.go
+++ b/cmd/med/cmd/inspect.go
@@ -24,6 +24,7 @@ import (
 const (
 	FlagHeight     = "height"
 	FlagTraceStore = "trace-store"
+	FlagTendermint = "tendermint"
 )
 
 // InspectCmd dumps app state to JSON.
@@ -31,7 +32,7 @@ const (
 func InspectCmd(appExporter types.AppExporter, appCreator types.AppCreator, defaultNodeHome string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inspect",
-		Short: "Inspect db state [tendermint]",
+		Short: "Inspect db state",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SetOut(cmd.OutOrStdout())
 			cmd.SetErr(cmd.OutOrStderr())
@@ -47,8 +48,8 @@ func InspectCmd(appExporter types.AppExporter, appCreator types.AppCreator, defa
 				return err
 			}
 
-			// TODO: fix to flag
-			if len(args) > 0 && args[0] == "tendermint" {
+			tendermint, _ := cmd.Flags().GetBool(FlagTendermint)
+			if tendermint {
 				return getCometbftState(serverCtx.Config)
 			}
 
@@ -136,6 +137,7 @@ func InspectCmd(appExporter types.AppExporter, appCreator types.AppCreator, defa
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
 	cmd.Flags().Int64(FlagHeight, -1, "Export state from a particular height (-1 means latest height)")
 	cmd.Flags().String(FlagTraceStore, "", "Enable KVStore tracing to an output file")
+	cmd.Flags().Bool(FlagTendermint, false, "Inspect tendermint state")
 
 	return cmd
 }

--- a/x/sequencer/keeper/hook_listener.go
+++ b/x/sequencer/keeper/hook_listener.go
@@ -53,13 +53,17 @@ func (hook rollappHook) AfterStateFinalized(ctx sdk.Context, rollappID string, s
 	}
 	if val != nil {
 		if (stateInfo.StartHeight + stateInfo.NumBlocks - 1) >= uint64(val.ReplaceProposer.BlockHeight) {
-			// Rollapp-binding check to prevent stalled finalization / cross-rollapp proposers
+			// Rollapp-binding check: drop corrupted ReplaceProposer state to prevent stalled finalization
 			oldSeq, found := hook.k.GetSequencer(ctx, val.ReplaceProposer.OldProposer)
 			if !found {
-				return types.ErrUnknownSequencer
+				hook.k.DeleteReplaceProposer(ctx, rollappID)
+				hook.k.Logger(ctx).Error("dropping invalid ReplaceProposer", "rollapp", rollappID, "old_sequencer", val.ReplaceProposer.OldProposer, "reason", "unknown old sequencer")
+				return nil
 			}
 			if oldSeq.RollappId != rollappID {
-				return types.ErrSequencerRollappMismatch
+				hook.k.DeleteReplaceProposer(ctx, rollappID)
+				hook.k.Logger(ctx).Error("dropping invalid ReplaceProposer", "rollapp", rollappID, "old_sequencer", val.ReplaceProposer.OldProposer, "reason", "rollapp mismatch")
+				return nil
 			}
 
 			err = hook.k.forceRemoveUnbondingSequencer(ctx, val.ReplaceProposer.OldProposer, stateInfo.StartHeight, stateInfo.NumBlocks)

--- a/x/sequencer/keeper/hook_listener.go
+++ b/x/sequencer/keeper/hook_listener.go
@@ -53,6 +53,15 @@ func (hook rollappHook) AfterStateFinalized(ctx sdk.Context, rollappID string, s
 	}
 	if val != nil {
 		if (stateInfo.StartHeight + stateInfo.NumBlocks - 1) >= uint64(val.ReplaceProposer.BlockHeight) {
+			// Rollapp-binding check to prevent stalled finalization / cross-rollapp proposers
+			oldSeq, found := hook.k.GetSequencer(ctx, val.ReplaceProposer.OldProposer)
+			if !found {
+				return types.ErrUnknownSequencer
+			}
+			if oldSeq.RollappId != rollappID {
+				return types.ErrSequencerRollappMismatch
+			}
+
 			err = hook.k.forceRemoveUnbondingSequencer(ctx, val.ReplaceProposer.OldProposer, stateInfo.StartHeight, stateInfo.NumBlocks)
 			if err != nil {
 				hook.k.Logger(ctx).Error("forceRemoveUnbondingSequencer error.", "sequencer", val.ReplaceProposer.OldProposer,

--- a/x/sequencer/keeper/hooks_test.go
+++ b/x/sequencer/keeper/hooks_test.go
@@ -79,7 +79,7 @@ func (suite *SequencerTestSuite) TestReplaceProposerAfterStateFinalizedRollappBi
 	err = keeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, &stateInfo)
 	suite.Require().NoError(err)
 
-	// 2. Corrupted ReplaceProposer state matching wrong oldProposer rollapp
+	// 2. Corrupted ReplaceProposer state: oldProposer belongs to wrong rollapp
 	// Cleanup and set a new one
 	keeper.DeleteReplaceProposer(suite.Ctx, rollappId)
 	
@@ -104,9 +104,28 @@ func (suite *SequencerTestSuite) TestReplaceProposerAfterStateFinalizedRollappBi
 	suite.Require().NoError(err)
 	store.Set(types.RepalceRollappProposerKey(rollappId), bz)
 
-	// Trigger hook with the wrong binding
+	// Trigger hook with the wrong binding — should recover (no error) and delete the bad entry
 	err = keeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, &stateInfo)
-	suite.Require().Error(err)
-	suite.Require().ErrorIs(err, types.ErrSequencerRollappMismatch)
+	suite.Require().NoError(err)
+	// Verify the corrupted entry was cleaned up
+	suite.Require().False(keeper.IsHasReplaceProposer(suite.Ctx, rollappId))
+
+	// 3. Unknown old sequencer — should also recover and delete
+	unknownBadMsg := types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: "cosmos1nonexistent",
+		NewProposer: oldProposerAddr,
+		BlockHeight: 10,
+	}
+	bz, err = suite.App.AppCodec().Marshal(&types.MsgStoreReplaceProposer{
+		ReplaceProposer: unknownBadMsg,
+		HubBlockHeight:  suite.Ctx.BlockHeight(),
+	})
+	suite.Require().NoError(err)
+	store.Set(types.RepalceRollappProposerKey(rollappId), bz)
+
+	err = keeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, &stateInfo)
+	suite.Require().NoError(err)
+	suite.Require().False(keeper.IsHasReplaceProposer(suite.Ctx, rollappId))
 }
 

--- a/x/sequencer/keeper/hooks_test.go
+++ b/x/sequencer/keeper/hooks_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"time"
 
+	rollapptypes "github.com/openmetaearth/me-hub/x/rollapp/types"
 	"github.com/openmetaearth/me-hub/x/sequencer/types"
 )
 
@@ -41,3 +42,71 @@ func (suite *SequencerTestSuite) TestFraudSubmittedHook() {
 		suite.Require().Equal(sequencer.Status, types.Unbonded)
 	}
 }
+
+func (suite *SequencerTestSuite) TestReplaceProposerAfterStateFinalizedRollappBinding() {
+	suite.SetupTest()
+	keeper := suite.App.SequencerKeeper
+
+	rollappId := suite.CreateDefaultRollapp()
+	oldProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, rollappId)
+	
+	// Set the old proposer as unbonding status so forceRemoveUnbondingSequencer can be run (otherwise it returns ErrInvalidSequencerStatus)
+	oldSeq, found := keeper.GetSequencer(suite.Ctx, oldProposerAddr)
+	suite.Require().True(found)
+	oldSeq.Status = types.Unbonding
+	keeper.SetSequencer(suite.Ctx, oldSeq)
+
+	// Create sequencer on another rollapp
+	otherRollappId := suite.CreateDefaultRollapp()
+	otherProposerAddr := suite.CreateDefaultSequencer(suite.Ctx, otherRollappId)
+	
+	// 1. Valid case matching rollappId
+	replaceProposerMsg := types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: oldProposerAddr,
+		NewProposer: otherProposerAddr,
+		BlockHeight: 10,
+	}
+	err := keeper.SetReplaceProposer(suite.Ctx, &replaceProposerMsg)
+	suite.Require().NoError(err)
+
+	stateInfo := rollapptypes.StateInfo{
+		StateInfoIndex: rollapptypes.StateInfoIndex{RollappId: rollappId, Index: 1},
+		StartHeight:    1,
+		NumBlocks:      15, // BlockHeight 10 <= StartHeight + NumBlocks - 1 (15)
+	}
+
+	err = keeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, &stateInfo)
+	suite.Require().NoError(err)
+
+	// 2. Corrupted ReplaceProposer state matching wrong oldProposer rollapp
+	// Cleanup and set a new one
+	keeper.DeleteReplaceProposer(suite.Ctx, rollappId)
+	
+	// Create another sequencer on the other rollapp
+	otherSeq, found := keeper.GetSequencer(suite.Ctx, otherProposerAddr)
+	suite.Require().True(found)
+	otherSeq.Status = types.Unbonding
+	keeper.SetSequencer(suite.Ctx, otherSeq)
+
+	badReplaceProposerMsg := types.MsgRepalceProposer{
+		RollappId:   rollappId,
+		OldProposer: otherProposerAddr, // Belongs to otherRollappId instead of rollappId
+		NewProposer: oldProposerAddr,
+		BlockHeight: 10,
+	}
+	// Bypass SetReplaceProposer check (which would block it at Tx submission time) to test the hook safety net
+	store := suite.Ctx.KVStore(suite.App.GetKey(types.StoreKey))
+	bz, err := suite.App.AppCodec().Marshal(&types.MsgStoreReplaceProposer{
+		ReplaceProposer: badReplaceProposerMsg,
+		HubBlockHeight:  suite.Ctx.BlockHeight(),
+	})
+	suite.Require().NoError(err)
+	store.Set(types.RepalceRollappProposerKey(rollappId), bz)
+
+	// Trigger hook with the wrong binding
+	err = keeper.RollappHooks().AfterStateFinalized(suite.Ctx, rollappId, &stateInfo)
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, types.ErrSequencerRollappMismatch)
+}
+


### PR DESCRIPTION
Fixes a TODO in InspectCmd to parse tendermint as a flag rather than a positional argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--tendermint` flag to the inspect command for selecting Tendermint/CometBFT state output.

* **Bug Fixes**
  * Improved handling of proposer replacement state during finalization, preventing stalled processing when stored sequencer references are missing or invalid.
  * Automatically clears invalid replacement entries and logs an error when inconsistent state is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->