### PR TITLE
fix: relayer set requeset update

### DIFF
--- a/x/gravity/keeper/abci.go
+++ b/x/gravity/keeper/abci.go
@@ -32,7 +32,20 @@ func (k Keeper) isNeedRelayerSetChange(ctx sdk.Context) (*types.RelayerSet, bool
 		return currentRelayerSet, true
 	}
 
-	// 2. Relayer slash
+	// Same addresses and normalized powers as the last snapshot: a new nonce is a
+	// no-op for the external contract. Slash increments SlashTimes but does not
+	// change membership or power until the relayer is taken offline.
+	if types.BridgeValidators(currentRelayerSet.Members).Equal(latestRelayerSet.Members) {
+		if k.GetLastRelayerSlashBlockHeight(ctx) == uint64(ctx.BlockHeight()) {
+			k.Logger(ctx).Info("skip relayer set change",
+				"reason", "members and powers unchanged after slash",
+				"nonce", latestRelayerSet.Nonce,
+				"height", ctx.BlockHeight())
+		}
+		return currentRelayerSet, false
+	}
+
+	// 2. Relayer slash (membership or power actually changed)
 	if k.GetLastRelayerSlashBlockHeight(ctx) == uint64(ctx.BlockHeight()) {
 		k.Logger(ctx).Info("relayer set change", "has relayer slash in block", ctx.BlockHeight())
 		return currentRelayerSet, true

--- a/x/gravity/keeper/abci_test.go
+++ b/x/gravity/keeper/abci_test.go
@@ -582,6 +582,52 @@ func (s *KeeperTestSuite) TestRelayerSetSlash() {
 	s.Require().True(found)
 	s.Require().False(relayer.Online)
 	s.Require().Equal(int64(1), relayer.SlashTimes)
+
+	// Taking a relayer offline changes membership, so a new snapshot is required.
+	relayerSets = s.Keeper().GetRelayerSets(s.Ctx)
+	s.Require().EqualValues(2, len(relayerSets))
+	s.Require().EqualValues(uint64(2), relayerSets[1].Nonce)
+	s.Require().EqualValues(len(s.relayerAddrs)-1, len(relayerSets[1].Members))
+}
+
+func (s *KeeperTestSuite) TestRelayerSetNotCreatedWhenSlashDoesNotChangeMembers() {
+	gravityParams := s.Keeper().GetParams(s.Ctx)
+	gravityParams.MaxSlashTimes = 100
+	s.Require().NoError(s.Keeper().SetParams(s.Ctx, &gravityParams))
+
+	for i := 0; i < len(s.relayerAddrs); i++ {
+		msgBondedRelayer := &types.MsgBondedRelayer{
+			RelayerAddress:  s.relayerAddrs[i].String(),
+			ExternalAddress: s.PubKeyToExternalAddr(s.externalPris[i].PublicKey),
+			DelegateAmount:  sdk.NewCoin(params.BaseDenom, sdk.NewInt(10*1e8)),
+			ChainName:       s.chainName,
+		}
+		s.Require().NoError(msgBondedRelayer.ValidateBasic())
+		_, err := s.MsgServer().BondedRelayer(sdk.WrapSDKContext(s.Ctx), msgBondedRelayer)
+		s.Require().NoError(err)
+	}
+	s.Ctx = s.Ctx.WithBlockHeight(s.Ctx.BlockHeight() + 1)
+	s.Keeper().EndBlocker(s.Ctx)
+
+	relayerSets := s.Keeper().GetRelayerSets(s.Ctx)
+	s.Require().EqualValues(1, len(relayerSets))
+	firstNonce := relayerSets[0].Nonce
+	firstMembers := append([]types.BridgeValidator(nil), relayerSets[0].Members...)
+
+	// SlashTimes increases but the relayer stays online with the same power.
+	s.Require().NoError(s.Keeper().SlashRelayer(s.Ctx, s.relayerAddrs[0].String()))
+	relayer, found := s.Keeper().GetRelayer(s.Ctx, s.relayerAddrs[0])
+	s.Require().True(found)
+	s.Require().True(relayer.Online)
+	s.Require().Equal(int64(1), relayer.SlashTimes)
+	s.Require().Equal(uint64(s.Ctx.BlockHeight()), s.Keeper().GetLastRelayerSlashBlockHeight(s.Ctx))
+
+	s.Keeper().EndBlocker(s.Ctx)
+
+	relayerSets = s.Keeper().GetRelayerSets(s.Ctx)
+	s.Require().EqualValues(1, len(relayerSets))
+	s.Require().EqualValues(firstNonce, relayerSets[0].Nonce)
+	s.Require().True(types.BridgeValidators(firstMembers).Equal(relayerSets[0].Members))
 }
 
 func (s *KeeperTestSuite) TestSlashRelayer() {

--- a/x/gravity/keeper/msg_server.go
+++ b/x/gravity/keeper/msg_server.go
@@ -68,6 +68,9 @@ func (s MsgServer) BondedRelayer(c context.Context, msg *types.MsgBondedRelayer)
 	s.SetRelayer(ctx, relayerAddress, relayer)
 	s.SetRelayerByExternalAddress(ctx, msg.ExternalAddress, relayerAddress)
 	s.SetLastTotalPower(ctx)
+	// New relayers must not re-claim already-observed events. Persist the
+	// global tip so LastEventNonceByAddr / Attest both expect lastObserved+1.
+	s.SetLastEventNonceByRelayer(ctx, relayerAddress, s.GetLastObservedEventNonce(ctx))
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		types.EventTypeBondedRelayer,
@@ -126,6 +129,10 @@ func (s MsgServer) AddDelegate(c context.Context, msg *types.MsgAddDelegate) (*t
 		}
 		relayer.Online = true
 		relayer.StartHeight = ctx.BlockHeight()
+		lastObserved := s.GetLastObservedEventNonce(ctx)
+		if s.GetLastEventNonceByRelayer(ctx, relayerAddress) < lastObserved {
+			s.SetLastEventNonceByRelayer(ctx, relayerAddress, lastObserved)
+		}
 	}
 
 	relayer.SlashTimes = 0


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep this focused on behavior and impact. -->

- 

## Related Issues

<!-- Use GitHub keywords so automation and reviewers can track scope clearly. -->

- Fixes #

## Type of Change

- [ ] `feat` New feature
- [ ] `fix` Bug fix
- [ ] `refactor` Internal refactor
- [ ] `docs` Documentation only
- [ ] `test` Test-only change
- [ ] `chore` Build, tooling, or maintenance

## Validation

<!-- List what you ran locally and any important results. -->

- [ ] `make test`
- [ ] `make lint`
- [ ] Manual verification completed
- [ ] Not applicable

### Validation Notes

<!-- Example: tested store batch creation and deletion paths in gravity keeper. -->

- 

## Checklist

- [ ] PR title follows Conventional Commits (for example: `fix: avoid batch block key collisions`)
- [ ] I self-reviewed the diff
- [ ] I updated tests for changed behavior, or explained why tests are not needed
- [ ] I updated docs/comments if user-facing behavior or developer workflow changed
- [ ] I regenerated protobuf / client artifacts if `.proto` or generated client files changed
- [ ] I called out breaking changes, migrations, or operator impact below

## Breaking Changes / Migration Notes

<!-- Describe required migration, config, state, API, or deployment follow-up. -->

- None

## Additional Context

<!-- Logs, screenshots, benchmarks, rollout notes, or anything reviewers should know. -->

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary relayer-set updates when slashing does not change relayer membership or voting power.
  - Continued creating updated relayer sets when a slash removes an offline relayer or changes membership.
  - Ensured relayers reconnecting through delegation resume with the latest observed event position.
  - Initialized newly bonded relayers with the current event position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->