### PR TITLE
fix(did): enforce comprehensive genesis state validation

### DIFF
--- a/x/did/types/genesis.go
+++ b/x/did/types/genesis.go
@@ -16,6 +16,10 @@ func DefaultGenesis() *GenesisState {
 	}
 }
 
+// credKey is used as a composite map key to safely deduplicate (did, sid) pairs
+// without risk of "/" collisions that a string concatenation key would have.
+type credKey struct{ Did, Sid string }
+
 // Validate performs basic genesis state validation returning an error upon any failure.
 func (gs *GenesisState) Validate() error {
 	// --- validate Infos ---
@@ -50,6 +54,17 @@ func (gs *GenesisState) Validate() error {
 		if len(svc.Sid) < 2 || len(svc.Sid) > 8 {
 			return fmt.Errorf("svcs[%d]: sid length must be between 2 and 8, got %d", i, len(svc.Sid))
 		}
+		if len(svc.Name) == 0 || len(svc.Name) > 20 {
+			return fmt.Errorf("svcs[%d]: name length must be between 1 and 20, got %d", i, len(svc.Name))
+		}
+		if len(svc.Description) > 1024 {
+			return fmt.Errorf("svcs[%d]: description length exceeds 1024, got %d", i, len(svc.Description))
+		}
+		for j, issuer := range svc.Issuers {
+			if len(issuer) != DidLength {
+				return fmt.Errorf("svcs[%d].issuers[%d]: issuer DID length must be %d, got %d", i, j, DidLength, len(issuer))
+			}
+		}
 		if _, ok := ServiceStatus_name[int32(svc.Status)]; !ok {
 			return fmt.Errorf("svcs[%d]: invalid service status %d", i, svc.Status)
 		}
@@ -60,7 +75,7 @@ func (gs *GenesisState) Validate() error {
 	}
 
 	// --- validate Vcs ---
-	vcSet := make(map[string]struct{}, len(gs.Vcs))
+	vcSet := make(map[credKey]struct{}, len(gs.Vcs))
 	for i, vc := range gs.Vcs {
 		if len(vc.Did) != DidLength {
 			return fmt.Errorf("vcs[%d]: DID length must be %d, got %d", i, DidLength, len(vc.Did))
@@ -71,10 +86,13 @@ func (gs *GenesisState) Validate() error {
 		if len(vc.Hash) == 0 || len(vc.Hash) > 128 {
 			return fmt.Errorf("vcs[%d]: hash length must be between 1 and 128, got %d", i, len(vc.Hash))
 		}
+		if len(vc.Uri) > 1024 {
+			return fmt.Errorf("vcs[%d]: uri length exceeds 1024, got %d", i, len(vc.Uri))
+		}
 		if len(vc.Data) > maxCredentialDataLength {
 			return fmt.Errorf("vcs[%d]: data length exceeds %d", i, maxCredentialDataLength)
 		}
-		key := vc.Did + "/" + vc.Sid
+		key := credKey{vc.Did, vc.Sid}
 		if _, dup := vcSet[key]; dup {
 			return fmt.Errorf("vcs[%d]: duplicate credential (did=%s, sid=%s)", i, vc.Did, vc.Sid)
 		}
@@ -84,7 +102,7 @@ func (gs *GenesisState) Validate() error {
 	// --- validate Flogs ---
 	// Each FilterLogger must reference an existing Credential in Vcs to prevent
 	// a panic in InitGenesis when GetCredential returns not-found.
-	flogSet := make(map[string]struct{}, len(gs.Flogs))
+	flogSet := make(map[credKey]struct{}, len(gs.Flogs))
 	for i, flog := range gs.Flogs {
 		if len(flog.Did) != DidLength {
 			return fmt.Errorf("flogs[%d]: DID length must be %d, got %d", i, DidLength, len(flog.Did))
@@ -92,7 +110,7 @@ func (gs *GenesisState) Validate() error {
 		if len(flog.Sid) < 2 || len(flog.Sid) > 8 {
 			return fmt.Errorf("flogs[%d]: sid length must be between 2 and 8, got %d", i, len(flog.Sid))
 		}
-		vcKey := flog.Did + "/" + flog.Sid
+		vcKey := credKey{flog.Did, flog.Sid}
 		if _, found := vcSet[vcKey]; !found {
 			return fmt.Errorf("flogs[%d]: referenced credential (did=%s, sid=%s) not found in vcs", i, flog.Did, flog.Sid)
 		}
@@ -100,6 +118,11 @@ func (gs *GenesisState) Validate() error {
 			return fmt.Errorf("flogs[%d]: duplicate filter logger (did=%s, sid=%s)", i, flog.Did, flog.Sid)
 		}
 		flogSet[vcKey] = struct{}{}
+		for k, filter := range flog.Filters {
+			if len(filter) > 1024 {
+				return fmt.Errorf("flogs[%d].filters[%d]: filter length exceeds 1024, got %d", i, k, len(filter))
+			}
+		}
 	}
 
 	return nil

--- a/x/did/types/genesis.go
+++ b/x/did/types/genesis.go
@@ -32,7 +32,8 @@ func (gs *GenesisState) Validate() error {
 		if info.Pubkey == "" {
 			return fmt.Errorf("infos[%d]: pubkey must not be empty", i)
 		}
-		if _, err := sdk.AccAddressFromBech32(info.Address); err != nil {
+		addr, err := sdk.AccAddressFromBech32(info.Address)
+		if err != nil {
 			return fmt.Errorf("infos[%d]: invalid address %q: %w", i, info.Address, err)
 		}
 		if _, ok := DidStatus_name[int32(info.Status)]; !ok {
@@ -42,10 +43,13 @@ func (gs *GenesisState) Validate() error {
 			return fmt.Errorf("infos[%d]: duplicate DID %q", i, info.Did)
 		}
 		didSet[info.Did] = struct{}{}
-		if _, dup := addrSet[info.Address]; dup {
+		// Normalize to canonical bech32 to prevent case-variant bypass
+		// (e.g. "ME1..." and "me1..." decode to the same bytes but differ as strings).
+		canonicalAddr := addr.String()
+		if _, dup := addrSet[canonicalAddr]; dup {
 			return fmt.Errorf("infos[%d]: duplicate address %q", i, info.Address)
 		}
-		addrSet[info.Address] = struct{}{}
+		addrSet[canonicalAddr] = struct{}{}
 	}
 
 	// --- validate Svcs ---

--- a/x/did/types/genesis.go
+++ b/x/did/types/genesis.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
@@ -12,5 +18,89 @@ func DefaultGenesis() *GenesisState {
 
 // Validate performs basic genesis state validation returning an error upon any failure.
 func (gs *GenesisState) Validate() error {
+	// --- validate Infos ---
+	didSet := make(map[string]struct{}, len(gs.Infos))
+	addrSet := make(map[string]struct{}, len(gs.Infos))
+	for i, info := range gs.Infos {
+		if len(info.Did) != DidLength {
+			return fmt.Errorf("infos[%d]: DID length must be %d, got %d", i, DidLength, len(info.Did))
+		}
+		if info.Pubkey == "" {
+			return fmt.Errorf("infos[%d]: pubkey must not be empty", i)
+		}
+		if _, err := sdk.AccAddressFromBech32(info.Address); err != nil {
+			return fmt.Errorf("infos[%d]: invalid address %q: %w", i, info.Address, err)
+		}
+		if _, ok := DidStatus_name[int32(info.Status)]; !ok {
+			return fmt.Errorf("infos[%d]: invalid DID status %d", i, info.Status)
+		}
+		if _, dup := didSet[info.Did]; dup {
+			return fmt.Errorf("infos[%d]: duplicate DID %q", i, info.Did)
+		}
+		didSet[info.Did] = struct{}{}
+		if _, dup := addrSet[info.Address]; dup {
+			return fmt.Errorf("infos[%d]: duplicate address %q", i, info.Address)
+		}
+		addrSet[info.Address] = struct{}{}
+	}
+
+	// --- validate Svcs ---
+	svcSet := make(map[string]struct{}, len(gs.Svcs))
+	for i, svc := range gs.Svcs {
+		if len(svc.Sid) < 2 || len(svc.Sid) > 8 {
+			return fmt.Errorf("svcs[%d]: sid length must be between 2 and 8, got %d", i, len(svc.Sid))
+		}
+		if _, ok := ServiceStatus_name[int32(svc.Status)]; !ok {
+			return fmt.Errorf("svcs[%d]: invalid service status %d", i, svc.Status)
+		}
+		if _, dup := svcSet[svc.Sid]; dup {
+			return fmt.Errorf("svcs[%d]: duplicate service sid %q", i, svc.Sid)
+		}
+		svcSet[svc.Sid] = struct{}{}
+	}
+
+	// --- validate Vcs ---
+	vcSet := make(map[string]struct{}, len(gs.Vcs))
+	for i, vc := range gs.Vcs {
+		if len(vc.Did) != DidLength {
+			return fmt.Errorf("vcs[%d]: DID length must be %d, got %d", i, DidLength, len(vc.Did))
+		}
+		if len(vc.Sid) < 2 || len(vc.Sid) > 8 {
+			return fmt.Errorf("vcs[%d]: sid length must be between 2 and 8, got %d", i, len(vc.Sid))
+		}
+		if len(vc.Hash) == 0 || len(vc.Hash) > 128 {
+			return fmt.Errorf("vcs[%d]: hash length must be between 1 and 128, got %d", i, len(vc.Hash))
+		}
+		if len(vc.Data) > maxCredentialDataLength {
+			return fmt.Errorf("vcs[%d]: data length exceeds %d", i, maxCredentialDataLength)
+		}
+		key := vc.Did + "/" + vc.Sid
+		if _, dup := vcSet[key]; dup {
+			return fmt.Errorf("vcs[%d]: duplicate credential (did=%s, sid=%s)", i, vc.Did, vc.Sid)
+		}
+		vcSet[key] = struct{}{}
+	}
+
+	// --- validate Flogs ---
+	// Each FilterLogger must reference an existing Credential in Vcs to prevent
+	// a panic in InitGenesis when GetCredential returns not-found.
+	flogSet := make(map[string]struct{}, len(gs.Flogs))
+	for i, flog := range gs.Flogs {
+		if len(flog.Did) != DidLength {
+			return fmt.Errorf("flogs[%d]: DID length must be %d, got %d", i, DidLength, len(flog.Did))
+		}
+		if len(flog.Sid) < 2 || len(flog.Sid) > 8 {
+			return fmt.Errorf("flogs[%d]: sid length must be between 2 and 8, got %d", i, len(flog.Sid))
+		}
+		vcKey := flog.Did + "/" + flog.Sid
+		if _, found := vcSet[vcKey]; !found {
+			return fmt.Errorf("flogs[%d]: referenced credential (did=%s, sid=%s) not found in vcs", i, flog.Did, flog.Sid)
+		}
+		if _, dup := flogSet[vcKey]; dup {
+			return fmt.Errorf("flogs[%d]: duplicate filter logger (did=%s, sid=%s)", i, flog.Did, flog.Sid)
+		}
+		flogSet[vcKey] = struct{}{}
+	}
+
 	return nil
 }

--- a/x/did/types/genesis_test.go
+++ b/x/did/types/genesis_test.go
@@ -90,6 +90,20 @@ func TestGenesisState_Validate_DuplicateAddress(t *testing.T) {
 	require.ErrorContains(t, gs.Validate(), "duplicate address")
 }
 
+func TestGenesisState_Validate_DuplicateAddressCaseVariant(t *testing.T) {
+	// bech32 upper-case variant of genesisTestAddress decodes to the same bytes
+	// but differs as a raw string — must still be caught as a duplicate.
+	gs := validGenesis()
+	upperAddr := strings.ToUpper(genesisTestAddress)
+	gs.Infos = append(gs.Infos, DidInfo{
+		Did:     "9999999999999",
+		Address: upperAddr,
+		Pubkey:  genesisTestPubkey,
+		Status:  DID_STATUS_ACTIVE,
+	})
+	require.ErrorContains(t, gs.Validate(), "duplicate address")
+}
+
 func TestGenesisState_Validate_InvalidDIDLength(t *testing.T) {
 	gs := validGenesis()
 	gs.Infos[0].Did = genesisTestShortValue

--- a/x/did/types/genesis_test.go
+++ b/x/did/types/genesis_test.go
@@ -1,4 +1,4 @@
-package types_test
+package types
 
 import (
 	"strings"
@@ -6,47 +6,49 @@ import (
 
 	_ "github.com/evmos/ethermint/crypto/ethsecp256k1"
 	"github.com/stretchr/testify/require"
-
-	"github.com/openmetaearth/me-hub/x/did/types"
 )
+
+// genesis_test.go is in package types (not types_test) so it shares the
+// TestMain defined in message_vc_test.go, which configures the "me" bech32
+// prefix before any test runs.
 
 const (
-	testDID     = "1000000000001" // length == DidLength (13)
-	testAddress = "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4"
-	testPubkey  = "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}"
+	genesisTestDID     = "1000000000001" // length == DidLength (13)
+	genesisTestAddress = "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4"
+	genesisTestPubkey  = "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}"
 )
 
-func validGenesis() types.GenesisState {
-	return types.GenesisState{
-		Infos: []types.DidInfo{
+func validGenesis() GenesisState {
+	return GenesisState{
+		Infos: []DidInfo{
 			{
-				Did:     testDID,
-				Address: testAddress,
-				Pubkey:  testPubkey,
-				Status:  types.DID_STATUS_ACTIVE,
+				Did:     genesisTestDID,
+				Address: genesisTestAddress,
+				Pubkey:  genesisTestPubkey,
+				Status:  DID_STATUS_ACTIVE,
 			},
 		},
-		Svcs: []types.Service{
+		Svcs: []Service{
 			{
 				Sid:         "kyc",
 				Name:        "kyc",
 				Description: "this is kyc test service.",
-				Issuers:     []string{testDID},
-				Status:      types.SERVICE_STATUS_ACTIVE,
+				Issuers:     []string{genesisTestDID},
+				Status:      SERVICE_STATUS_ACTIVE,
 			},
 		},
-		Vcs: []types.Credential{
+		Vcs: []Credential{
 			{
-				Did:  testDID,
+				Did:  genesisTestDID,
 				Sid:  "kyc",
 				Hash: "0000000000000000001",
 				Uri:  "http://metaearth.com/files/0001.vc",
 				Data: []byte("test"),
 			},
 		},
-		Flogs: []types.FilterLogger{
+		Flogs: []FilterLogger{
 			{
-				Did: testDID,
+				Did: genesisTestDID,
 				Sid: "kyc",
 				Filters: [][]byte{
 					[]byte("A0"),
@@ -56,30 +58,33 @@ func validGenesis() types.GenesisState {
 	}
 }
 
+// --- happy path ---
+
 func TestGenesisState_Validate_Valid(t *testing.T) {
 	gs := validGenesis()
 	require.NoError(t, gs.Validate())
 }
 
 func TestGenesisState_Validate_EmptyGenesis(t *testing.T) {
-	gs := types.DefaultGenesis()
+	gs := DefaultGenesis()
 	require.NoError(t, gs.Validate())
 }
 
+// --- Infos ---
+
 func TestGenesisState_Validate_DuplicateDID(t *testing.T) {
 	gs := validGenesis()
-	gs.Infos = append(gs.Infos, gs.Infos[0]) // duplicate DID
+	gs.Infos = append(gs.Infos, gs.Infos[0])
 	require.ErrorContains(t, gs.Validate(), "duplicate DID")
 }
 
 func TestGenesisState_Validate_DuplicateAddress(t *testing.T) {
 	gs := validGenesis()
-	// different DID but same address
-	gs.Infos = append(gs.Infos, types.DidInfo{
+	gs.Infos = append(gs.Infos, DidInfo{
 		Did:     "9999999999999",
-		Address: testAddress,
-		Pubkey:  testPubkey,
-		Status:  types.DID_STATUS_ACTIVE,
+		Address: genesisTestAddress,
+		Pubkey:  genesisTestPubkey,
+		Status:  DID_STATUS_ACTIVE,
 	})
 	require.ErrorContains(t, gs.Validate(), "duplicate address")
 }
@@ -102,6 +107,14 @@ func TestGenesisState_Validate_InvalidAddress(t *testing.T) {
 	require.ErrorContains(t, gs.Validate(), "invalid address")
 }
 
+func TestGenesisState_Validate_InvalidDidStatus(t *testing.T) {
+	gs := validGenesis()
+	gs.Infos[0].Status = DidStatus(99)
+	require.ErrorContains(t, gs.Validate(), "invalid DID status")
+}
+
+// --- Svcs ---
+
 func TestGenesisState_Validate_DuplicateServiceSid(t *testing.T) {
 	gs := validGenesis()
 	gs.Svcs = append(gs.Svcs, gs.Svcs[0])
@@ -110,9 +123,41 @@ func TestGenesisState_Validate_DuplicateServiceSid(t *testing.T) {
 
 func TestGenesisState_Validate_InvalidServiceSidLength(t *testing.T) {
 	gs := validGenesis()
-	gs.Svcs[0].Sid = "a" // too short
+	gs.Svcs[0].Sid = "a" // too short (< 2)
 	require.ErrorContains(t, gs.Validate(), "sid length")
 }
+
+func TestGenesisState_Validate_InvalidServiceNameEmpty(t *testing.T) {
+	gs := validGenesis()
+	gs.Svcs[0].Name = ""
+	require.ErrorContains(t, gs.Validate(), "name length")
+}
+
+func TestGenesisState_Validate_InvalidServiceNameTooLong(t *testing.T) {
+	gs := validGenesis()
+	gs.Svcs[0].Name = strings.Repeat("x", 21)
+	require.ErrorContains(t, gs.Validate(), "name length")
+}
+
+func TestGenesisState_Validate_InvalidServiceDescriptionTooLong(t *testing.T) {
+	gs := validGenesis()
+	gs.Svcs[0].Description = strings.Repeat("x", 1025)
+	require.ErrorContains(t, gs.Validate(), "description length")
+}
+
+func TestGenesisState_Validate_InvalidServiceIssuerDIDLength(t *testing.T) {
+	gs := validGenesis()
+	gs.Svcs[0].Issuers = []string{"tooshort"}
+	require.ErrorContains(t, gs.Validate(), "issuer DID length")
+}
+
+func TestGenesisState_Validate_InvalidServiceStatus(t *testing.T) {
+	gs := validGenesis()
+	gs.Svcs[0].Status = ServiceStatus(99)
+	require.ErrorContains(t, gs.Validate(), "invalid service status")
+}
+
+// --- Vcs ---
 
 func TestGenesisState_Validate_DuplicateCredential(t *testing.T) {
 	gs := validGenesis()
@@ -120,16 +165,47 @@ func TestGenesisState_Validate_DuplicateCredential(t *testing.T) {
 	require.ErrorContains(t, gs.Validate(), "duplicate credential")
 }
 
+func TestGenesisState_Validate_InvalidCredentialDIDLength(t *testing.T) {
+	gs := validGenesis()
+	gs.Vcs[0].Did = "short"
+	require.ErrorContains(t, gs.Validate(), "DID length")
+}
+
+func TestGenesisState_Validate_InvalidCredentialSidLength(t *testing.T) {
+	gs := validGenesis()
+	gs.Vcs[0].Sid = "a" // too short
+	require.ErrorContains(t, gs.Validate(), "sid length")
+}
+
+func TestGenesisState_Validate_InvalidCredentialHashEmpty(t *testing.T) {
+	gs := validGenesis()
+	gs.Vcs[0].Hash = ""
+	require.ErrorContains(t, gs.Validate(), "hash length")
+}
+
+func TestGenesisState_Validate_InvalidCredentialHashTooLong(t *testing.T) {
+	gs := validGenesis()
+	gs.Vcs[0].Hash = strings.Repeat("x", 129)
+	require.ErrorContains(t, gs.Validate(), "hash length")
+}
+
+func TestGenesisState_Validate_InvalidCredentialUriTooLong(t *testing.T) {
+	gs := validGenesis()
+	gs.Vcs[0].Uri = strings.Repeat("x", 1025)
+	require.ErrorContains(t, gs.Validate(), "uri length")
+}
+
 func TestGenesisState_Validate_CredentialDataTooLarge(t *testing.T) {
 	gs := validGenesis()
-	gs.Vcs[0].Data = []byte(strings.Repeat("x", 64*1024+1))
+	gs.Vcs[0].Data = []byte(strings.Repeat("x", maxCredentialDataLength+1))
 	require.ErrorContains(t, gs.Validate(), "data length exceeds")
 }
 
+// --- Flogs ---
+
 func TestGenesisState_Validate_FlogOrphanCredential(t *testing.T) {
 	gs := validGenesis()
-	// flog references a credential that does not exist in Vcs
-	gs.Flogs[0].Did = "9999999999999"
+	gs.Flogs[0].Did = "9999999999999" // no matching vc
 	require.ErrorContains(t, gs.Validate(), "not found in vcs")
 }
 
@@ -137,6 +213,18 @@ func TestGenesisState_Validate_FlogInvalidDIDLength(t *testing.T) {
 	gs := validGenesis()
 	gs.Flogs[0].Did = "short"
 	require.ErrorContains(t, gs.Validate(), "DID length")
+}
+
+func TestGenesisState_Validate_FlogInvalidSidLength(t *testing.T) {
+	gs := validGenesis()
+	gs.Flogs[0].Sid = "a" // too short
+	require.ErrorContains(t, gs.Validate(), "sid length")
+}
+
+func TestGenesisState_Validate_FlogFilterTooLong(t *testing.T) {
+	gs := validGenesis()
+	gs.Flogs[0].Filters = [][]byte{[]byte(strings.Repeat("x", 1025))}
+	require.ErrorContains(t, gs.Validate(), "filter length exceeds")
 }
 
 func TestGenesisState_Validate_DuplicateFlog(t *testing.T) {

--- a/x/did/types/genesis_test.go
+++ b/x/did/types/genesis_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"strings"
 	"testing"
 
 	_ "github.com/evmos/ethermint/crypto/ethsecp256k1"
@@ -9,13 +10,20 @@ import (
 	"github.com/openmetaearth/me-hub/x/did/types"
 )
 
-func TestGenesisState_Validate(t *testing.T) {
-	test := types.GenesisState{
+const (
+	testDID     = "1000000000001" // length == DidLength (13)
+	testAddress = "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4"
+	testPubkey  = "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}"
+)
+
+func validGenesis() types.GenesisState {
+	return types.GenesisState{
 		Infos: []types.DidInfo{
 			{
-				Did:    "1000000000001",
-				Pubkey: "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}",
-				Status: types.DID_STATUS_ACTIVE,
+				Did:     testDID,
+				Address: testAddress,
+				Pubkey:  testPubkey,
+				Status:  types.DID_STATUS_ACTIVE,
 			},
 		},
 		Svcs: []types.Service{
@@ -23,13 +31,13 @@ func TestGenesisState_Validate(t *testing.T) {
 				Sid:         "kyc",
 				Name:        "kyc",
 				Description: "this is kyc test service.",
-				Issuers:     []string{"1000000000001"},
+				Issuers:     []string{testDID},
 				Status:      types.SERVICE_STATUS_ACTIVE,
 			},
 		},
 		Vcs: []types.Credential{
 			{
-				Did:  "1000000000001",
+				Did:  testDID,
 				Sid:  "kyc",
 				Hash: "0000000000000000001",
 				Uri:  "http://metaearth.com/files/0001.vc",
@@ -38,7 +46,7 @@ func TestGenesisState_Validate(t *testing.T) {
 		},
 		Flogs: []types.FilterLogger{
 			{
-				Did: "000000000001",
+				Did: testDID,
 				Sid: "kyc",
 				Filters: [][]byte{
 					[]byte("A0"),
@@ -46,7 +54,93 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 		},
 	}
+}
 
-	err := test.Validate()
-	require.NoError(t, err)
+func TestGenesisState_Validate_Valid(t *testing.T) {
+	gs := validGenesis()
+	require.NoError(t, gs.Validate())
+}
+
+func TestGenesisState_Validate_EmptyGenesis(t *testing.T) {
+	gs := types.DefaultGenesis()
+	require.NoError(t, gs.Validate())
+}
+
+func TestGenesisState_Validate_DuplicateDID(t *testing.T) {
+	gs := validGenesis()
+	gs.Infos = append(gs.Infos, gs.Infos[0]) // duplicate DID
+	require.ErrorContains(t, gs.Validate(), "duplicate DID")
+}
+
+func TestGenesisState_Validate_DuplicateAddress(t *testing.T) {
+	gs := validGenesis()
+	// different DID but same address
+	gs.Infos = append(gs.Infos, types.DidInfo{
+		Did:     "9999999999999",
+		Address: testAddress,
+		Pubkey:  testPubkey,
+		Status:  types.DID_STATUS_ACTIVE,
+	})
+	require.ErrorContains(t, gs.Validate(), "duplicate address")
+}
+
+func TestGenesisState_Validate_InvalidDIDLength(t *testing.T) {
+	gs := validGenesis()
+	gs.Infos[0].Did = "short"
+	require.ErrorContains(t, gs.Validate(), "DID length")
+}
+
+func TestGenesisState_Validate_EmptyPubkey(t *testing.T) {
+	gs := validGenesis()
+	gs.Infos[0].Pubkey = ""
+	require.ErrorContains(t, gs.Validate(), "pubkey must not be empty")
+}
+
+func TestGenesisState_Validate_InvalidAddress(t *testing.T) {
+	gs := validGenesis()
+	gs.Infos[0].Address = "not-a-valid-address"
+	require.ErrorContains(t, gs.Validate(), "invalid address")
+}
+
+func TestGenesisState_Validate_DuplicateServiceSid(t *testing.T) {
+	gs := validGenesis()
+	gs.Svcs = append(gs.Svcs, gs.Svcs[0])
+	require.ErrorContains(t, gs.Validate(), "duplicate service sid")
+}
+
+func TestGenesisState_Validate_InvalidServiceSidLength(t *testing.T) {
+	gs := validGenesis()
+	gs.Svcs[0].Sid = "a" // too short
+	require.ErrorContains(t, gs.Validate(), "sid length")
+}
+
+func TestGenesisState_Validate_DuplicateCredential(t *testing.T) {
+	gs := validGenesis()
+	gs.Vcs = append(gs.Vcs, gs.Vcs[0])
+	require.ErrorContains(t, gs.Validate(), "duplicate credential")
+}
+
+func TestGenesisState_Validate_CredentialDataTooLarge(t *testing.T) {
+	gs := validGenesis()
+	gs.Vcs[0].Data = []byte(strings.Repeat("x", 64*1024+1))
+	require.ErrorContains(t, gs.Validate(), "data length exceeds")
+}
+
+func TestGenesisState_Validate_FlogOrphanCredential(t *testing.T) {
+	gs := validGenesis()
+	// flog references a credential that does not exist in Vcs
+	gs.Flogs[0].Did = "9999999999999"
+	require.ErrorContains(t, gs.Validate(), "not found in vcs")
+}
+
+func TestGenesisState_Validate_FlogInvalidDIDLength(t *testing.T) {
+	gs := validGenesis()
+	gs.Flogs[0].Did = "short"
+	require.ErrorContains(t, gs.Validate(), "DID length")
+}
+
+func TestGenesisState_Validate_DuplicateFlog(t *testing.T) {
+	gs := validGenesis()
+	gs.Flogs = append(gs.Flogs, gs.Flogs[0])
+	require.ErrorContains(t, gs.Validate(), "duplicate filter logger")
 }

--- a/x/did/types/genesis_test.go
+++ b/x/did/types/genesis_test.go
@@ -13,9 +13,10 @@ import (
 // prefix before any test runs.
 
 const (
-	genesisTestDID     = "1000000000001" // length == DidLength (13)
-	genesisTestAddress = "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4"
-	genesisTestPubkey  = "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}"
+	genesisTestDID        = "1000000000001" // length == DidLength (13)
+	genesisTestAddress    = "me1kjnt3ypezt3yf58w8upujvejdtt5xsvkq5dpk4"
+	genesisTestPubkey     = "{\"@type\":\"/ethermint.crypto.v1.ethsecp256k1.PubKey\",\"key\":\"AjkBriaNQIyoihm/Op5a53ovjdThnbs8G3GhSdErW7Mt\"}"
+	genesisTestShortValue = "short" // invalid DID/sid value used across multiple tests
 )
 
 func validGenesis() GenesisState {
@@ -91,7 +92,7 @@ func TestGenesisState_Validate_DuplicateAddress(t *testing.T) {
 
 func TestGenesisState_Validate_InvalidDIDLength(t *testing.T) {
 	gs := validGenesis()
-	gs.Infos[0].Did = "short"
+	gs.Infos[0].Did = genesisTestShortValue
 	require.ErrorContains(t, gs.Validate(), "DID length")
 }
 
@@ -167,7 +168,7 @@ func TestGenesisState_Validate_DuplicateCredential(t *testing.T) {
 
 func TestGenesisState_Validate_InvalidCredentialDIDLength(t *testing.T) {
 	gs := validGenesis()
-	gs.Vcs[0].Did = "short"
+	gs.Vcs[0].Did = genesisTestShortValue
 	require.ErrorContains(t, gs.Validate(), "DID length")
 }
 
@@ -211,7 +212,7 @@ func TestGenesisState_Validate_FlogOrphanCredential(t *testing.T) {
 
 func TestGenesisState_Validate_FlogInvalidDIDLength(t *testing.T) {
 	gs := validGenesis()
-	gs.Flogs[0].Did = "short"
+	gs.Flogs[0].Did = genesisTestShortValue
 	require.ErrorContains(t, gs.Validate(), "DID length")
 }
 


### PR DESCRIPTION
- validate DID infos for length, pubkey presence, Bech32 address format, status, and duplicate DID/address entries
- validate services, credentials, and filter loggers for field lengths, enum status values, and duplicate records
- ensure filter loggers reference existing credentials to prevent InitGenesis panics
- add genesis validation test helpers and coverage for valid and invalid cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened genesis validation for identity, service, credential, and filter logger records with stricter field-length checks, bech32 address validation, status enum enforcement, and duplicate detection.
  * Improved reference integrity by rejecting orphan credential references and duplicate credential/filter-logger links.
* **Tests**
  * Expanded and refactored genesis validation tests into focused “valid” and granular negative cases covering duplicates, invalid formats, and size-limit violations (including filter length).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->