### PR TITLE
fix: delegate interest validation and add rollapp unit tests

### DIFF
--- a/x/rollapp/keeper/msg_server_update_rollapp_test.go
+++ b/x/rollapp/keeper/msg_server_update_rollapp_test.go
@@ -1,0 +1,133 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/openmetaearth/me-hub/x/rollapp/types"
+)
+
+func (suite *RollappTestSuite) TestUpdateRollapp() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	original := types.Rollapp{
+		RollappId:             "rollapp_1234-1",
+		Creator:               alice,
+		MaxSequencers:         2,
+		PermissionedAddresses: []string{bob, carol},
+		ChannelId:             "channel-0",
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, original)
+
+	updateMsg := types.MsgUpdateRollapp{
+		Creator:               alice,
+		RollappId:             original.RollappId,
+		MaxSequencers:         3,
+		PermissionedAddresses: []string{bob},
+	}
+
+	updateResp, err := suite.msgServer.UpdateRollapp(goCtx, &updateMsg)
+	suite.Require().NoError(err)
+	suite.Require().EqualValues(types.MsgUpdateRollappResponse{}, *updateResp)
+
+	updated, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, original.RollappId)
+	suite.Require().True(found)
+	suite.Require().EqualValues(original.RollappId, updated.RollappId)
+	suite.Require().EqualValues(original.Creator, updated.Creator)
+	suite.Require().EqualValues(uint64(3), updated.MaxSequencers)
+	suite.Require().EqualValues([]string{bob}, updated.PermissionedAddresses)
+	suite.Require().EqualValues(original.ChannelId, updated.ChannelId)
+}
+
+func (suite *RollappTestSuite) TestUpdateRollappUnknownRollappID() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	updateMsg := types.MsgUpdateRollapp{
+		Creator:   alice,
+		RollappId: "unknown-rollapp",
+	}
+
+	_, err := suite.msgServer.UpdateRollapp(goCtx, &updateMsg)
+	suite.EqualError(err, types.ErrUnknownRollappID.Error())
+}
+
+func (suite *RollappTestSuite) TestUpdateRollappWhenDisabled() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	original := types.Rollapp{
+		RollappId:     "rollapp_1234-1",
+		Creator:       alice,
+		MaxSequencers: 1,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, original)
+
+	params := suite.App.RollappKeeper.GetParams(suite.Ctx)
+	params.RollappsEnabled = false
+	suite.App.RollappKeeper.SetParams(suite.Ctx, params)
+
+	updateMsg := types.MsgUpdateRollapp{
+		Creator:       alice,
+		RollappId:     original.RollappId,
+		MaxSequencers: 2,
+	}
+
+	_, err := suite.msgServer.UpdateRollapp(goCtx, &updateMsg)
+	suite.EqualError(err, types.ErrRollappsDisabled.Error())
+
+	stored, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, original.RollappId)
+	suite.Require().True(found)
+	suite.Require().EqualValues(original, stored)
+}
+
+func (suite *RollappTestSuite) TestUpdateRollappFrozen() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	original := types.Rollapp{
+		RollappId:     "rollapp_1234-1",
+		Creator:       alice,
+		MaxSequencers: 1,
+		Frozen:        true,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, original)
+
+	updateMsg := types.MsgUpdateRollapp{
+		Creator:       alice,
+		RollappId:     original.RollappId,
+		MaxSequencers: 2,
+	}
+
+	_, err := suite.msgServer.UpdateRollapp(goCtx, &updateMsg)
+	suite.EqualError(err, types.ErrRollappJailed.Error())
+
+	stored, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, original.RollappId)
+	suite.Require().True(found)
+	suite.Require().EqualValues(original, stored)
+}
+
+func (suite *RollappTestSuite) TestUpdateRollappUnauthorizedCreator() {
+	suite.SetupTest()
+	goCtx := sdk.WrapSDKContext(suite.Ctx)
+
+	original := types.Rollapp{
+		RollappId:     "rollapp_1234-1",
+		Creator:       alice,
+		MaxSequencers: 1,
+	}
+	suite.App.RollappKeeper.SetRollapp(suite.Ctx, original)
+
+	updateMsg := types.MsgUpdateRollapp{
+		Creator:       bob,
+		RollappId:     original.RollappId,
+		MaxSequencers: 2,
+	}
+
+	_, err := suite.msgServer.UpdateRollapp(goCtx, &updateMsg)
+	suite.EqualError(err, types.ErrUnauthorizedRollappCreator.Error())
+
+	stored, found := suite.App.RollappKeeper.GetRollapp(suite.Ctx, original.RollappId)
+	suite.Require().True(found)
+	suite.Require().EqualValues(original, stored)
+}

--- a/x/wstaking/keeper/msg_server_delegate.go
+++ b/x/wstaking/keeper/msg_server_delegate.go
@@ -67,13 +67,13 @@ func (k MsgServer) Delegate(goCtx context.Context, msg *stakingtypes.MsgDelegate
 		if err != nil {
 			return nil, err
 		}
-		if region.DelegateInterest.GTE(rewards) {
-			region.DelegateInterest = region.DelegateInterest.Sub(rewards)
-		}
-		if !region.DelegateInterest.GTE(rewards) {
-			return nil, fmt.Errorf("region(%s) total interest not enough.need pay %s,only have %s",
+
+		if region.DelegateInterest.LT(rewards) {
+			return nil, fmt.Errorf("delegate err, region(%s) total interest not enough.need pay %s,only have %s",
 				region.RegionId, rewards.String(), region.DelegateInterest.String())
 		}
+		region.DelegateInterest = region.DelegateInterest.Sub(rewards)
+
 		err = k.bankKeeper.Extend().SendCoinsWithTag(ctx, regionTreasureAddr, delegatorAddress, sdk.NewCoins(sdk.NewCoin(params.BaseDenom, rewards.TruncateInt())),
 			fmt.Sprintf("Delegate_SendRewards_%s", region.RegionId),
 		)


### PR DESCRIPTION
This pull request introduces a new set of unit tests for the `UpdateRollapp` message server functionality and makes a logic correction in the delegation process for region interest checks. The changes improve test coverage for rollapp updates and clarify the validation logic for region reward delegation.

**Rollapp update tests:**

* Added comprehensive tests for the `UpdateRollapp` message server, covering scenarios such as successful updates, unknown rollapp IDs, rollapps being disabled, frozen rollapps, and unauthorized creators in `msg_server_update_rollapp_test.go`.

**Delegation logic correction:**

* Fixed the logic in `MsgServer.Delegate` to ensure that the region's `DelegateInterest` is only deducted if it is sufficient to cover the rewards, improving error handling and preventing negative balances (`msg_server_delegate.go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollapp update handling so changes are correctly validated and rejected when the rollapp is unavailable, frozen, missing, or updated by the wrong creator.
  * Tightened delegation reward/interest handling to fail earlier when available interest is insufficient, helping prevent incorrect deductions.

* **Tests**
  * Added coverage for rollapp update success and failure scenarios to improve release confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->