### PR TITLE
fix: update OnRecvPacket return handling and transfer enabling logic

### DIFF
--- a/x/rollapp/transfergenesis/ibc_module.go
+++ b/x/rollapp/transfergenesis/ibc_module.go
@@ -113,11 +113,11 @@ func (w IBCModule) OnRecvPacket(
 	memo, err := getMemo(transfer.GetMemo())
 	if errorsmod.IsOf(err, gerrc.ErrNotFound) {
 		// The first regular transfer marks the full opening of the bridge, more genesis transfers will not be allowed.
-		err := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
-		if err == nil && !ra.GenesisState.TransfersEnabled {
+		ack := w.IBCModule.OnRecvPacket(ctx, packet, relayer)
+		if (ack == nil || ack.Success()) && !ra.GenesisState.TransfersEnabled {
 			w.rollappKeeper.EnableTransfers(ctx, ra.RollappId)
 		}
-		return err
+		return ack
 	}
 	if err != nil {
 		l.Error("Get memo.", "err", err)


### PR DESCRIPTION
This pull request updates the `OnRecvPacket` function in `ibc_module.go` to improve how acknowledgments are handled and to ensure transfer enabling logic is based on the success of the packet acknowledgment, not just the absence of errors.

Key change:

* Changed the handling of the return value from `OnRecvPacket` to use the acknowledgment (`ack`) object, checking for both `nil` and successful acknowledgments before enabling transfers, and returning `ack` instead of an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rollapp transfers now enable only after a successful IBC packet acknowledgment, avoiding cases where transfers could be turned on too early.
  * Improved handling of packet processing results so successful and failed acknowledgments are treated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->