### PR TITLE
fix: add external bridge fee precision

### DIFF
--- a/x/gravity/keeper/batch_fee.go
+++ b/x/gravity/keeper/batch_fee.go
@@ -117,8 +117,9 @@ func (k Keeper) AddUnbatchedTxBridgeFee(ctx sdk.Context, txId uint64, sender sdk
 		return err
 	}
 
-	// add bridge fee amount
-	tx.Fee.Amount = tx.Fee.Amount.Add(addBridgeFee.Amount)
+	// Outgoing transaction amounts are stored in external-chain units.
+	externalBridgeFee := types.GetExternalUnlockAmount(addBridgeFee.Amount, k.moduleName, bridgeToken)
+	tx.Fee.Amount = tx.Fee.Amount.Add(externalBridgeFee)
 	if err := k.AddUnbatchedTx(ctx, tx); err != nil {
 		return err
 	}

--- a/x/gravity/keeper/msg_server_test.go
+++ b/x/gravity/keeper/msg_server_test.go
@@ -738,6 +738,84 @@ func (s *KeeperTestSuite) TestMsgBridgeTokenClaim() {
 	}
 }
 
+func (s *KeeperTestSuite) TestMsgSendToExternalIncreaseBridgeFeeAndCancel() {
+	sender := s.relayerAddrs[0]
+	denom := "uusdt"
+	initialSupply := sdk.NewCoin(denom, sdkmath.NewInt(150))
+	amount := sdk.NewCoin(denom, sdkmath.NewInt(40))
+	bridgeFee := sdk.NewCoin(denom, sdkmath.NewInt(10))
+	additionalFee := sdk.NewCoin(denom, sdkmath.NewInt(5))
+	bridgeToken := s.NewBridgeToken(sender, initialSupply)
+	bridgeToken.Symbol = "USDT"
+	bridgeToken.Decimal = 18
+	s.Keeper().SetBridgeToken(s.Ctx, &bridgeToken)
+
+	getBalance := func() sdkmath.Int {
+		return s.App.BankKeeper.GetBalance(s.Ctx, sender, denom).Amount
+	}
+	getSupply := func() sdkmath.Int {
+		return s.App.BankKeeper.GetSupply(s.Ctx, denom).Amount
+	}
+	getBridgeTokenSupply := func() sdkmath.Int {
+		bridgeToken, err := s.Keeper().GetBridgeTokenByDenom(s.Ctx, denom)
+		s.Require().NoError(err)
+		return bridgeToken.Supply
+	}
+	assertBalanceAndSupply := func(expected sdkmath.Int) {
+		s.Require().EqualValues(expected, getBalance())
+		s.Require().EqualValues(expected, getSupply())
+		s.Require().EqualValues(expected, getBridgeTokenSupply())
+	}
+
+	assertBalanceAndSupply(initialSupply.Amount)
+
+	sendResp, err := s.MsgServer().SendToExternal(sdk.WrapSDKContext(s.Ctx), &types.MsgSendToExternal{
+		Sender:    sender.String(),
+		Dest:      helpers.GenExternalAddr(s.chainName),
+		Amount:    amount,
+		BridgeFee: bridgeFee,
+		ChainName: s.chainName,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(sendResp)
+	s.Require().NotZero(sendResp.OutgoingTxId)
+
+	afterSend := initialSupply.Amount.Sub(amount.Amount).Sub(bridgeFee.Amount)
+	assertBalanceAndSupply(afterSend)
+
+	outgoingTx, err := s.Keeper().GetUnbatchedTxById(s.Ctx, sendResp.OutgoingTxId)
+	s.Require().NoError(err)
+	s.Require().EqualValues(types.GetExternalUnlockAmount(amount.Amount, s.chainName, &bridgeToken), outgoingTx.Token.Amount)
+	s.Require().EqualValues(types.GetExternalUnlockAmount(bridgeFee.Amount, s.chainName, &bridgeToken), outgoingTx.Fee.Amount)
+
+	_, err = s.MsgServer().IncreaseBridgeFee(sdk.WrapSDKContext(s.Ctx), &types.MsgIncreaseBridgeFee{
+		ChainName:     s.chainName,
+		TransactionId: sendResp.OutgoingTxId,
+		Sender:        sender.String(),
+		AddBridgeFee:  additionalFee,
+	})
+	s.Require().NoError(err)
+
+	afterIncrease := afterSend.Sub(additionalFee.Amount)
+	assertBalanceAndSupply(afterIncrease)
+
+	outgoingTx, err = s.Keeper().GetUnbatchedTxById(s.Ctx, sendResp.OutgoingTxId)
+	s.Require().NoError(err)
+	expectedExternalFee := types.GetExternalUnlockAmount(bridgeFee.Amount.Add(additionalFee.Amount), s.chainName, &bridgeToken)
+	s.Require().EqualValues(expectedExternalFee, outgoingTx.Fee.Amount)
+
+	_, err = s.MsgServer().CancelSendToExternal(sdk.WrapSDKContext(s.Ctx), &types.MsgCancelSendToExternal{
+		TransactionId: sendResp.OutgoingTxId,
+		Sender:        sender.String(),
+		ChainName:     s.chainName,
+	})
+	s.Require().NoError(err)
+
+	assertBalanceAndSupply(initialSupply.Amount)
+	_, err = s.Keeper().GetUnbatchedTxById(s.Ctx, sendResp.OutgoingTxId)
+	s.Require().Error(err)
+}
+
 func (s *KeeperTestSuite) TestRequestBatchBaseFee() {
 	// 1. First sets up a valid relayer set
 	totalPower := sdk.ZeroInt()


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bridge fee calculations to use the appropriate external-chain unlock units.
  * Improved fee handling when increasing fees for outgoing transfers.

* **Tests**
  * Added coverage for increasing a transfer’s bridge fee and cancelling the transfer.
  * Verified balances, supply, fees, and transaction cleanup throughout the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->