### PR TITLE
fix: fix LastObservedRelayer used hardcode bsc as chain name(#240)

### DIFF
--- a/x/gravity/keeper/grpc_query_router.go
+++ b/x/gravity/keeper/grpc_query_router.go
@@ -228,7 +228,7 @@ func (k RouterKeeper) BridgeChainList(c context.Context, req *types.QueryBridgeC
 }
 
 func (k RouterKeeper) LastObservedRelayer(c context.Context, req *types.QueryLastObservedRelayer) (*types.QueryLastObservedRelayerResponse, error) {
-	if queryServer, err := k.getQueryServerByChainName(bsctypes.ModuleName); err != nil {
+	if queryServer, err := k.getQueryServerByChainName(req.ChainName); err != nil {
 		return nil, err
 	} else {
 		return queryServer.LastObservedRelayer(c, req)


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query routing so the last observed relayer is now looked up using the requested chain name, helping ensure results come from the right chain-specific query service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->