### PR TITLE
fix: last observed nonce for new relayer

### DIFF
--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -281,16 +281,12 @@ func (k Keeper) GetLastEventNonceByRelayer(ctx sdk.Context, relayerAddr sdk.AccA
 	bytes := store.Get(types.GetLastEventNonceByRelayerKey(relayerAddr))
 
 	if len(bytes) == 0 {
-		// in the case that we have no existing value this is the first
-		// time a relayerAddr is submitting a claim. Since we don't want to force
-		// them to replay the entire history of all events ever we can't start
-		// at zero
-		lastEventNonce := k.GetLastObservedEventNonce(ctx)
-		if lastEventNonce >= 1 {
-			return lastEventNonce - 1
-		} else {
-			return 0
-		}
+		// First claim from this relayer. Treat them as already caught up to
+		// the globally observed tip so Attest expects lastObserved+1.
+		// Returning lastObserved-1 (Gravity's original) forced a re-claim of
+		// the already-observed event, which fails when that event is a
+		// RelayerSetUpdate whose members have since unbonded.
+		return k.GetLastObservedEventNonce(ctx)
 	}
 	return sdk.BigEndianToUint64(bytes)
 }

--- a/x/gravity/keeper/attestation.go
+++ b/x/gravity/keeper/attestation.go
@@ -281,12 +281,21 @@ func (k Keeper) GetLastEventNonceByRelayer(ctx sdk.Context, relayerAddr sdk.AccA
 	bytes := store.Get(types.GetLastEventNonceByRelayerKey(relayerAddr))
 
 	if len(bytes) == 0 {
-		// First claim from this relayer. Treat them as already caught up to
-		// the globally observed tip so Attest expects lastObserved+1.
-		// Returning lastObserved-1 (Gravity's original) forced a re-claim of
-		// the already-observed event, which fails when that event is a
-		// RelayerSetUpdate whose members have since unbonded.
-		return k.GetLastObservedEventNonce(ctx)
+		// in the case that we have no existing value this is the first
+		// time a relayerAddr is submitting a claim. Since we don't want to force
+		// them to replay the entire history of all events ever we can't start
+		// at zero.
+		//
+		// Return lastObserved-1 so the first expected claim is lastObserved.
+		// That lets a new or late relayer still vote on the already-observed tip
+		// (needed for the signed window) without replaying history. Returning
+		// lastObserved would make Attest expect lastObserved+1 and reject the
+		// remaining votes once quorum is reached.
+		lastEventNonce := k.GetLastObservedEventNonce(ctx)
+		if lastEventNonce >= 1 {
+			return lastEventNonce - 1
+		}
+		return 0
 	}
 	return sdk.BigEndianToUint64(bytes)
 }

--- a/x/gravity/keeper/attestation_test.go
+++ b/x/gravity/keeper/attestation_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openmetaearth/me-hub/x/gravity/types"
 )
 
-func (s *KeeperTestSuite) TestGetLastEventNonceByRelayer_EmptyStoreUsesLastObserved() {
+func (s *KeeperTestSuite) TestGetLastEventNonceByRelayer_EmptyStoreUsesLastObservedMinusOne() {
 	k := s.Keeper()
 	newRelayer := s.relayerAddrs[0]
 
@@ -16,30 +16,31 @@ func (s *KeeperTestSuite) TestGetLastEventNonceByRelayer_EmptyStoreUsesLastObser
 		"empty store with no observed events must start at 0")
 
 	k.SetLastObservedEventNonce(s.Ctx, 266)
-	s.Require().EqualValues(uint64(266), k.GetLastEventNonceByRelayer(s.Ctx, newRelayer),
-		"new relayer must be treated as caught up to lastObserved, not lastObserved-1")
+	s.Require().EqualValues(uint64(265), k.GetLastEventNonceByRelayer(s.Ctx, newRelayer),
+		"new relayer must start at lastObserved-1 so the first expected claim is the observed tip")
 
 	k.SetLastEventNonceByRelayer(s.Ctx, newRelayer, 100)
 	s.Require().EqualValues(uint64(100), k.GetLastEventNonceByRelayer(s.Ctx, newRelayer),
 		"stored personal nonce must win over lastObserved")
 }
 
