### PR TITLE
fix: improve error messages for invalid token ID in NFT creation

### DIFF
--- a/x/wnft/keeper/msg_server.go
+++ b/x/wnft/keeper/msg_server.go
@@ -101,11 +101,11 @@ func (k Keeper) MintNFT(goCtx context.Context, msg *types.MsgMintNFT) (*types.Ms
 
 	tokenId, err := strconv.ParseUint(msg.TokenId, 10, 64)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id, token id must be a valid unsigned integer")
 	}
 
 	if tokenId < 1 || tokenId > class.TotalSupply {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid token id, token id must be between 1 and the total supply of the NFT type")
 	}
 
 	if k.GetTotalSupply(ctx, msg.ClassId) >= class.TotalSupply {


### PR DESCRIPTION
This pull request improves the error messages in the `MintNFT` function to provide more detailed and user-friendly feedback when a token ID is invalid.

Error message improvements:

* Updated the error message for invalid token ID parsing to specify that the token ID must be a valid unsigned integer (`x/wnft/keeper/msg_server.go`)
* Enhanced the error message for out-of-range token IDs to clarify that the token ID must be between 1 and the total supply of the NFT type (`x/wnft/keeper/msg_server.go`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFT minting error messages when the token ID is not a valid unsigned integer.
  * Clarified validation feedback when the token ID falls outside the allowed supply range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->