### PR TITLE
fix: check sub account register did

### DIFF
--- a/x/did/types/errors.go
+++ b/x/did/types/errors.go
@@ -32,4 +32,5 @@ var (
 	ErrCredentialExists   = errors.Register(ModuleName, 150, "kyc credential already exists")
 	ErrCredentialNotFound = errors.Register(ModuleName, 151, "kyc credential not found")
 	ErrUnauthorized       = errors.Register(ModuleName, 152, "unauthorized")
+	ErrSubAccountAlreadyRegistered = errors.Register(ModuleName, 153, "sub account already registered")
 )

--- a/x/kyc/keeper/msg_server.go
+++ b/x/kyc/keeper/msg_server.go
@@ -56,6 +56,11 @@ func (m msgServer) Approve(goCtx context.Context, msg *types.MsgApprove) (*types
 		return &types.MsgApproveResponse{}, didtypes.ErrDidExists
 	}
 
+	// check sub account
+	if m.didKeeper.HasDidBySubAccount(ctx, msg.Address) {
+		return &types.MsgApproveResponse{}, didtypes.ErrSubAccountAlreadyRegistered
+	}
+
 	// check region
 	if _, found := m.stkKeeper.GetRegion(ctx, msg.RegionId); !found {
 		return &types.MsgApproveResponse{}, stktypes.ErrRegionNotExist

--- a/x/kyc/keeper/msg_server_sub_account.go
+++ b/x/kyc/keeper/msg_server_sub_account.go
@@ -25,8 +25,12 @@ func (m msgServer) CreateSubAccount(goCtx context.Context, msg *types.MsgCreateS
 	}
 
 	holderInfo, found := m.GetDidInfo(ctx, did)
-	if !found || holderInfo.Status != didtypes.DID_STATUS_ACTIVE {
+	if !found {
 		return &types.MsgCreateSubAccountResponse{}, didtypes.ErrHolderNotFound
+	}
+
+	if holderInfo.Status != didtypes.DID_STATUS_ACTIVE {
+		return &types.MsgCreateSubAccountResponse{}, didtypes.ErrDidNotActive
 	}
 
 	if !m.HasKYC(ctx, did) {

--- a/x/kyc/keeper/msg_server_test.go
+++ b/x/kyc/keeper/msg_server_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openmetaearth/me-hub/app/apptesting"
 	"github.com/openmetaearth/me-hub/app/params"
+	didtypes "github.com/openmetaearth/me-hub/x/did/types"
 	"github.com/openmetaearth/me-hub/x/kyc/types"
 	"github.com/openmetaearth/me-hub/x/wdistri"
 	"github.com/openmetaearth/me-hub/x/wmint"
@@ -61,6 +62,70 @@ func (s *KeeperTestSuite) TestApprove() {
 	s.Require().True(f)
 	s.Require().Equal(msg.Uri, kyc.Uri)
 	s.Require().Equal(msg.Hash, kyc.Hash)
+}
+
+func (s *KeeperTestSuite) setupApproveCtx() {
+	s.Ctx = s.App.BaseApp.NewContext(false, tmproto.Header{}).WithBlockHeight(wminttypes.OneDayTotalBlocks).WithChainID(apptesting.TestChainID)
+	wmint.BeginBlocker(s.Ctx, s.App.MintKeeper, nil)
+	wdistri.EndBlock(s.Ctx, abci.RequestEndBlock{Height: s.Ctx.BlockHeight()}, *s.App.DistrKeeper)
+}
+
+func (s *KeeperTestSuite) TestApproveRejectsSubAccountAddress() {
+	s.setupApproveCtx()
+
+	s.Run("sub account already registered in map", func() {
+		subAddr, subPubkey := s.newEthSubAccount()
+		const parentDid = "parent-did-0001"
+		s.App.DidKeeper.SetSubAccountDidMap(s.Ctx, subAddr.String(), parentDid)
+
+		inviter, _ := s.NewAccount()
+		_, err := s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+			Issuer:   s.Dao.GlobalDao,
+			Did:      "2222222222222222",
+			RegionId: strings.ToLower(wstakingtypes.MeEarthRegionName),
+			Address:  subAddr.String(),
+			Pubkey:   subPubkey,
+			Uri:      "http://127.0.0.1/8001",
+			Hash:     "aaaa",
+			Inviter:  inviter.String(),
+			Level:    2,
+		})
+		s.Require().ErrorIs(err, didtypes.ErrSubAccountAlreadyRegistered)
+
+		_, found := s.Keeper().GetDID(s.Ctx, subAddr)
+		s.Require().False(found)
+	})
+
+	s.Run("address bound via create sub account", func() {
+		const parentDid = "3333333333333333"
+		userAddr, userPubkey := s.newSecp256k1UserAccount()
+		s.setupActiveKyc(userAddr, userPubkey, parentDid)
+
+		subAddr, subPubkey := s.newEthSubAccount()
+		_, err := s.msgServer.CreateSubAccount(s.Ctx, &types.MsgCreateSubAccount{
+			Creator:          userAddr.String(),
+			SubAccount:       subAddr.String(),
+			SubAccountPubkey: subPubkey,
+		})
+		s.Require().NoError(err)
+
+		inviter, _ := s.NewAccount()
+		_, err = s.msgServer.Approve(s.Ctx, &types.MsgApprove{
+			Issuer:   s.Dao.GlobalDao,
+			Did:      "4444444444444444",
+			RegionId: strings.ToLower(wstakingtypes.MeEarthRegionName),
+			Address:  subAddr.String(),
+			Pubkey:   subPubkey,
+			Uri:      "http://127.0.0.1/8001",
+			Hash:     "bbbb",
+			Inviter:  inviter.String(),
+			Level:    2,
+		})
+		s.Require().ErrorIs(err, didtypes.ErrSubAccountAlreadyRegistered)
+
+		_, found := s.Keeper().GetDID(s.Ctx, subAddr)
+		s.Require().False(found)
+	})
 }
 
 func (s *KeeperTestSuite) TestCreateSBTRejectsDuplicateDid() {


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented approval of addresses that are already registered as DID sub-accounts.
  * Improved error reporting when a holder DID is inactive versus unavailable.
  * Ensured rejected approvals do not create new DID records.
* **Tests**
  * Added coverage for duplicate and previously created sub-account addresses during approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->