-func (s *KeeperTestSuite) TestAttest_NewRelayerSkipsAlreadyObservedNonce() {
+func (s *KeeperTestSuite) TestAttest_NewRelayerCanVoteOnAlreadyObservedNonce() {
 	k := s.Keeper()
 	relayer := s.relayerAddrs[0]
 	k.SetLastObservedEventNonce(s.Ctx, 266)
 
-	s.Require().EqualValues(uint64(266), k.GetLastEventNonceByRelayer(s.Ctx, relayer))
+	s.Require().EqualValues(uint64(265), k.GetLastEventNonceByRelayer(s.Ctx, relayer))
+
+	// Skipping the observed tip would brick late votes after quorum.
+	nextClaim := sendToMeClaim(relayer, s.chainName, 267)
+	_, err := k.Attest(s.Ctx, relayer, nextClaim)
+	s.Require().ErrorIs(err, types.ErrNonContinuousEventNonce,
+		"new relayer must not skip the already-observed tip")
 
 	observedClaim := sendToMeClaim(relayer, s.chainName, 266)
-	_, err := k.Attest(s.Ctx, relayer, observedClaim)
-	s.Require().ErrorIs(err, types.ErrNonContinuousEventNonce,
-		"new relayer must not re-claim the already-observed tip")
-
-	nextClaim := sendToMeClaim(relayer, s.chainName, 267)
-	_, err = k.Attest(s.Ctx, relayer, nextClaim)
+	_, err = k.Attest(s.Ctx, relayer, observedClaim)
 	s.Require().NoError(err)
-	s.Require().EqualValues(uint64(267), k.GetLastEventNonceByRelayer(s.Ctx, relayer))
+	s.Require().EqualValues(uint64(266), k.GetLastEventNonceByRelayer(s.Ctx, relayer))
 }
 
 func sendToMeClaim(relayer sdk.AccAddress, chainName string, nonce uint64) *types.MsgSendToMeClaim {

--- a/x/gravity/keeper/attestation_test.go
+++ b/x/gravity/keeper/attestation_test.go
@@ -1,1 +1,56 @@
 package keeper_test
+
+import (
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/openmetaearth/me-hub/x/gravity/types"
+)
+
+func (s *KeeperTestSuite) TestGetLastEventNonceByRelayer_EmptyStoreUsesLastObserved() {
+	k := s.Keeper()
+	newRelayer := s.relayerAddrs[0]
+
+	s.Require().EqualValues(uint64(0), k.GetLastObservedEventNonce(s.Ctx))
+	s.Require().EqualValues(uint64(0), k.GetLastEventNonceByRelayer(s.Ctx, newRelayer),
+		"empty store with no observed events must start at 0")
+
+	k.SetLastObservedEventNonce(s.Ctx, 266)
+	s.Require().EqualValues(uint64(266), k.GetLastEventNonceByRelayer(s.Ctx, newRelayer),
+		"new relayer must be treated as caught up to lastObserved, not lastObserved-1")
+
+	k.SetLastEventNonceByRelayer(s.Ctx, newRelayer, 100)
+	s.Require().EqualValues(uint64(100), k.GetLastEventNonceByRelayer(s.Ctx, newRelayer),
+		"stored personal nonce must win over lastObserved")
+}
+
+func (s *KeeperTestSuite) TestAttest_NewRelayerSkipsAlreadyObservedNonce() {
+	k := s.Keeper()
+	relayer := s.relayerAddrs[0]
+	k.SetLastObservedEventNonce(s.Ctx, 266)
+
+	s.Require().EqualValues(uint64(266), k.GetLastEventNonceByRelayer(s.Ctx, relayer))
+
+	observedClaim := sendToMeClaim(relayer, s.chainName, 266)
+	_, err := k.Attest(s.Ctx, relayer, observedClaim)
+	s.Require().ErrorIs(err, types.ErrNonContinuousEventNonce,
+		"new relayer must not re-claim the already-observed tip")
+
+	nextClaim := sendToMeClaim(relayer, s.chainName, 267)
+	_, err = k.Attest(s.Ctx, relayer, nextClaim)
+	s.Require().NoError(err)
+	s.Require().EqualValues(uint64(267), k.GetLastEventNonceByRelayer(s.Ctx, relayer))
+}
+
+func sendToMeClaim(relayer sdk.AccAddress, chainName string, nonce uint64) *types.MsgSendToMeClaim {
+	return &types.MsgSendToMeClaim{
+		EventNonce:     nonce,
+		BlockHeight:    1,
+		TokenContract:  "0x0000000000000000000000000000000000000001",
+		Amount:         sdkmath.NewInt(1000),
+		Sender:         "0x0000000000000000000000000000000000000002",
+		Receiver:       relayer.String(),
+		RelayerAddress: relayer.String(),
+		ChainName:      chainName,
+	}
+}

--- a/x/gravity/keeper/genesis.go
+++ b/x/gravity/keeper/genesis.go
@@ -96,8 +96,13 @@ func InitGenesis(ctx sdk.Context, k Keeper, state *types.GenesisState) {
 		}
 		// reconstruct the latest event nonce for every validator
 		// if somehow this genesis state is saved when all attestations
-		// have been cleaned up GetLastEventNonceByRelayer returns lastObserved
-		// (new relayers start at lastObserved+1 and do not re-claim the tip)
+		// have been cleaned up GetLastEventNonceByRelayer handles that case
+		//
+		// if we where to save and load the last event nonce for every validator
+		// then we would need to carry that state forever across all chain restarts
+		// but since we've already had to handle the edge case of new validators joining
+		// while all attestations have already been cleaned up we can do this instead and
+		// not carry around every validators event nonce counter forever.
 		for _, vote := range att.Votes {
 			relayer := sdk.MustAccAddressFromBech32(vote)
 			last := k.GetLastEventNonceByRelayer(ctx, relayer)

--- a/x/gravity/keeper/genesis.go
+++ b/x/gravity/keeper/genesis.go
@@ -96,13 +96,8 @@ func InitGenesis(ctx sdk.Context, k Keeper, state *types.GenesisState) {
 		}
 		// reconstruct the latest event nonce for every validator
 		// if somehow this genesis state is saved when all attestations
-		// have been cleaned up GetLastEventNonceByRelayer handles that case
-		//
-		// if we where to save and load the last event nonce for every validator
-		// then we would need to carry that state forever across all chain restarts
-		// but since we've already had to handle the edge case of new validators joining
-		// while all attestations have already been cleaned up we can do this instead and
-		// not carry around every validators event nonce counter forever.
+		// have been cleaned up GetLastEventNonceByRelayer returns lastObserved
+		// (new relayers start at lastObserved+1 and do not re-claim the tip)
 		for _, vote := range att.Votes {
 			relayer := sdk.MustAccAddressFromBech32(vote)
 			last := k.GetLastEventNonceByRelayer(ctx, relayer)


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected event nonce tracking for relayers without previously stored nonce data.
  - New relayers now synchronize with the latest observed nonce and begin with the next valid nonce.
  - Prevented re-attestation of already observed events while allowing subsequent valid attestations.

- **Tests**
  - Added coverage for empty stores, new relayer synchronization, stored nonce precedence, and attestation continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->