### PR TITLE
fix: reset slash fraction

### DIFF
--- a/app/upgrades/v2_0_15_rc3/upgrade.go
+++ b/app/upgrades/v2_0_15_rc3/upgrade.go
@@ -28,6 +28,7 @@ func CreateUpgradeHandler(
 		bscParams := keepers.BscKeeper.GetParams(ctx)
 		bscParams.MaxSlashTimes = 100
 		bscParams.MaxSendToExternalUsdAmount = maxSendToExternalUsdAmount
+		bscParams.SlashFraction = sdk.MustNewDecFromStr("0.01")
 		if err := keepers.BscKeeper.SetParams(ctx, &bscParams); err != nil {
 			return nil, fmt.Errorf("failed to set BSC max send to external amount: %w", err)
 		}
@@ -35,6 +36,7 @@ func CreateUpgradeHandler(
 		tronParams := keepers.TronKeeper.GetParams(ctx)
 		tronParams.MaxSlashTimes = 100
 		tronParams.MaxSendToExternalUsdAmount = maxSendToExternalUsdAmount
+		tronParams.SlashFraction = sdk.MustNewDecFromStr("0.01")
 		if err := keepers.TronKeeper.SetParams(ctx, &tronParams); err != nil {
 			return nil, fmt.Errorf("failed to set Tron max send to external amount: %w", err)
 		}


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BSC and Tron configurations to use a 1% slash fraction during the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->