### PR TITLE
fix: check sub account did

### DIFF
--- a/x/kyc/keeper/msg_server_sub_account.go
+++ b/x/kyc/keeper/msg_server_sub_account.go
@@ -79,6 +79,11 @@ func (m msgServer) CreateSubAccount(goCtx context.Context, msg *types.MsgCreateS
 		return &types.MsgCreateSubAccountResponse{}, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, "pubkey does not match sub_account address")
 	}
 
+	_, ok = m.GetDID(ctx, subAccount)
+	if ok {
+		return &types.MsgCreateSubAccountResponse{}, types.ErrSubAccountHasDID
+	}
+
 	if !m.accountKeeper.HasAccount(ctx, subAccount) {
 		newAccount := m.accountKeeper.NewAccountWithAddress(ctx, subAccount)
 		err = newAccount.SetPubKey(subAccountPubKey)

--- a/x/kyc/keeper/msg_server_sub_account_test.go
+++ b/x/kyc/keeper/msg_server_sub_account_test.go
@@ -294,4 +294,22 @@ func (s *KeeperTestSuite) TestCreateSubAccount() {
 		})
 		s.Require().ErrorIs(err, sdkerrors.ErrInvalidPubKey)
 	})
+
+	s.Run("sub_account already has did", func() {
+		const did9 = "1212121212121"
+		userAddr, userPubkey := s.newSecp256k1UserAccount()
+		s.setupActiveKyc(userAddr, userPubkey, did9)
+
+		subAddr, subPubkey := s.newEthSubAccount()
+		const subDid = "1313131313131"
+		s.Keeper().SetDID(s.Ctx, subAddr, subDid)
+
+		_, err := s.msgServer.CreateSubAccount(s.Ctx, &types.MsgCreateSubAccount{
+			Creator:          daoCreator,
+			Account:          userAddr.String(),
+			SubAccount:       subAddr.String(),
+			SubAccountPubkey: subPubkey,
+		})
+		s.Require().ErrorIs(err, types.ErrSubAccountHasDID)
+	})
 }

--- a/x/kyc/types/errors.go
+++ b/x/kyc/types/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrUnauthorized                = errors.Register(ModuleName, 107, "unauthorized")
 	ErrEthAccountNotAllowed        = errors.Register(ModuleName, 108, "main account is an eth account and cannot create sub account")
 	ErrMainAccountPubkeyNotSet     = errors.Register(ModuleName, 109, "main account pubkey is not set")
+	ErrSubAccountHasDID            = errors.Register(ModuleName, 110, "sub account already has a DID")
 )


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sub-accounts from being created when they already have a DID assigned.
  * Returned a clearer error when this validation fails.
  * Added coverage for the existing-DID case to confirm the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->