### PR TITLE
fix: check old chainid

### DIFF
--- a/types/version.go
+++ b/types/version.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 	"regexp"
-	"strings"
 	"sync"
 )
 

--- a/types/version.go
+++ b/types/version.go
@@ -8,10 +8,9 @@ import (
 )
 
 const (
-	MainnetV1ChainId  = "mechain"
+	MainnetV1ChainId  = "me-chain"
 	MainnetV2ChainId  = "mechain_2404-1"
 	MainnetEvmChainID = 2404
-	TestnetEvmChainID = 202404
 )
 
 var (
@@ -35,16 +34,13 @@ func ChainIdWithEIP155() string {
 }
 
 // ChainIdWithEIP155From maps a Cosmos chain-id to the EIP-155 format expected by Ethermint.
-// Legacy mainnet chains use the plain "mechain" id; EVM uses chain id 2404 (mechain_2404-1).
+// Legacy mainnet chains use the plain "me-chain" id; EVM uses chain id 2404 (mechain_2404-1).
 func ChainIdWithEIP155From(id string) string {
 	if eip155SuffixReg.MatchString(id) {
 		return id
 	}
 	if id == MainnetV1ChainId {
 		return MainnetV2ChainId
-	}
-	if strings.Contains(id, "testnet") {
-		return fmt.Sprintf("%s_%d-1", id, TestnetEvmChainID)
 	}
 	return fmt.Sprintf("%s_%d-1", id, MainnetEvmChainID)
 }

--- a/types/version_test.go
+++ b/types/version_test.go
@@ -25,16 +25,6 @@ func TestChainIdWithEIP155From(t *testing.T) {
 			input: "mechain_2404-1",
 			want:  "mechain_2404-1",
 		},
-		{
-			name:  "legacy testnet",
-			input: "mechain_testnet",
-			want:  "mechain_testnet_202404-1",
-		},
-		{
-			name:  "testnet eip155",
-			input: "mechain_testnet_202405-1",
-			want:  "mechain_testnet_202405-1",
-		},
 	}
 
 	for _, tc := range tests {
@@ -46,7 +36,6 @@ func TestChainIdWithEIP155From(t *testing.T) {
 }
 
 func TestChainIdWithEIP155(t *testing.T) {
-	evmChainId, err := types.ParseChainID("me-chain_2404-1")
-	require.NoError(t, err)
-	require.Equal(t, uint64(2404), evmChainId)
+	_, err := types.ParseChainID("me-chain_2404-1")
+	require.ErrorIs(t, err, types.ErrInvalidChainID)
 }

--- a/types/version_test.go
+++ b/types/version_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"github.com/evmos/ethermint/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,4 +43,10 @@ func TestChainIdWithEIP155From(t *testing.T) {
 			require.Equal(t, tc.want, ChainIdWithEIP155From(tc.input))
 		})
 	}
+}
+
+func TestChainIdWithEIP155(t *testing.T) {
+	evmChainId, err := types.ParseChainID("me-chain_2404-1")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2404), evmChainId)
 }


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated chain ID handling to use the new mainnet identifier format.
  * Improved EIP-155 chain ID conversion so existing formatted IDs are preserved and other IDs map consistently.
  * Added coverage to verify chain ID parsing and EVM chain ID extraction works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->